### PR TITLE
feat: add project and task management with MCP server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,10 +42,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "atk"
@@ -313,6 +374,52 @@ dependencies = [
  "wasm-bindgen",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -832,12 +939,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -892,6 +1015,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1556,6 +1680,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,6 +1905,17 @@ dependencies = [
 [[package]]
 name = "magical-merchant-mcp-cli"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "magical-merchant-core",
+ "rmcp",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "markup5ever"
@@ -2090,6 +2231,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2142,6 +2289,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "percent-encoding"
@@ -2709,6 +2862,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2759,7 +2947,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -2784,8 +2972,10 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -2795,6 +2985,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3038,6 +3240,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -3647,9 +3859,23 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3822,7 +4048,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3969,6 +4207,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,8 +1896,10 @@ name = "magical-merchant-core"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "markdown-frontmatter",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "thiserror 2.0.18",
 ]
@@ -1913,8 +1915,20 @@ dependencies = [
  "rmcp",
  "schemars 0.8.22",
  "serde",
- "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "markdown-frontmatter"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a46ec238a43080a53dc296b015d91fa033030d25bc05863f899915265afd5d"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -2931,6 +2945,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3145,9 +3165,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -3181,6 +3201,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -3911,11 +3944,26 @@ checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned 1.0.4",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -3938,9 +3986,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -3976,25 +4024,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -4170,6 +4218,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,8 +5,10 @@ edition = "2021"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
+markdown-frontmatter = { version = "0.5", features = ["yaml"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 thiserror = "2"
 
 [dev-dependencies]

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -10,4 +10,7 @@ pub enum CoreError {
 
     #[error("Not found: {0}")]
     NotFound(String),
+
+    #[error("Parse error: {0}")]
+    Parse(String),
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -4,4 +4,10 @@ use thiserror::Error;
 pub enum CoreError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+
+    #[error("Invalid slug: {0}")]
+    InvalidSlug(String),
+
+    #[error("Not found: {0}")]
+    NotFound(String),
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -11,6 +11,12 @@ pub enum CoreError {
     #[error("Not found: {0}")]
     NotFound(String),
 
+    #[error("Already exists: {0}")]
+    AlreadyExists(String),
+
+    #[error("Invalid path: {0}")]
+    PathTraversal(String),
+
     #[error("Parse error: {0}")]
     Parse(String),
 }

--- a/core/src/format.rs
+++ b/core/src/format.rs
@@ -107,8 +107,7 @@ mod tests {
 
     #[test]
     fn test_format_note_markdown_empty_tags() {
-        let result =
-            format_note_markdown("body", &[], fixed_timestamp(), &test_context()).unwrap();
+        let result = format_note_markdown("body", &[], fixed_timestamp(), &test_context()).unwrap();
         let (fm, _body): (NoteFrontmatter, String) = frontmatter::parse(&result).unwrap();
         assert!(fm.tags.is_empty());
     }

--- a/core/src/format.rs
+++ b/core/src/format.rs
@@ -1,5 +1,8 @@
-use chrono::{DateTime, Local};
+use chrono::{DateTime, FixedOffset, Local};
 use serde::Serialize;
+
+use crate::error::CoreError;
+use crate::frontmatter::{self, ContextMeta, NoteFrontmatter};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct DeviceContext {
@@ -34,23 +37,23 @@ pub fn format_note_markdown(
     tags: &[String],
     timestamp: DateTime<Local>,
     context: &DeviceContext,
-) -> String {
-    let time_str = timestamp.format("%Y-%m-%dT%H:%M:%S%:z").to_string();
-    let tags_str = tags
-        .iter()
-        .map(|t| format!("\"{t}\""))
-        .collect::<Vec<_>>()
-        .join(", ");
-    format!(
-        "---\ntime: \"{time_str}\"\ntags: [{tags_str}]\ncontext:\n  battery: {battery}\n  is_charging: {is_charging}\n---\n{body}",
-        battery = context.battery,
-        is_charging = context.is_charging,
-    )
+) -> Result<String, CoreError> {
+    let time: DateTime<FixedOffset> = timestamp.into();
+    let fm = NoteFrontmatter {
+        time,
+        tags: tags.to_vec(),
+        context: Some(ContextMeta {
+            battery: context.battery,
+            is_charging: context.is_charging,
+        }),
+    };
+    frontmatter::render(&fm, body)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::frontmatter::NoteFrontmatter;
     use chrono::TimeZone;
 
     fn fixed_timestamp() -> DateTime<Local> {
@@ -90,20 +93,24 @@ mod tests {
     fn test_format_note_markdown() {
         let tags = vec!["rust".to_string(), "memo".to_string()];
         let result =
-            format_note_markdown("# Hello\nWorld", &tags, fixed_timestamp(), &test_context());
+            format_note_markdown("# Hello\nWorld", &tags, fixed_timestamp(), &test_context())
+                .unwrap();
 
-        assert!(result.starts_with("---\n"));
-        assert!(result.contains("time: \"2026-03-20T14:30:45"));
-        assert!(result.contains("tags: [\"rust\", \"memo\"]"));
-        assert!(result.contains("battery: 82"));
-        assert!(result.contains("is_charging: false"));
-        assert!(result.ends_with("---\n# Hello\nWorld"));
+        let (fm, body): (NoteFrontmatter, String) = frontmatter::parse(&result).unwrap();
+        assert_eq!(fm.tags, vec!["rust", "memo"]);
+        assert!(fm.context.is_some());
+        let ctx = fm.context.unwrap();
+        assert_eq!(ctx.battery, 82);
+        assert!(!ctx.is_charging);
+        assert_eq!(body, "# Hello\nWorld");
     }
 
     #[test]
     fn test_format_note_markdown_empty_tags() {
-        let result = format_note_markdown("body", &[], fixed_timestamp(), &test_context());
-        assert!(result.contains("tags: []"));
+        let result =
+            format_note_markdown("body", &[], fixed_timestamp(), &test_context()).unwrap();
+        let (fm, _body): (NoteFrontmatter, String) = frontmatter::parse(&result).unwrap();
+        assert!(fm.tags.is_empty());
     }
 
     #[test]
@@ -112,8 +119,10 @@ mod tests {
             battery: 100,
             is_charging: true,
         };
-        let result = format_note_markdown("body", &[], fixed_timestamp(), &ctx);
-        assert!(result.contains("battery: 100"));
-        assert!(result.contains("is_charging: true"));
+        let result = format_note_markdown("body", &[], fixed_timestamp(), &ctx).unwrap();
+        let (fm, _body): (NoteFrontmatter, String) = frontmatter::parse(&result).unwrap();
+        let context = fm.context.unwrap();
+        assert_eq!(context.battery, 100);
+        assert!(context.is_charging);
     }
 }

--- a/core/src/frontmatter.rs
+++ b/core/src/frontmatter.rs
@@ -1,0 +1,145 @@
+use chrono::{DateTime, FixedOffset};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+use crate::error::CoreError;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct NoteFrontmatter {
+    pub time: DateTime<FixedOffset>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub context: Option<ContextMeta>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ContextMeta {
+    pub battery: u8,
+    pub is_charging: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ProjectFrontmatter {
+    pub name: String,
+    pub created: DateTime<FixedOffset>,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TaskFrontmatter {
+    pub title: String,
+    pub created: DateTime<FixedOffset>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed: Option<DateTime<FixedOffset>>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+pub fn render<T: Serialize>(fm: &T, body: &str) -> Result<String, CoreError> {
+    let yaml = serde_yaml::to_string(fm).map_err(|e| CoreError::Parse(e.to_string()))?;
+    Ok(format!("---\n{yaml}---\n{body}"))
+}
+
+pub fn parse<T: DeserializeOwned>(content: &str) -> Result<(T, String), CoreError> {
+    let (fm, body) = markdown_frontmatter::parse::<T>(content)
+        .map_err(|e| CoreError::Parse(format!("{e:?}")))?;
+    Ok((fm, body.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn fixed_offset() -> FixedOffset {
+        FixedOffset::east_opt(9 * 3600).unwrap()
+    }
+
+    fn sample_datetime() -> DateTime<FixedOffset> {
+        fixed_offset()
+            .with_ymd_and_hms(2026, 3, 20, 14, 30, 45)
+            .unwrap()
+    }
+
+    #[test]
+    fn test_project_frontmatter_roundtrip() {
+        let fm = ProjectFrontmatter {
+            name: "My Project".to_string(),
+            created: sample_datetime(),
+            description: "A test project".to_string(),
+        };
+        let rendered = render(&fm, "").unwrap();
+        let (parsed, body): (ProjectFrontmatter, _) = parse(&rendered).unwrap();
+        assert_eq!(parsed, fm);
+        assert_eq!(body, "");
+    }
+
+    #[test]
+    fn test_task_frontmatter_roundtrip() {
+        let fm = TaskFrontmatter {
+            title: "My Task".to_string(),
+            created: sample_datetime(),
+            completed: None,
+            tags: vec!["rust".to_string(), "test".to_string()],
+        };
+        let rendered = render(&fm, "Task body here").unwrap();
+        let (parsed, body): (TaskFrontmatter, _) = parse(&rendered).unwrap();
+        assert_eq!(parsed, fm);
+        assert_eq!(body, "Task body here");
+    }
+
+    #[test]
+    fn test_task_frontmatter_with_completed_roundtrip() {
+        let fm = TaskFrontmatter {
+            title: "Done Task".to_string(),
+            created: sample_datetime(),
+            completed: Some(sample_datetime()),
+            tags: vec![],
+        };
+        let rendered = render(&fm, "body").unwrap();
+        let (parsed, body): (TaskFrontmatter, _) = parse(&rendered).unwrap();
+        assert_eq!(parsed, fm);
+        assert_eq!(body, "body");
+    }
+
+    #[test]
+    fn test_note_frontmatter_roundtrip() {
+        let fm = NoteFrontmatter {
+            time: sample_datetime(),
+            tags: vec!["memo".to_string()],
+            context: Some(ContextMeta {
+                battery: 82,
+                is_charging: false,
+            }),
+        };
+        let rendered = render(&fm, "# Hello\nWorld").unwrap();
+        let (parsed, body): (NoteFrontmatter, _) = parse(&rendered).unwrap();
+        assert_eq!(parsed, fm);
+        assert_eq!(body, "# Hello\nWorld");
+    }
+
+    #[test]
+    fn test_note_frontmatter_no_context() {
+        let fm = NoteFrontmatter {
+            time: sample_datetime(),
+            tags: vec![],
+            context: None,
+        };
+        let rendered = render(&fm, "body").unwrap();
+        let (parsed, _body): (NoteFrontmatter, _) = parse(&rendered).unwrap();
+        assert_eq!(parsed, fm);
+    }
+
+    #[test]
+    fn test_render_contains_delimiters() {
+        let fm = ProjectFrontmatter {
+            name: "Test".to_string(),
+            created: sample_datetime(),
+            description: "Desc".to_string(),
+        };
+        let rendered = render(&fm, "body").unwrap();
+        assert!(rendered.starts_with("---\n"));
+        assert!(rendered.contains("\n---\n"));
+        assert!(rendered.ends_with("body"));
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,5 +12,7 @@ pub use path::{
     active_tasks_dir, done_tasks_dir, note_file_path, project_dir, project_file_path,
     projects_dir, timeline_file_path,
 };
-pub use project::{ProjectSummary, TaskSummary};
+pub use project::{
+    create_project, list_projects, read_project, ProjectSummary, TaskSummary,
+};
 pub use save::{read_timeline, save_note, save_timeline_entry};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,6 @@
 mod error;
 mod format;
+pub mod frontmatter;
 mod note;
 mod path;
 mod project;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,7 +13,8 @@ pub use path::{
     projects_dir, timeline_file_path,
 };
 pub use project::{
-    complete_task, create_project, create_task, list_active_tasks, list_done_tasks, list_projects,
-    read_project, update_task, ProjectSummary, TaskSummary,
+    complete_task, create_project, create_task, get_project_activity_summary, list_active_tasks,
+    list_done_tasks, list_projects, read_project, update_task, ProjectActivitySummary,
+    ProjectSummary, TaskSummary,
 };
 pub use save::{read_timeline, save_note, save_timeline_entry};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,8 +9,8 @@ pub use error::CoreError;
 pub use format::{format_note_markdown, format_timeline_line, DeviceContext};
 pub use note::{create_draft_note, list_notes, read_note, update_note, NoteSummary};
 pub use path::{
-    active_tasks_dir, done_tasks_dir, note_file_path, project_dir, project_file_path,
-    projects_dir, timeline_file_path,
+    active_tasks_dir, done_tasks_dir, note_file_path, project_dir, project_file_path, projects_dir,
+    timeline_file_path,
 };
 pub use project::{
     complete_task, create_project, create_task, get_project_activity_summary, list_active_tasks,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,6 +13,7 @@ pub use path::{
     projects_dir, timeline_file_path,
 };
 pub use project::{
-    create_project, list_projects, read_project, ProjectSummary, TaskSummary,
+    complete_task, create_project, create_task, list_active_tasks, list_done_tasks, list_projects,
+    read_project, update_task, ProjectSummary, TaskSummary,
 };
 pub use save::{read_timeline, save_note, save_timeline_entry};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,10 +2,15 @@ mod error;
 mod format;
 mod note;
 mod path;
+mod project;
 mod save;
 
 pub use error::CoreError;
 pub use format::{format_note_markdown, format_timeline_line, DeviceContext};
 pub use note::{create_draft_note, list_notes, read_note, update_note, NoteSummary};
-pub use path::{note_file_path, timeline_file_path};
+pub use path::{
+    active_tasks_dir, done_tasks_dir, note_file_path, project_dir, project_file_path,
+    projects_dir, timeline_file_path,
+};
+pub use project::{ProjectSummary, TaskSummary};
 pub use save::{read_timeline, save_note, save_timeline_entry};

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -1,11 +1,12 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use chrono::Local;
+use chrono::{DateTime, FixedOffset, Local};
 use serde::Serialize;
 
 use crate::error::CoreError;
 use crate::format::{format_note_markdown, DeviceContext};
+use crate::frontmatter::{self, NoteFrontmatter};
 use crate::path::note_file_path;
 
 fn ensure_dir(path: &Path) -> Result<(), CoreError> {
@@ -25,7 +26,7 @@ pub fn create_draft_note(
     let file_path = note_file_path(base_dir, now);
     ensure_dir(&file_path)?;
 
-    let content = format_note_markdown(body, tags, now, context);
+    let content = format_note_markdown(body, tags, now, context)?;
     fs::write(&file_path, content)?;
     Ok(file_path)
 }
@@ -37,7 +38,7 @@ pub fn update_note(
     context: &DeviceContext,
 ) -> Result<(), CoreError> {
     let now = Local::now();
-    let content = format_note_markdown(body, tags, now, context);
+    let content = format_note_markdown(body, tags, now, context)?;
     fs::write(file_path, content)?;
     Ok(())
 }
@@ -46,7 +47,7 @@ pub fn update_note(
 pub struct NoteSummary {
     pub path: PathBuf,
     pub filename: String,
-    pub time: Option<String>,
+    pub time: Option<DateTime<FixedOffset>>,
     pub tags: Vec<String>,
     pub preview: String,
 }
@@ -70,7 +71,7 @@ pub fn list_notes(base_dir: &Path) -> Result<Vec<NoteSummary>, CoreError> {
             let path = entry.path();
             let filename = entry.file_name().to_string_lossy().to_string();
             let content = fs::read_to_string(&path).unwrap_or_default();
-            let (time, tags, preview) = parse_frontmatter(&content);
+            let (time, tags, preview) = parse_note_content(&content);
             NoteSummary {
                 path,
                 filename,
@@ -88,33 +89,17 @@ pub fn read_note(file_path: &Path) -> Result<String, CoreError> {
     Ok(fs::read_to_string(file_path)?)
 }
 
-fn parse_frontmatter(content: &str) -> (Option<String>, Vec<String>, String) {
-    let mut time = None;
-    let mut tags = Vec::new();
-    let mut body = content;
-
-    if let Some(stripped) = content.strip_prefix("---\n") {
-        if let Some(end) = stripped.find("\n---\n") {
-            let frontmatter = &stripped[..end];
-            body = &stripped[end + 5..];
-
-            for line in frontmatter.lines() {
-                if let Some(t) = line.strip_prefix("time: ") {
-                    time = Some(t.trim_matches('"').to_string());
-                } else if let Some(t) = line.strip_prefix("tags: [") {
-                    let t = t.trim_end_matches(']');
-                    tags = t
-                        .split(", ")
-                        .map(|s| s.trim_matches('"').to_string())
-                        .filter(|s| !s.is_empty())
-                        .collect();
-                }
-            }
+fn parse_note_content(content: &str) -> (Option<DateTime<FixedOffset>>, Vec<String>, String) {
+    match frontmatter::parse::<NoteFrontmatter>(content) {
+        Ok((fm, body)) => {
+            let preview: String = body.chars().take(100).collect();
+            (Some(fm.time), fm.tags, preview)
+        }
+        Err(_) => {
+            let preview: String = content.chars().take(100).collect();
+            (None, Vec::new(), preview)
         }
     }
-
-    let preview: String = body.chars().take(100).collect();
-    (time, tags, preview)
 }
 
 #[cfg(test)]
@@ -188,10 +173,22 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_frontmatter() {
-        let content = "---\ntime: \"2026-03-20T14:30:45+09:00\"\ntags: [\"a\", \"b\"]\ncontext:\n  battery: 50\n  is_charging: false\n---\n# Title\nBody";
-        let (time, tags, preview) = parse_frontmatter(content);
-        assert_eq!(time.unwrap(), "2026-03-20T14:30:45+09:00");
+    fn test_parse_note_content() {
+        use chrono::TimeZone;
+        let fm = NoteFrontmatter {
+            time: FixedOffset::east_opt(9 * 3600)
+                .unwrap()
+                .with_ymd_and_hms(2026, 3, 20, 14, 30, 45)
+                .unwrap(),
+            tags: vec!["a".to_string(), "b".to_string()],
+            context: Some(crate::frontmatter::ContextMeta {
+                battery: 50,
+                is_charging: false,
+            }),
+        };
+        let content = frontmatter::render(&fm, "# Title\nBody").unwrap();
+        let (time, tags, preview) = parse_note_content(&content);
+        assert!(time.is_some());
         assert_eq!(tags, vec!["a", "b"]);
         assert!(preview.contains("# Title"));
     }

--- a/core/src/path.rs
+++ b/core/src/path.rs
@@ -15,6 +15,26 @@ pub fn note_file_path(base_dir: &Path, timestamp: DateTime<Local>) -> PathBuf {
         .join(format!("{}.md", timestamp.format("%Y%m%d_%H%M%S")))
 }
 
+pub fn projects_dir(base_dir: &Path) -> PathBuf {
+    base_dir.join("data").join("projects")
+}
+
+pub fn project_dir(base_dir: &Path, slug: &str) -> PathBuf {
+    projects_dir(base_dir).join(slug)
+}
+
+pub fn project_file_path(base_dir: &Path, slug: &str) -> PathBuf {
+    project_dir(base_dir, slug).join("project.md")
+}
+
+pub fn active_tasks_dir(base_dir: &Path, slug: &str) -> PathBuf {
+    project_dir(base_dir, slug).join("active")
+}
+
+pub fn done_tasks_dir(base_dir: &Path, slug: &str) -> PathBuf {
+    project_dir(base_dir, slug).join("done")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -32,5 +52,41 @@ mod tests {
         let ts = Local.with_ymd_and_hms(2026, 3, 20, 14, 30, 45).unwrap();
         let path = note_file_path(Path::new("/app"), ts);
         assert_eq!(path, PathBuf::from("/app/data/notes/20260320_143045.md"));
+    }
+
+    #[test]
+    fn test_projects_dir() {
+        let path = projects_dir(Path::new("/app"));
+        assert_eq!(path, PathBuf::from("/app/data/projects"));
+    }
+
+    #[test]
+    fn test_project_dir() {
+        let path = project_dir(Path::new("/app"), "my-project");
+        assert_eq!(path, PathBuf::from("/app/data/projects/my-project"));
+    }
+
+    #[test]
+    fn test_project_file_path() {
+        let path = project_file_path(Path::new("/app"), "my-project");
+        assert_eq!(
+            path,
+            PathBuf::from("/app/data/projects/my-project/project.md")
+        );
+    }
+
+    #[test]
+    fn test_active_tasks_dir() {
+        let path = active_tasks_dir(Path::new("/app"), "my-project");
+        assert_eq!(
+            path,
+            PathBuf::from("/app/data/projects/my-project/active")
+        );
+    }
+
+    #[test]
+    fn test_done_tasks_dir() {
+        let path = done_tasks_dir(Path::new("/app"), "my-project");
+        assert_eq!(path, PathBuf::from("/app/data/projects/my-project/done"));
     }
 }

--- a/core/src/path.rs
+++ b/core/src/path.rs
@@ -78,10 +78,7 @@ mod tests {
     #[test]
     fn test_active_tasks_dir() {
         let path = active_tasks_dir(Path::new("/app"), "my-project");
-        assert_eq!(
-            path,
-            PathBuf::from("/app/data/projects/my-project/active")
-        );
+        assert_eq!(path, PathBuf::from("/app/data/projects/my-project/active"));
     }
 
     #[test]

--- a/core/src/project.rs
+++ b/core/src/project.rs
@@ -5,13 +5,14 @@ use chrono::{DateTime, FixedOffset, Local, NaiveDate};
 use serde::Serialize;
 
 use crate::error::CoreError;
+use crate::frontmatter::{self, ProjectFrontmatter, TaskFrontmatter};
 use crate::path;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ProjectSummary {
     pub slug: String,
     pub name: String,
-    pub created: String,
+    pub created: DateTime<FixedOffset>,
     pub description: String,
     pub active_task_count: usize,
 }
@@ -20,8 +21,8 @@ pub struct ProjectSummary {
 pub struct TaskSummary {
     pub filename: String,
     pub title: String,
-    pub created: String,
-    pub completed: Option<String>,
+    pub created: DateTime<FixedOffset>,
+    pub completed: Option<DateTime<FixedOffset>>,
     pub tags: Vec<String>,
     pub body: String,
 }
@@ -33,33 +34,6 @@ fn is_valid_slug(slug: &str) -> bool {
             .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
         && !slug.starts_with('-')
         && !slug.ends_with('-')
-}
-
-fn format_project_md(name: &str, description: &str, created: &str) -> String {
-    format!("---\nname: \"{name}\"\ncreated: \"{created}\"\ndescription: \"{description}\"\n---\n")
-}
-
-fn parse_project_frontmatter(content: &str) -> (String, String, String) {
-    let mut name = String::new();
-    let mut created = String::new();
-    let mut description = String::new();
-
-    if let Some(stripped) = content.strip_prefix("---\n") {
-        if let Some(end) = stripped.find("\n---") {
-            let frontmatter = &stripped[..end];
-            for line in frontmatter.lines() {
-                if let Some(v) = line.strip_prefix("name: ") {
-                    name = v.trim_matches('"').to_string();
-                } else if let Some(v) = line.strip_prefix("created: ") {
-                    created = v.trim_matches('"').to_string();
-                } else if let Some(v) = line.strip_prefix("description: ") {
-                    description = v.trim_matches('"').to_string();
-                }
-            }
-        }
-    }
-
-    (name, created, description)
 }
 
 pub fn create_project(
@@ -76,8 +50,13 @@ pub fn create_project(
     fs::create_dir_all(path::active_tasks_dir(base_dir, slug))?;
     fs::create_dir_all(path::done_tasks_dir(base_dir, slug))?;
 
-    let now = Local::now().format("%Y-%m-%dT%H:%M:%S%:z").to_string();
-    let content = format_project_md(name, description, &now);
+    let now: DateTime<FixedOffset> = Local::now().into();
+    let fm = ProjectFrontmatter {
+        name: name.to_string(),
+        created: now,
+        description: description.to_string(),
+    };
+    let content = frontmatter::render(&fm, "")?;
     let file_path = path::project_file_path(base_dir, slug);
     fs::write(&file_path, content)?;
 
@@ -107,71 +86,6 @@ pub fn list_projects(base_dir: &Path) -> Result<Vec<ProjectSummary>, CoreError> 
     Ok(projects)
 }
 
-fn format_task_md(title: &str, tags: &[String], created: &str, body: &str) -> String {
-    let tags_str = tags
-        .iter()
-        .map(|t| format!("\"{t}\""))
-        .collect::<Vec<_>>()
-        .join(", ");
-    format!("---\ntitle: \"{title}\"\ncreated: \"{created}\"\ntags: [{tags_str}]\n---\n{body}")
-}
-
-fn format_completed_task_md(
-    title: &str,
-    tags: &[String],
-    created: &str,
-    completed: &str,
-    body: &str,
-) -> String {
-    let tags_str = tags
-        .iter()
-        .map(|t| format!("\"{t}\""))
-        .collect::<Vec<_>>()
-        .join(", ");
-    format!("---\ntitle: \"{title}\"\ncreated: \"{created}\"\ncompleted: \"{completed}\"\ntags: [{tags_str}]\n---\n{body}")
-}
-
-fn parse_task_frontmatter(content: &str) -> TaskSummary {
-    let mut title = String::new();
-    let mut created = String::new();
-    let mut completed = None;
-    let mut tags = Vec::new();
-    let mut body = content.to_string();
-
-    if let Some(stripped) = content.strip_prefix("---\n") {
-        if let Some(end) = stripped.find("\n---\n") {
-            let frontmatter = &stripped[..end];
-            body = stripped[end + 5..].to_string();
-
-            for line in frontmatter.lines() {
-                if let Some(v) = line.strip_prefix("title: ") {
-                    title = v.trim_matches('"').to_string();
-                } else if let Some(v) = line.strip_prefix("created: ") {
-                    created = v.trim_matches('"').to_string();
-                } else if let Some(v) = line.strip_prefix("completed: ") {
-                    completed = Some(v.trim_matches('"').to_string());
-                } else if let Some(v) = line.strip_prefix("tags: [") {
-                    let v = v.trim_end_matches(']');
-                    tags = v
-                        .split(", ")
-                        .map(|s| s.trim_matches('"').to_string())
-                        .filter(|s| !s.is_empty())
-                        .collect();
-                }
-            }
-        }
-    }
-
-    TaskSummary {
-        filename: String::new(),
-        title,
-        created,
-        completed,
-        tags,
-        body,
-    }
-}
-
 pub fn create_task(
     base_dir: &Path,
     project_slug: &str,
@@ -184,14 +98,31 @@ pub fn create_task(
         return Err(CoreError::NotFound(format!("project: {project_slug}")));
     }
 
-    let now = Local::now();
+    let now: DateTime<FixedOffset> = Local::now().into();
     let filename = format!("{}.md", now.format("%Y%m%d_%H%M%S"));
     let file_path = active_dir.join(&filename);
-    let created = now.format("%Y-%m-%dT%H:%M:%S%:z").to_string();
-    let content = format_task_md(title, tags, &created, body);
+    let fm = TaskFrontmatter {
+        title: title.to_string(),
+        created: now,
+        completed: None,
+        tags: tags.to_vec(),
+    };
+    let content = frontmatter::render(&fm, body)?;
     fs::write(&file_path, content)?;
 
     Ok(file_path)
+}
+
+fn parse_task_file(content: &str) -> Result<TaskSummary, CoreError> {
+    let (fm, body): (TaskFrontmatter, String) = frontmatter::parse(content)?;
+    Ok(TaskSummary {
+        filename: String::new(),
+        title: fm.title,
+        created: fm.created,
+        completed: fm.completed,
+        tags: fm.tags,
+        body,
+    })
 }
 
 fn list_tasks_in_dir(dir: &Path) -> Result<Vec<TaskSummary>, CoreError> {
@@ -205,16 +136,14 @@ fn list_tasks_in_dir(dir: &Path) -> Result<Vec<TaskSummary>, CoreError> {
         .collect();
     entries.sort_by_key(|e| std::cmp::Reverse(e.file_name()));
 
-    let tasks = entries
-        .into_iter()
-        .map(|entry| {
-            let filename = entry.file_name().to_string_lossy().to_string();
-            let content = fs::read_to_string(entry.path()).unwrap_or_default();
-            let mut task = parse_task_frontmatter(&content);
-            task.filename = filename;
-            task
-        })
-        .collect();
+    let mut tasks = Vec::new();
+    for entry in entries {
+        let filename = entry.file_name().to_string_lossy().to_string();
+        let content = fs::read_to_string(entry.path())?;
+        let mut task = parse_task_file(&content)?;
+        task.filename = filename;
+        tasks.push(task);
+    }
 
     Ok(tasks)
 }
@@ -239,11 +168,16 @@ pub fn complete_task(base_dir: &Path, project_slug: &str, filename: &str) -> Res
     }
 
     let content = fs::read_to_string(&active_path)?;
-    let task = parse_task_frontmatter(&content);
+    let task = parse_task_file(&content)?;
 
-    let now = Local::now().format("%Y-%m-%dT%H:%M:%S%:z").to_string();
-    let new_content =
-        format_completed_task_md(&task.title, &task.tags, &task.created, &now, &task.body);
+    let now: DateTime<FixedOffset> = Local::now().into();
+    let fm = TaskFrontmatter {
+        title: task.title,
+        created: task.created,
+        completed: Some(now),
+        tags: task.tags,
+    };
+    let new_content = frontmatter::render(&fm, &task.body)?;
 
     let done_path = path::done_tasks_dir(base_dir, project_slug).join(filename);
     fs::write(&done_path, new_content)?;
@@ -268,8 +202,14 @@ pub fn update_task(
     }
 
     let content = fs::read_to_string(&active_path)?;
-    let task = parse_task_frontmatter(&content);
-    let new_content = format_task_md(title, tags, &task.created, body);
+    let task = parse_task_file(&content)?;
+    let fm = TaskFrontmatter {
+        title: title.to_string(),
+        created: task.created,
+        completed: None,
+        tags: tags.to_vec(),
+    };
+    let new_content = frontmatter::render(&fm, body)?;
     fs::write(&active_path, new_content)?;
 
     Ok(())
@@ -282,7 +222,7 @@ pub fn read_project(base_dir: &Path, slug: &str) -> Result<ProjectSummary, CoreE
     }
 
     let content = fs::read_to_string(&file_path)?;
-    let (name, created, description) = parse_project_frontmatter(&content);
+    let (fm, _body): (ProjectFrontmatter, String) = frontmatter::parse(&content)?;
 
     let active_dir = path::active_tasks_dir(base_dir, slug);
     let active_task_count = if active_dir.exists() {
@@ -296,9 +236,9 @@ pub fn read_project(base_dir: &Path, slug: &str) -> Result<ProjectSummary, CoreE
 
     Ok(ProjectSummary {
         slug: slug.to_string(),
-        name,
-        created,
-        description,
+        name: fm.name,
+        created: fm.created,
+        description: fm.description,
         active_task_count,
     })
 }
@@ -325,13 +265,6 @@ pub fn get_project_activity_summary(
             .into_iter()
             .filter(|task| {
                 task.completed
-                    .as_ref()
-                    .and_then(|c| DateTime::parse_from_str(c, "%Y-%m-%dT%H:%M:%S%:z").ok())
-                    .or_else(|| {
-                        task.completed
-                            .as_ref()
-                            .and_then(|c| DateTime::<FixedOffset>::parse_from_rfc3339(c).ok())
-                    })
                     .map(|dt| {
                         let date = dt.date_naive();
                         date >= start && date <= end
@@ -356,7 +289,36 @@ pub fn get_project_activity_summary(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
     use tempfile::TempDir;
+
+    fn fixed_offset() -> FixedOffset {
+        FixedOffset::east_opt(9 * 3600).unwrap()
+    }
+
+    fn sample_datetime(
+        year: i32,
+        month: u32,
+        day: u32,
+        hour: u32,
+        min: u32,
+        sec: u32,
+    ) -> DateTime<FixedOffset> {
+        fixed_offset()
+            .with_ymd_and_hms(year, month, day, hour, min, sec)
+            .unwrap()
+    }
+
+    fn write_task_file(dir: &Path, filename: &str, fm: &TaskFrontmatter, body: &str) {
+        let content = frontmatter::render(fm, body).unwrap();
+        fs::write(dir.join(filename), content).unwrap();
+    }
+
+    fn write_done_task(tmp: &TempDir, slug: &str, filename: &str, fm: &TaskFrontmatter) {
+        let done_dir = path::done_tasks_dir(tmp.path(), slug);
+        let content = frontmatter::render(fm, "body").unwrap();
+        fs::write(done_dir.join(filename), content).unwrap();
+    }
 
     #[test]
     fn test_is_valid_slug() {
@@ -383,9 +345,9 @@ mod tests {
         assert!(path::active_tasks_dir(tmp.path(), "my-proj").exists());
         assert!(path::done_tasks_dir(tmp.path(), "my-proj").exists());
 
-        let content = fs::read_to_string(path::project_file_path(tmp.path(), "my-proj")).unwrap();
-        assert!(content.contains("name: \"My Project\""));
-        assert!(content.contains("description: \"A test project\""));
+        let summary = read_project(tmp.path(), "my-proj").unwrap();
+        assert_eq!(summary.name, "My Project");
+        assert_eq!(summary.description, "A test project");
     }
 
     #[test]
@@ -443,9 +405,10 @@ mod tests {
         assert!(path.exists());
 
         let content = fs::read_to_string(&path).unwrap();
-        assert!(content.contains("title: \"My Task\""));
-        assert!(content.contains("tags: [\"rust\", \"test\"]"));
-        assert!(content.contains("Task body"));
+        let (fm, body): (TaskFrontmatter, String) = frontmatter::parse(&content).unwrap();
+        assert_eq!(fm.title, "My Task");
+        assert_eq!(fm.tags, vec!["rust", "test"]);
+        assert_eq!(body, "Task body");
     }
 
     #[test]
@@ -468,22 +431,32 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
 
-        // Create tasks with different filenames by writing directly
         let active_dir = path::active_tasks_dir(tmp.path(), "proj");
-        fs::write(
-            active_dir.join("20260101_120000.md"),
-            "---\ntitle: \"First\"\ncreated: \"2026-01-01\"\ntags: []\n---\nbody1",
-        )
-        .unwrap();
-        fs::write(
-            active_dir.join("20260102_120000.md"),
-            "---\ntitle: \"Second\"\ncreated: \"2026-01-02\"\ntags: []\n---\nbody2",
-        )
-        .unwrap();
+        write_task_file(
+            &active_dir,
+            "20260101_120000.md",
+            &TaskFrontmatter {
+                title: "First".to_string(),
+                created: sample_datetime(2026, 1, 1, 12, 0, 0),
+                completed: None,
+                tags: vec![],
+            },
+            "body1",
+        );
+        write_task_file(
+            &active_dir,
+            "20260102_120000.md",
+            &TaskFrontmatter {
+                title: "Second".to_string(),
+                created: sample_datetime(2026, 1, 2, 12, 0, 0),
+                completed: None,
+                tags: vec![],
+            },
+            "body2",
+        );
 
         let tasks = list_active_tasks(tmp.path(), "proj").unwrap();
         assert_eq!(tasks.len(), 2);
-        // Reverse sorted, so newer first
         assert_eq!(tasks[0].title, "Second");
         assert_eq!(tasks[1].title, "First");
     }
@@ -495,25 +468,30 @@ mod tests {
 
         let active_dir = path::active_tasks_dir(tmp.path(), "proj");
         let filename = "20260101_120000.md";
-        fs::write(
-            active_dir.join(filename),
-            "---\ntitle: \"Task\"\ncreated: \"2026-01-01T12:00:00+09:00\"\ntags: [\"a\"]\n---\nbody",
-        )
-        .unwrap();
+        write_task_file(
+            &active_dir,
+            filename,
+            &TaskFrontmatter {
+                title: "Task".to_string(),
+                created: sample_datetime(2026, 1, 1, 12, 0, 0),
+                completed: None,
+                tags: vec!["a".to_string()],
+            },
+            "body",
+        );
 
         complete_task(tmp.path(), "proj", filename).unwrap();
 
-        // Active file should be gone
         assert!(!active_dir.join(filename).exists());
 
-        // Done file should exist with completed field
         let done_path = path::done_tasks_dir(tmp.path(), "proj").join(filename);
         assert!(done_path.exists());
         let content = fs::read_to_string(&done_path).unwrap();
-        assert!(content.contains("completed: \""));
-        assert!(content.contains("title: \"Task\""));
-        assert!(content.contains("tags: [\"a\"]"));
-        assert!(content.contains("body"));
+        let (fm, body): (TaskFrontmatter, String) = frontmatter::parse(&content).unwrap();
+        assert_eq!(fm.title, "Task");
+        assert!(fm.completed.is_some());
+        assert_eq!(fm.tags, vec!["a"]);
+        assert_eq!(body, "body");
     }
 
     #[test]
@@ -531,11 +509,18 @@ mod tests {
 
         let active_dir = path::active_tasks_dir(tmp.path(), "proj");
         let filename = "20260101_120000.md";
-        fs::write(
-            active_dir.join(filename),
-            "---\ntitle: \"Old\"\ncreated: \"2026-01-01T12:00:00+09:00\"\ntags: []\n---\nold body",
-        )
-        .unwrap();
+        let original_created = sample_datetime(2026, 1, 1, 12, 0, 0);
+        write_task_file(
+            &active_dir,
+            filename,
+            &TaskFrontmatter {
+                title: "Old".to_string(),
+                created: original_created,
+                completed: None,
+                tags: vec![],
+            },
+            "old body",
+        );
 
         let new_tags = vec!["updated".to_string()];
         update_task(
@@ -549,11 +534,11 @@ mod tests {
         .unwrap();
 
         let content = fs::read_to_string(active_dir.join(filename)).unwrap();
-        assert!(content.contains("title: \"New Title\""));
-        assert!(content.contains("tags: [\"updated\"]"));
-        assert!(content.contains("new body"));
-        // Preserve original created timestamp
-        assert!(content.contains("created: \"2026-01-01T12:00:00+09:00\""));
+        let (fm, body): (TaskFrontmatter, String) = frontmatter::parse(&content).unwrap();
+        assert_eq!(fm.title, "New Title");
+        assert_eq!(fm.tags, vec!["updated"]);
+        assert_eq!(body, "new body");
+        assert_eq!(fm.created, original_created);
     }
 
     #[test]
@@ -562,23 +547,20 @@ mod tests {
         create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
 
         let active_dir = path::active_tasks_dir(tmp.path(), "proj");
-        fs::write(
-            active_dir.join("20260101_120000.md"),
-            "---\ntitle: \"T\"\ncreated: \"2026\"\ntags: []\n---\n",
-        )
-        .unwrap();
+        write_task_file(
+            &active_dir,
+            "20260101_120000.md",
+            &TaskFrontmatter {
+                title: "T".to_string(),
+                created: sample_datetime(2026, 1, 1, 12, 0, 0),
+                completed: None,
+                tags: vec![],
+            },
+            "",
+        );
 
         let summary = read_project(tmp.path(), "proj").unwrap();
         assert_eq!(summary.active_task_count, 1);
-    }
-
-    fn write_done_task(tmp: &TempDir, slug: &str, filename: &str, completed: &str) {
-        let done_dir = path::done_tasks_dir(tmp.path(), slug);
-        fs::write(
-            done_dir.join(filename),
-            format!("---\ntitle: \"Task\"\ncreated: \"2026-01-01T12:00:00+09:00\"\ncompleted: \"{completed}\"\ntags: []\n---\nbody"),
-        )
-        .unwrap();
     }
 
     #[test]
@@ -586,23 +568,39 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
 
+        let created = sample_datetime(2026, 1, 1, 12, 0, 0);
         write_done_task(
             &tmp,
             "proj",
             "20260101_120000.md",
-            "2026-01-15T12:00:00+09:00",
+            &TaskFrontmatter {
+                title: "Task".to_string(),
+                created,
+                completed: Some(sample_datetime(2026, 1, 15, 12, 0, 0)),
+                tags: vec![],
+            },
         );
         write_done_task(
             &tmp,
             "proj",
             "20260201_120000.md",
-            "2026-02-15T12:00:00+09:00",
+            &TaskFrontmatter {
+                title: "Task".to_string(),
+                created,
+                completed: Some(sample_datetime(2026, 2, 15, 12, 0, 0)),
+                tags: vec![],
+            },
         );
         write_done_task(
             &tmp,
             "proj",
             "20260301_120000.md",
-            "2026-03-15T12:00:00+09:00",
+            &TaskFrontmatter {
+                title: "Task".to_string(),
+                created,
+                completed: Some(sample_datetime(2026, 3, 15, 12, 0, 0)),
+                tags: vec![],
+            },
         );
 
         let start = NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
@@ -619,17 +617,28 @@ mod tests {
         create_project(tmp.path(), "alpha", "Alpha", "A").unwrap();
         create_project(tmp.path(), "beta", "Beta", "B").unwrap();
 
+        let created = sample_datetime(2026, 1, 1, 12, 0, 0);
         write_done_task(
             &tmp,
             "alpha",
             "20260101_120000.md",
-            "2026-01-15T12:00:00+09:00",
+            &TaskFrontmatter {
+                title: "Task".to_string(),
+                created,
+                completed: Some(sample_datetime(2026, 1, 15, 12, 0, 0)),
+                tags: vec![],
+            },
         );
         write_done_task(
             &tmp,
             "beta",
             "20260101_120000.md",
-            "2026-01-20T12:00:00+09:00",
+            &TaskFrontmatter {
+                title: "Task".to_string(),
+                created,
+                completed: Some(sample_datetime(2026, 1, 20, 12, 0, 0)),
+                tags: vec![],
+            },
         );
 
         let start = NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
@@ -646,11 +655,17 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
 
+        let created = sample_datetime(2026, 1, 1, 12, 0, 0);
         write_done_task(
             &tmp,
             "proj",
             "20260101_120000.md",
-            "2026-01-15T12:00:00+09:00",
+            &TaskFrontmatter {
+                title: "Task".to_string(),
+                created,
+                completed: Some(sample_datetime(2026, 1, 15, 12, 0, 0)),
+                tags: vec![],
+            },
         );
 
         let start = NaiveDate::from_ymd_opt(2026, 6, 1).unwrap();

--- a/core/src/project.rs
+++ b/core/src/project.rs
@@ -36,6 +36,17 @@ fn is_valid_slug(slug: &str) -> bool {
         && !slug.ends_with('-')
 }
 
+fn validate_filename(filename: &str) -> Result<(), CoreError> {
+    if filename.contains('/')
+        || filename.contains('\\')
+        || filename.contains('\0')
+        || filename.contains("..")
+    {
+        return Err(CoreError::PathTraversal(filename.to_string()));
+    }
+    Ok(())
+}
+
 pub fn create_project(
     base_dir: &Path,
     slug: &str,
@@ -44,6 +55,11 @@ pub fn create_project(
 ) -> Result<PathBuf, CoreError> {
     if !is_valid_slug(slug) {
         return Err(CoreError::InvalidSlug(slug.to_string()));
+    }
+
+    let file_path = path::project_file_path(base_dir, slug);
+    if file_path.exists() {
+        return Err(CoreError::AlreadyExists(format!("project: {slug}")));
     }
 
     let proj_dir = path::project_dir(base_dir, slug);
@@ -99,7 +115,7 @@ pub fn create_task(
     }
 
     let now: DateTime<FixedOffset> = Local::now().into();
-    let filename = format!("{}.md", now.format("%Y%m%d_%H%M%S"));
+    let filename = format!("{}.md", now.format("%Y%m%d_%H%M%S_%3f"));
     let file_path = active_dir.join(&filename);
     let fm = TaskFrontmatter {
         title: title.to_string(),
@@ -152,14 +168,23 @@ pub fn list_active_tasks(
     base_dir: &Path,
     project_slug: &str,
 ) -> Result<Vec<TaskSummary>, CoreError> {
+    let project_file = path::project_file_path(base_dir, project_slug);
+    if !project_file.exists() {
+        return Err(CoreError::NotFound(format!("project: {project_slug}")));
+    }
     list_tasks_in_dir(&path::active_tasks_dir(base_dir, project_slug))
 }
 
 pub fn list_done_tasks(base_dir: &Path, project_slug: &str) -> Result<Vec<TaskSummary>, CoreError> {
+    let project_file = path::project_file_path(base_dir, project_slug);
+    if !project_file.exists() {
+        return Err(CoreError::NotFound(format!("project: {project_slug}")));
+    }
     list_tasks_in_dir(&path::done_tasks_dir(base_dir, project_slug))
 }
 
 pub fn complete_task(base_dir: &Path, project_slug: &str, filename: &str) -> Result<(), CoreError> {
+    validate_filename(filename)?;
     let active_path = path::active_tasks_dir(base_dir, project_slug).join(filename);
     if !active_path.exists() {
         return Err(CoreError::NotFound(format!(
@@ -194,6 +219,7 @@ pub fn update_task(
     tags: &[String],
     body: &str,
 ) -> Result<(), CoreError> {
+    validate_filename(filename)?;
     let active_path = path::active_tasks_dir(base_dir, project_slug).join(filename);
     if !active_path.exists() {
         return Err(CoreError::NotFound(format!(
@@ -673,5 +699,43 @@ mod tests {
         let result = get_project_activity_summary(tmp.path(), start, end).unwrap();
 
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_create_project_already_exists() {
+        let tmp = TempDir::new().unwrap();
+        create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
+        let result = create_project(tmp.path(), "proj", "Proj2", "Desc2");
+        assert!(matches!(result, Err(CoreError::AlreadyExists(_))));
+    }
+
+    #[test]
+    fn test_complete_task_path_traversal() {
+        let tmp = TempDir::new().unwrap();
+        create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
+        let result = complete_task(tmp.path(), "proj", "../../../etc/passwd");
+        assert!(matches!(result, Err(CoreError::PathTraversal(_))));
+    }
+
+    #[test]
+    fn test_update_task_path_traversal() {
+        let tmp = TempDir::new().unwrap();
+        create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
+        let result = update_task(tmp.path(), "proj", "../evil.md", "T", &[], "b");
+        assert!(matches!(result, Err(CoreError::PathTraversal(_))));
+    }
+
+    #[test]
+    fn test_list_active_tasks_nonexistent_project() {
+        let tmp = TempDir::new().unwrap();
+        let result = list_active_tasks(tmp.path(), "nonexistent");
+        assert!(matches!(result, Err(CoreError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_list_done_tasks_nonexistent_project() {
+        let tmp = TempDir::new().unwrap();
+        let result = list_done_tasks(tmp.path(), "nonexistent");
+        assert!(matches!(result, Err(CoreError::NotFound(_))));
     }
 }

--- a/core/src/project.rs
+++ b/core/src/project.rs
@@ -1,4 +1,11 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::Local;
 use serde::Serialize;
+
+use crate::error::CoreError;
+use crate::path;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ProjectSummary {
@@ -17,4 +24,197 @@ pub struct TaskSummary {
     pub completed: Option<String>,
     pub tags: Vec<String>,
     pub body: String,
+}
+
+fn is_valid_slug(slug: &str) -> bool {
+    !slug.is_empty()
+        && slug
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        && !slug.starts_with('-')
+        && !slug.ends_with('-')
+}
+
+fn format_project_md(name: &str, description: &str, created: &str) -> String {
+    format!(
+        "---\nname: \"{name}\"\ncreated: \"{created}\"\ndescription: \"{description}\"\n---\n"
+    )
+}
+
+fn parse_project_frontmatter(content: &str) -> (String, String, String) {
+    let mut name = String::new();
+    let mut created = String::new();
+    let mut description = String::new();
+
+    if let Some(stripped) = content.strip_prefix("---\n") {
+        if let Some(end) = stripped.find("\n---") {
+            let frontmatter = &stripped[..end];
+            for line in frontmatter.lines() {
+                if let Some(v) = line.strip_prefix("name: ") {
+                    name = v.trim_matches('"').to_string();
+                } else if let Some(v) = line.strip_prefix("created: ") {
+                    created = v.trim_matches('"').to_string();
+                } else if let Some(v) = line.strip_prefix("description: ") {
+                    description = v.trim_matches('"').to_string();
+                }
+            }
+        }
+    }
+
+    (name, created, description)
+}
+
+pub fn create_project(
+    base_dir: &Path,
+    slug: &str,
+    name: &str,
+    description: &str,
+) -> Result<PathBuf, CoreError> {
+    if !is_valid_slug(slug) {
+        return Err(CoreError::InvalidSlug(slug.to_string()));
+    }
+
+    let proj_dir = path::project_dir(base_dir, slug);
+    fs::create_dir_all(path::active_tasks_dir(base_dir, slug))?;
+    fs::create_dir_all(path::done_tasks_dir(base_dir, slug))?;
+
+    let now = Local::now().format("%Y-%m-%dT%H:%M:%S%:z").to_string();
+    let content = format_project_md(name, description, &now);
+    let file_path = path::project_file_path(base_dir, slug);
+    fs::write(&file_path, content)?;
+
+    Ok(proj_dir)
+}
+
+pub fn list_projects(base_dir: &Path) -> Result<Vec<ProjectSummary>, CoreError> {
+    let dir = path::projects_dir(base_dir);
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut projects = Vec::new();
+    let mut entries: Vec<_> = fs::read_dir(&dir)?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .collect();
+    entries.sort_by_key(|e| e.file_name());
+
+    for entry in entries {
+        let slug = entry.file_name().to_string_lossy().to_string();
+        if let Ok(summary) = read_project(base_dir, &slug) {
+            projects.push(summary);
+        }
+    }
+
+    Ok(projects)
+}
+
+pub fn read_project(base_dir: &Path, slug: &str) -> Result<ProjectSummary, CoreError> {
+    let file_path = path::project_file_path(base_dir, slug);
+    if !file_path.exists() {
+        return Err(CoreError::NotFound(format!("project: {slug}")));
+    }
+
+    let content = fs::read_to_string(&file_path)?;
+    let (name, created, description) = parse_project_frontmatter(&content);
+
+    let active_dir = path::active_tasks_dir(base_dir, slug);
+    let active_task_count = if active_dir.exists() {
+        fs::read_dir(&active_dir)?
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+            .count()
+    } else {
+        0
+    };
+
+    Ok(ProjectSummary {
+        slug: slug.to_string(),
+        name,
+        created,
+        description,
+        active_task_count,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_is_valid_slug() {
+        assert!(is_valid_slug("my-project"));
+        assert!(is_valid_slug("project123"));
+        assert!(is_valid_slug("a"));
+        assert!(!is_valid_slug(""));
+        assert!(!is_valid_slug("My-Project"));
+        assert!(!is_valid_slug("-start"));
+        assert!(!is_valid_slug("end-"));
+        assert!(!is_valid_slug("has space"));
+        assert!(!is_valid_slug("under_score"));
+    }
+
+    #[test]
+    fn test_create_project() {
+        let tmp = TempDir::new().unwrap();
+        let result = create_project(tmp.path(), "my-proj", "My Project", "A test project");
+        assert!(result.is_ok());
+
+        let proj_dir = result.unwrap();
+        assert!(proj_dir.exists());
+        assert!(path::project_file_path(tmp.path(), "my-proj").exists());
+        assert!(path::active_tasks_dir(tmp.path(), "my-proj").exists());
+        assert!(path::done_tasks_dir(tmp.path(), "my-proj").exists());
+
+        let content =
+            fs::read_to_string(path::project_file_path(tmp.path(), "my-proj")).unwrap();
+        assert!(content.contains("name: \"My Project\""));
+        assert!(content.contains("description: \"A test project\""));
+    }
+
+    #[test]
+    fn test_create_project_invalid_slug() {
+        let tmp = TempDir::new().unwrap();
+        let result = create_project(tmp.path(), "Bad Slug", "Name", "Desc");
+        assert!(matches!(result, Err(CoreError::InvalidSlug(_))));
+    }
+
+    #[test]
+    fn test_list_projects_empty() {
+        let tmp = TempDir::new().unwrap();
+        let projects = list_projects(tmp.path()).unwrap();
+        assert!(projects.is_empty());
+    }
+
+    #[test]
+    fn test_list_projects_multiple() {
+        let tmp = TempDir::new().unwrap();
+        create_project(tmp.path(), "alpha", "Alpha", "First").unwrap();
+        create_project(tmp.path(), "beta", "Beta", "Second").unwrap();
+
+        let projects = list_projects(tmp.path()).unwrap();
+        assert_eq!(projects.len(), 2);
+        assert_eq!(projects[0].slug, "alpha");
+        assert_eq!(projects[1].slug, "beta");
+    }
+
+    #[test]
+    fn test_read_project() {
+        let tmp = TempDir::new().unwrap();
+        create_project(tmp.path(), "test-proj", "Test", "Desc").unwrap();
+
+        let summary = read_project(tmp.path(), "test-proj").unwrap();
+        assert_eq!(summary.slug, "test-proj");
+        assert_eq!(summary.name, "Test");
+        assert_eq!(summary.description, "Desc");
+        assert_eq!(summary.active_task_count, 0);
+    }
+
+    #[test]
+    fn test_read_project_not_found() {
+        let tmp = TempDir::new().unwrap();
+        let result = read_project(tmp.path(), "nonexistent");
+        assert!(matches!(result, Err(CoreError::NotFound(_))));
+    }
 }

--- a/core/src/project.rs
+++ b/core/src/project.rs
@@ -1,0 +1,20 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProjectSummary {
+    pub slug: String,
+    pub name: String,
+    pub created: String,
+    pub description: String,
+    pub active_task_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskSummary {
+    pub filename: String,
+    pub title: String,
+    pub created: String,
+    pub completed: Option<String>,
+    pub tags: Vec<String>,
+    pub body: String,
+}

--- a/core/src/project.rs
+++ b/core/src/project.rs
@@ -36,9 +36,7 @@ fn is_valid_slug(slug: &str) -> bool {
 }
 
 fn format_project_md(name: &str, description: &str, created: &str) -> String {
-    format!(
-        "---\nname: \"{name}\"\ncreated: \"{created}\"\ndescription: \"{description}\"\n---\n"
-    )
+    format!("---\nname: \"{name}\"\ncreated: \"{created}\"\ndescription: \"{description}\"\n---\n")
 }
 
 fn parse_project_frontmatter(content: &str) -> (String, String, String) {
@@ -183,9 +181,7 @@ pub fn create_task(
 ) -> Result<PathBuf, CoreError> {
     let active_dir = path::active_tasks_dir(base_dir, project_slug);
     if !active_dir.exists() {
-        return Err(CoreError::NotFound(format!(
-            "project: {project_slug}"
-        )));
+        return Err(CoreError::NotFound(format!("project: {project_slug}")));
     }
 
     let now = Local::now();
@@ -230,18 +226,11 @@ pub fn list_active_tasks(
     list_tasks_in_dir(&path::active_tasks_dir(base_dir, project_slug))
 }
 
-pub fn list_done_tasks(
-    base_dir: &Path,
-    project_slug: &str,
-) -> Result<Vec<TaskSummary>, CoreError> {
+pub fn list_done_tasks(base_dir: &Path, project_slug: &str) -> Result<Vec<TaskSummary>, CoreError> {
     list_tasks_in_dir(&path::done_tasks_dir(base_dir, project_slug))
 }
 
-pub fn complete_task(
-    base_dir: &Path,
-    project_slug: &str,
-    filename: &str,
-) -> Result<(), CoreError> {
+pub fn complete_task(base_dir: &Path, project_slug: &str, filename: &str) -> Result<(), CoreError> {
     let active_path = path::active_tasks_dir(base_dir, project_slug).join(filename);
     if !active_path.exists() {
         return Err(CoreError::NotFound(format!(
@@ -339,9 +328,9 @@ pub fn get_project_activity_summary(
                     .as_ref()
                     .and_then(|c| DateTime::parse_from_str(c, "%Y-%m-%dT%H:%M:%S%:z").ok())
                     .or_else(|| {
-                        task.completed.as_ref().and_then(|c| {
-                            DateTime::<FixedOffset>::parse_from_rfc3339(c).ok()
-                        })
+                        task.completed
+                            .as_ref()
+                            .and_then(|c| DateTime::<FixedOffset>::parse_from_rfc3339(c).ok())
                     })
                     .map(|dt| {
                         let date = dt.date_naive();
@@ -394,8 +383,7 @@ mod tests {
         assert!(path::active_tasks_dir(tmp.path(), "my-proj").exists());
         assert!(path::done_tasks_dir(tmp.path(), "my-proj").exists());
 
-        let content =
-            fs::read_to_string(path::project_file_path(tmp.path(), "my-proj")).unwrap();
+        let content = fs::read_to_string(path::project_file_path(tmp.path(), "my-proj")).unwrap();
         assert!(content.contains("name: \"My Project\""));
         assert!(content.contains("description: \"A test project\""));
     }
@@ -550,7 +538,15 @@ mod tests {
         .unwrap();
 
         let new_tags = vec!["updated".to_string()];
-        update_task(tmp.path(), "proj", filename, "New Title", &new_tags, "new body").unwrap();
+        update_task(
+            tmp.path(),
+            "proj",
+            filename,
+            "New Title",
+            &new_tags,
+            "new body",
+        )
+        .unwrap();
 
         let content = fs::read_to_string(active_dir.join(filename)).unwrap();
         assert!(content.contains("title: \"New Title\""));
@@ -590,9 +586,24 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
 
-        write_done_task(&tmp, "proj", "20260101_120000.md", "2026-01-15T12:00:00+09:00");
-        write_done_task(&tmp, "proj", "20260201_120000.md", "2026-02-15T12:00:00+09:00");
-        write_done_task(&tmp, "proj", "20260301_120000.md", "2026-03-15T12:00:00+09:00");
+        write_done_task(
+            &tmp,
+            "proj",
+            "20260101_120000.md",
+            "2026-01-15T12:00:00+09:00",
+        );
+        write_done_task(
+            &tmp,
+            "proj",
+            "20260201_120000.md",
+            "2026-02-15T12:00:00+09:00",
+        );
+        write_done_task(
+            &tmp,
+            "proj",
+            "20260301_120000.md",
+            "2026-03-15T12:00:00+09:00",
+        );
 
         let start = NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
         let end = NaiveDate::from_ymd_opt(2026, 2, 28).unwrap();
@@ -608,8 +619,18 @@ mod tests {
         create_project(tmp.path(), "alpha", "Alpha", "A").unwrap();
         create_project(tmp.path(), "beta", "Beta", "B").unwrap();
 
-        write_done_task(&tmp, "alpha", "20260101_120000.md", "2026-01-15T12:00:00+09:00");
-        write_done_task(&tmp, "beta", "20260101_120000.md", "2026-01-20T12:00:00+09:00");
+        write_done_task(
+            &tmp,
+            "alpha",
+            "20260101_120000.md",
+            "2026-01-15T12:00:00+09:00",
+        );
+        write_done_task(
+            &tmp,
+            "beta",
+            "20260101_120000.md",
+            "2026-01-20T12:00:00+09:00",
+        );
 
         let start = NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
         let end = NaiveDate::from_ymd_opt(2026, 1, 31).unwrap();
@@ -625,7 +646,12 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
 
-        write_done_task(&tmp, "proj", "20260101_120000.md", "2026-01-15T12:00:00+09:00");
+        write_done_task(
+            &tmp,
+            "proj",
+            "20260101_120000.md",
+            "2026-01-15T12:00:00+09:00",
+        );
 
         let start = NaiveDate::from_ymd_opt(2026, 6, 1).unwrap();
         let end = NaiveDate::from_ymd_opt(2026, 6, 30).unwrap();

--- a/core/src/project.rs
+++ b/core/src/project.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use chrono::Local;
+use chrono::{DateTime, FixedOffset, Local, NaiveDate};
 use serde::Serialize;
 
 use crate::error::CoreError;
@@ -314,6 +314,56 @@ pub fn read_project(base_dir: &Path, slug: &str) -> Result<ProjectSummary, CoreE
     })
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct ProjectActivitySummary {
+    pub slug: String,
+    pub name: String,
+    pub completed_tasks: Vec<TaskSummary>,
+    pub active_task_count: usize,
+}
+
+pub fn get_project_activity_summary(
+    base_dir: &Path,
+    start: NaiveDate,
+    end: NaiveDate,
+) -> Result<Vec<ProjectActivitySummary>, CoreError> {
+    let projects = list_projects(base_dir)?;
+    let mut result = Vec::new();
+
+    for project in projects {
+        let done_tasks = list_done_tasks(base_dir, &project.slug)?;
+        let filtered: Vec<TaskSummary> = done_tasks
+            .into_iter()
+            .filter(|task| {
+                task.completed
+                    .as_ref()
+                    .and_then(|c| DateTime::parse_from_str(c, "%Y-%m-%dT%H:%M:%S%:z").ok())
+                    .or_else(|| {
+                        task.completed.as_ref().and_then(|c| {
+                            DateTime::<FixedOffset>::parse_from_rfc3339(c).ok()
+                        })
+                    })
+                    .map(|dt| {
+                        let date = dt.date_naive();
+                        date >= start && date <= end
+                    })
+                    .unwrap_or(false)
+            })
+            .collect();
+
+        if !filtered.is_empty() || project.active_task_count > 0 {
+            result.push(ProjectActivitySummary {
+                slug: project.slug,
+                name: project.name,
+                completed_tasks: filtered,
+                active_task_count: project.active_task_count,
+            });
+        }
+    }
+
+    Ok(result)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -524,5 +574,63 @@ mod tests {
 
         let summary = read_project(tmp.path(), "proj").unwrap();
         assert_eq!(summary.active_task_count, 1);
+    }
+
+    fn write_done_task(tmp: &TempDir, slug: &str, filename: &str, completed: &str) {
+        let done_dir = path::done_tasks_dir(tmp.path(), slug);
+        fs::write(
+            done_dir.join(filename),
+            format!("---\ntitle: \"Task\"\ncreated: \"2026-01-01T12:00:00+09:00\"\ncompleted: \"{completed}\"\ntags: []\n---\nbody"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_activity_summary_date_filter() {
+        let tmp = TempDir::new().unwrap();
+        create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
+
+        write_done_task(&tmp, "proj", "20260101_120000.md", "2026-01-15T12:00:00+09:00");
+        write_done_task(&tmp, "proj", "20260201_120000.md", "2026-02-15T12:00:00+09:00");
+        write_done_task(&tmp, "proj", "20260301_120000.md", "2026-03-15T12:00:00+09:00");
+
+        let start = NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+        let end = NaiveDate::from_ymd_opt(2026, 2, 28).unwrap();
+        let result = get_project_activity_summary(tmp.path(), start, end).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].completed_tasks.len(), 2);
+    }
+
+    #[test]
+    fn test_activity_summary_multiple_projects() {
+        let tmp = TempDir::new().unwrap();
+        create_project(tmp.path(), "alpha", "Alpha", "A").unwrap();
+        create_project(tmp.path(), "beta", "Beta", "B").unwrap();
+
+        write_done_task(&tmp, "alpha", "20260101_120000.md", "2026-01-15T12:00:00+09:00");
+        write_done_task(&tmp, "beta", "20260101_120000.md", "2026-01-20T12:00:00+09:00");
+
+        let start = NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+        let end = NaiveDate::from_ymd_opt(2026, 1, 31).unwrap();
+        let result = get_project_activity_summary(tmp.path(), start, end).unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].completed_tasks.len(), 1);
+        assert_eq!(result[1].completed_tasks.len(), 1);
+    }
+
+    #[test]
+    fn test_activity_summary_empty_result() {
+        let tmp = TempDir::new().unwrap();
+        create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
+
+        write_done_task(&tmp, "proj", "20260101_120000.md", "2026-01-15T12:00:00+09:00");
+
+        let start = NaiveDate::from_ymd_opt(2026, 6, 1).unwrap();
+        let end = NaiveDate::from_ymd_opt(2026, 6, 30).unwrap();
+        let result = get_project_activity_summary(tmp.path(), start, end).unwrap();
+
+        assert!(result.is_empty());
     }
 }

--- a/core/src/project.rs
+++ b/core/src/project.rs
@@ -109,6 +109,183 @@ pub fn list_projects(base_dir: &Path) -> Result<Vec<ProjectSummary>, CoreError> 
     Ok(projects)
 }
 
+fn format_task_md(title: &str, tags: &[String], created: &str, body: &str) -> String {
+    let tags_str = tags
+        .iter()
+        .map(|t| format!("\"{t}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("---\ntitle: \"{title}\"\ncreated: \"{created}\"\ntags: [{tags_str}]\n---\n{body}")
+}
+
+fn format_completed_task_md(
+    title: &str,
+    tags: &[String],
+    created: &str,
+    completed: &str,
+    body: &str,
+) -> String {
+    let tags_str = tags
+        .iter()
+        .map(|t| format!("\"{t}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("---\ntitle: \"{title}\"\ncreated: \"{created}\"\ncompleted: \"{completed}\"\ntags: [{tags_str}]\n---\n{body}")
+}
+
+fn parse_task_frontmatter(content: &str) -> TaskSummary {
+    let mut title = String::new();
+    let mut created = String::new();
+    let mut completed = None;
+    let mut tags = Vec::new();
+    let mut body = content.to_string();
+
+    if let Some(stripped) = content.strip_prefix("---\n") {
+        if let Some(end) = stripped.find("\n---\n") {
+            let frontmatter = &stripped[..end];
+            body = stripped[end + 5..].to_string();
+
+            for line in frontmatter.lines() {
+                if let Some(v) = line.strip_prefix("title: ") {
+                    title = v.trim_matches('"').to_string();
+                } else if let Some(v) = line.strip_prefix("created: ") {
+                    created = v.trim_matches('"').to_string();
+                } else if let Some(v) = line.strip_prefix("completed: ") {
+                    completed = Some(v.trim_matches('"').to_string());
+                } else if let Some(v) = line.strip_prefix("tags: [") {
+                    let v = v.trim_end_matches(']');
+                    tags = v
+                        .split(", ")
+                        .map(|s| s.trim_matches('"').to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect();
+                }
+            }
+        }
+    }
+
+    TaskSummary {
+        filename: String::new(),
+        title,
+        created,
+        completed,
+        tags,
+        body,
+    }
+}
+
+pub fn create_task(
+    base_dir: &Path,
+    project_slug: &str,
+    title: &str,
+    tags: &[String],
+    body: &str,
+) -> Result<PathBuf, CoreError> {
+    let active_dir = path::active_tasks_dir(base_dir, project_slug);
+    if !active_dir.exists() {
+        return Err(CoreError::NotFound(format!(
+            "project: {project_slug}"
+        )));
+    }
+
+    let now = Local::now();
+    let filename = format!("{}.md", now.format("%Y%m%d_%H%M%S"));
+    let file_path = active_dir.join(&filename);
+    let created = now.format("%Y-%m-%dT%H:%M:%S%:z").to_string();
+    let content = format_task_md(title, tags, &created, body);
+    fs::write(&file_path, content)?;
+
+    Ok(file_path)
+}
+
+fn list_tasks_in_dir(dir: &Path) -> Result<Vec<TaskSummary>, CoreError> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries: Vec<_> = fs::read_dir(dir)?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+        .collect();
+    entries.sort_by_key(|e| std::cmp::Reverse(e.file_name()));
+
+    let tasks = entries
+        .into_iter()
+        .map(|entry| {
+            let filename = entry.file_name().to_string_lossy().to_string();
+            let content = fs::read_to_string(entry.path()).unwrap_or_default();
+            let mut task = parse_task_frontmatter(&content);
+            task.filename = filename;
+            task
+        })
+        .collect();
+
+    Ok(tasks)
+}
+
+pub fn list_active_tasks(
+    base_dir: &Path,
+    project_slug: &str,
+) -> Result<Vec<TaskSummary>, CoreError> {
+    list_tasks_in_dir(&path::active_tasks_dir(base_dir, project_slug))
+}
+
+pub fn list_done_tasks(
+    base_dir: &Path,
+    project_slug: &str,
+) -> Result<Vec<TaskSummary>, CoreError> {
+    list_tasks_in_dir(&path::done_tasks_dir(base_dir, project_slug))
+}
+
+pub fn complete_task(
+    base_dir: &Path,
+    project_slug: &str,
+    filename: &str,
+) -> Result<(), CoreError> {
+    let active_path = path::active_tasks_dir(base_dir, project_slug).join(filename);
+    if !active_path.exists() {
+        return Err(CoreError::NotFound(format!(
+            "task: {project_slug}/{filename}"
+        )));
+    }
+
+    let content = fs::read_to_string(&active_path)?;
+    let task = parse_task_frontmatter(&content);
+
+    let now = Local::now().format("%Y-%m-%dT%H:%M:%S%:z").to_string();
+    let new_content =
+        format_completed_task_md(&task.title, &task.tags, &task.created, &now, &task.body);
+
+    let done_path = path::done_tasks_dir(base_dir, project_slug).join(filename);
+    fs::write(&done_path, new_content)?;
+    fs::remove_file(&active_path)?;
+
+    Ok(())
+}
+
+pub fn update_task(
+    base_dir: &Path,
+    project_slug: &str,
+    filename: &str,
+    title: &str,
+    tags: &[String],
+    body: &str,
+) -> Result<(), CoreError> {
+    let active_path = path::active_tasks_dir(base_dir, project_slug).join(filename);
+    if !active_path.exists() {
+        return Err(CoreError::NotFound(format!(
+            "task: {project_slug}/{filename}"
+        )));
+    }
+
+    let content = fs::read_to_string(&active_path)?;
+    let task = parse_task_frontmatter(&content);
+    let new_content = format_task_md(title, tags, &task.created, body);
+    fs::write(&active_path, new_content)?;
+
+    Ok(())
+}
+
 pub fn read_project(base_dir: &Path, slug: &str) -> Result<ProjectSummary, CoreError> {
     let file_path = path::project_file_path(base_dir, slug);
     if !file_path.exists() {
@@ -216,5 +393,136 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let result = read_project(tmp.path(), "nonexistent");
         assert!(matches!(result, Err(CoreError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_create_task() {
+        let tmp = TempDir::new().unwrap();
+        create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
+
+        let tags = vec!["rust".to_string(), "test".to_string()];
+        let path = create_task(tmp.path(), "proj", "My Task", &tags, "Task body").unwrap();
+        assert!(path.exists());
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("title: \"My Task\""));
+        assert!(content.contains("tags: [\"rust\", \"test\"]"));
+        assert!(content.contains("Task body"));
+    }
+
+    #[test]
+    fn test_create_task_nonexistent_project() {
+        let tmp = TempDir::new().unwrap();
+        let result = create_task(tmp.path(), "nonexistent", "Task", &[], "body");
+        assert!(matches!(result, Err(CoreError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_list_active_tasks_empty() {
+        let tmp = TempDir::new().unwrap();
+        create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
+        let tasks = list_active_tasks(tmp.path(), "proj").unwrap();
+        assert!(tasks.is_empty());
+    }
+
+    #[test]
+    fn test_list_active_tasks_multiple() {
+        let tmp = TempDir::new().unwrap();
+        create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
+
+        // Create tasks with different filenames by writing directly
+        let active_dir = path::active_tasks_dir(tmp.path(), "proj");
+        fs::write(
+            active_dir.join("20260101_120000.md"),
+            "---\ntitle: \"First\"\ncreated: \"2026-01-01\"\ntags: []\n---\nbody1",
+        )
+        .unwrap();
+        fs::write(
+            active_dir.join("20260102_120000.md"),
+            "---\ntitle: \"Second\"\ncreated: \"2026-01-02\"\ntags: []\n---\nbody2",
+        )
+        .unwrap();
+
+        let tasks = list_active_tasks(tmp.path(), "proj").unwrap();
+        assert_eq!(tasks.len(), 2);
+        // Reverse sorted, so newer first
+        assert_eq!(tasks[0].title, "Second");
+        assert_eq!(tasks[1].title, "First");
+    }
+
+    #[test]
+    fn test_complete_task() {
+        let tmp = TempDir::new().unwrap();
+        create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
+
+        let active_dir = path::active_tasks_dir(tmp.path(), "proj");
+        let filename = "20260101_120000.md";
+        fs::write(
+            active_dir.join(filename),
+            "---\ntitle: \"Task\"\ncreated: \"2026-01-01T12:00:00+09:00\"\ntags: [\"a\"]\n---\nbody",
+        )
+        .unwrap();
+
+        complete_task(tmp.path(), "proj", filename).unwrap();
+
+        // Active file should be gone
+        assert!(!active_dir.join(filename).exists());
+
+        // Done file should exist with completed field
+        let done_path = path::done_tasks_dir(tmp.path(), "proj").join(filename);
+        assert!(done_path.exists());
+        let content = fs::read_to_string(&done_path).unwrap();
+        assert!(content.contains("completed: \""));
+        assert!(content.contains("title: \"Task\""));
+        assert!(content.contains("tags: [\"a\"]"));
+        assert!(content.contains("body"));
+    }
+
+    #[test]
+    fn test_complete_task_not_found() {
+        let tmp = TempDir::new().unwrap();
+        create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
+        let result = complete_task(tmp.path(), "proj", "nonexistent.md");
+        assert!(matches!(result, Err(CoreError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_update_task() {
+        let tmp = TempDir::new().unwrap();
+        create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
+
+        let active_dir = path::active_tasks_dir(tmp.path(), "proj");
+        let filename = "20260101_120000.md";
+        fs::write(
+            active_dir.join(filename),
+            "---\ntitle: \"Old\"\ncreated: \"2026-01-01T12:00:00+09:00\"\ntags: []\n---\nold body",
+        )
+        .unwrap();
+
+        let new_tags = vec!["updated".to_string()];
+        update_task(tmp.path(), "proj", filename, "New Title", &new_tags, "new body").unwrap();
+
+        let content = fs::read_to_string(active_dir.join(filename)).unwrap();
+        assert!(content.contains("title: \"New Title\""));
+        assert!(content.contains("tags: [\"updated\"]"));
+        assert!(content.contains("new body"));
+        // Preserve original created timestamp
+        assert!(content.contains("created: \"2026-01-01T12:00:00+09:00\""));
+    }
+
+    #[test]
+    fn test_read_project_with_active_tasks() {
+        let tmp = TempDir::new().unwrap();
+        create_project(tmp.path(), "proj", "Proj", "Desc").unwrap();
+
+        let active_dir = path::active_tasks_dir(tmp.path(), "proj");
+        fs::write(
+            active_dir.join("20260101_120000.md"),
+            "---\ntitle: \"T\"\ncreated: \"2026\"\ntags: []\n---\n",
+        )
+        .unwrap();
+
+        let summary = read_project(tmp.path(), "proj").unwrap();
+        assert_eq!(summary.active_task_count, 1);
     }
 }

--- a/core/src/save.rs
+++ b/core/src/save.rs
@@ -51,7 +51,7 @@ pub fn save_note(
     let file_path = note_file_path(base_dir, now);
     ensure_dir(&file_path)?;
 
-    let content = format_note_markdown(body, tags, now, context);
+    let content = format_note_markdown(body, tags, now, context)?;
     fs::write(&file_path, content)?;
     Ok(())
 }
@@ -124,8 +124,10 @@ mod tests {
 
         let content = fs::read_to_string(files[0].as_ref().unwrap().path()).unwrap();
         assert!(content.contains("---"));
-        assert!(content.contains("tags: [\"test\"]"));
-        assert!(content.contains("# Title\nBody"));
+        let (fm, body): (crate::frontmatter::NoteFrontmatter, String) =
+            crate::frontmatter::parse(&content).unwrap();
+        assert_eq!(fm.tags, vec!["test"]);
+        assert_eq!(body, "# Title\nBody");
     }
 
     #[test]
@@ -136,7 +138,9 @@ mod tests {
         let notes_dir = tmp.path().join("data/notes");
         let files: Vec<_> = fs::read_dir(&notes_dir).unwrap().collect();
         let content = fs::read_to_string(files[0].as_ref().unwrap().path()).unwrap();
-        assert!(content.contains("tags: []"));
+        let (fm, _body): (crate::frontmatter::NoteFrontmatter, String) =
+            crate::frontmatter::parse(&content).unwrap();
+        assert!(fm.tags.is_empty());
     }
 
     #[test]

--- a/mcp-cli/Cargo.toml
+++ b/mcp-cli/Cargo.toml
@@ -4,6 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+magical-merchant-core = { path = "../core" }
+rmcp = { version = "1", features = ["server", "macros", "transport-io", "schemars"] }
+schemars = "0.8"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+chrono = { version = "0.4", features = ["serde"] }
+tokio = { version = "1", features = ["full"] }
+clap = { version = "4", features = ["derive", "env"] }
+anyhow = "1"
 
 [lints]
 workspace = true

--- a/mcp-cli/Cargo.toml
+++ b/mcp-cli/Cargo.toml
@@ -8,7 +8,6 @@ magical-merchant-core = { path = "../core" }
 rmcp = { version = "1", features = ["server", "macros", "transport-io", "schemars"] }
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive", "env"] }

--- a/mcp-cli/src/main.rs
+++ b/mcp-cli/src/main.rs
@@ -5,15 +5,18 @@ use clap::Parser;
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::{Json, Parameters};
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ListToolsResult, PaginatedRequestParams, ServerInfo,
-    ServerCapabilities,
+    CallToolRequestParams, CallToolResult, ListToolsResult, PaginatedRequestParams,
+    ServerCapabilities, ServerInfo,
 };
 use rmcp::service::RequestContext;
 use rmcp::{schemars, tool, tool_router, ErrorData, RoleServer, ServerHandler, ServiceExt};
 use serde::{Deserialize, Serialize};
 
 #[derive(Parser)]
-#[command(name = "magical-merchant-mcp", about = "MCP server for magical-merchant")]
+#[command(
+    name = "magical-merchant-mcp",
+    about = "MCP server for magical-merchant"
+)]
 struct Cli {
     #[arg(long, env = "MAGICAL_MERCHANT_DATA_DIR")]
     data_dir: PathBuf,
@@ -129,9 +132,8 @@ impl McpServer {
         &self,
         Parameters(param): Parameters<ProjectSlugParam>,
     ) -> Json<TaskListOutput> {
-        let tasks =
-            magical_merchant_core::list_active_tasks(&self.data_dir, &param.project_slug)
-                .unwrap_or_default();
+        let tasks = magical_merchant_core::list_active_tasks(&self.data_dir, &param.project_slug)
+            .unwrap_or_default();
         Json(TaskListOutput {
             tasks: tasks.iter().map(task_to_info).collect(),
         })

--- a/mcp-cli/src/main.rs
+++ b/mcp-cli/src/main.rs
@@ -109,9 +109,10 @@ fn task_to_info(t: &magical_merchant_core::TaskSummary) -> TaskInfo {
 #[tool_router]
 impl McpServer {
     #[tool(name = "list_projects", description = "List all projects")]
-    fn list_projects(&self) -> Json<ProjectListOutput> {
-        let projects = magical_merchant_core::list_projects(&self.data_dir).unwrap_or_default();
-        Json(ProjectListOutput {
+    fn list_projects(&self) -> Result<Json<ProjectListOutput>, String> {
+        let projects =
+            magical_merchant_core::list_projects(&self.data_dir).map_err(|e| e.to_string())?;
+        Ok(Json(ProjectListOutput {
             projects: projects
                 .into_iter()
                 .map(|p| ProjectInfo {
@@ -121,7 +122,7 @@ impl McpServer {
                     active_task_count: p.active_task_count,
                 })
                 .collect(),
-        })
+        }))
     }
 
     #[tool(
@@ -131,12 +132,12 @@ impl McpServer {
     fn list_active_tasks(
         &self,
         Parameters(param): Parameters<ProjectSlugParam>,
-    ) -> Json<TaskListOutput> {
+    ) -> Result<Json<TaskListOutput>, String> {
         let tasks = magical_merchant_core::list_active_tasks(&self.data_dir, &param.project_slug)
-            .unwrap_or_default();
-        Json(TaskListOutput {
+            .map_err(|e| e.to_string())?;
+        Ok(Json(TaskListOutput {
             tasks: tasks.iter().map(task_to_info).collect(),
-        })
+        }))
     }
 
     #[tool(
@@ -146,12 +147,12 @@ impl McpServer {
     fn list_completed_tasks(
         &self,
         Parameters(param): Parameters<ProjectSlugParam>,
-    ) -> Json<TaskListOutput> {
+    ) -> Result<Json<TaskListOutput>, String> {
         let tasks = magical_merchant_core::list_done_tasks(&self.data_dir, &param.project_slug)
-            .unwrap_or_default();
-        Json(TaskListOutput {
+            .map_err(|e| e.to_string())?;
+        Ok(Json(TaskListOutput {
             tasks: tasks.iter().map(task_to_info).collect(),
-        })
+        }))
     }
 
     #[tool(
@@ -161,17 +162,23 @@ impl McpServer {
     fn get_task_history(
         &self,
         Parameters(param): Parameters<DateRangeParam>,
-    ) -> Json<ActivityOutput> {
+    ) -> Result<Json<ActivityOutput>, String> {
         let start = NaiveDate::parse_from_str(&param.start_date, "%Y-%m-%d")
-            .unwrap_or(NaiveDate::from_ymd_opt(2000, 1, 1).unwrap());
+            .map_err(|e| format!("Invalid start_date '{}': {e}", param.start_date))?;
         let end = NaiveDate::parse_from_str(&param.end_date, "%Y-%m-%d")
-            .unwrap_or(NaiveDate::from_ymd_opt(2099, 12, 31).unwrap());
+            .map_err(|e| format!("Invalid end_date '{}': {e}", param.end_date))?;
+
+        if start > end {
+            return Err(format!(
+                "start_date ({start}) must not be after end_date ({end})"
+            ));
+        }
 
         let summaries =
             magical_merchant_core::get_project_activity_summary(&self.data_dir, start, end)
-                .unwrap_or_default();
+                .map_err(|e| e.to_string())?;
 
-        Json(ActivityOutput {
+        Ok(Json(ActivityOutput {
             summaries: summaries
                 .into_iter()
                 .map(|s| ActivityInfo {
@@ -181,7 +188,7 @@ impl McpServer {
                     active_task_count: s.active_task_count,
                 })
                 .collect(),
-        })
+        }))
     }
 }
 

--- a/mcp-cli/src/main.rs
+++ b/mcp-cli/src/main.rs
@@ -99,8 +99,8 @@ fn task_to_info(t: &magical_merchant_core::TaskSummary) -> TaskInfo {
     TaskInfo {
         filename: t.filename.clone(),
         title: t.title.clone(),
-        created: t.created.clone(),
-        completed: t.completed.clone(),
+        created: t.created.to_rfc3339(),
+        completed: t.completed.map(|dt| dt.to_rfc3339()),
         tags: t.tags.clone(),
         body: t.body.clone(),
     }

--- a/mcp-cli/src/main.rs
+++ b/mcp-cli/src/main.rs
@@ -1,3 +1,222 @@
-fn main() {
-    todo!("MCP CLI not yet implemented")
+use std::path::PathBuf;
+
+use chrono::NaiveDate;
+use clap::Parser;
+use rmcp::handler::server::tool::ToolRouter;
+use rmcp::handler::server::wrapper::{Json, Parameters};
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, ListToolsResult, PaginatedRequestParams, ServerInfo,
+    ServerCapabilities,
+};
+use rmcp::service::RequestContext;
+use rmcp::{schemars, tool, tool_router, ErrorData, RoleServer, ServerHandler, ServiceExt};
+use serde::{Deserialize, Serialize};
+
+#[derive(Parser)]
+#[command(name = "magical-merchant-mcp", about = "MCP server for magical-merchant")]
+struct Cli {
+    #[arg(long, env = "MAGICAL_MERCHANT_DATA_DIR")]
+    data_dir: PathBuf,
+}
+
+struct McpServer {
+    data_dir: PathBuf,
+    tool_router: ToolRouter<Self>,
+}
+
+impl McpServer {
+    fn new(data_dir: PathBuf) -> Self {
+        Self {
+            data_dir,
+            tool_router: Self::tool_router(),
+        }
+    }
+}
+
+// --- Parameter types ---
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct ProjectSlugParam {
+    /// The project slug identifier
+    project_slug: String,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct DateRangeParam {
+    /// Start date in YYYY-MM-DD format
+    start_date: String,
+    /// End date in YYYY-MM-DD format
+    end_date: String,
+}
+
+// --- Output types ---
+
+#[derive(Serialize, schemars::JsonSchema)]
+struct ProjectListOutput {
+    projects: Vec<ProjectInfo>,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+struct ProjectInfo {
+    slug: String,
+    name: String,
+    description: String,
+    active_task_count: usize,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+struct TaskListOutput {
+    tasks: Vec<TaskInfo>,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+struct TaskInfo {
+    filename: String,
+    title: String,
+    created: String,
+    completed: Option<String>,
+    tags: Vec<String>,
+    body: String,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+struct ActivityOutput {
+    summaries: Vec<ActivityInfo>,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+struct ActivityInfo {
+    slug: String,
+    name: String,
+    completed_tasks: Vec<TaskInfo>,
+    active_task_count: usize,
+}
+
+fn task_to_info(t: &magical_merchant_core::TaskSummary) -> TaskInfo {
+    TaskInfo {
+        filename: t.filename.clone(),
+        title: t.title.clone(),
+        created: t.created.clone(),
+        completed: t.completed.clone(),
+        tags: t.tags.clone(),
+        body: t.body.clone(),
+    }
+}
+
+#[tool_router]
+impl McpServer {
+    #[tool(name = "list_projects", description = "List all projects")]
+    fn list_projects(&self) -> Json<ProjectListOutput> {
+        let projects = magical_merchant_core::list_projects(&self.data_dir).unwrap_or_default();
+        Json(ProjectListOutput {
+            projects: projects
+                .into_iter()
+                .map(|p| ProjectInfo {
+                    slug: p.slug,
+                    name: p.name,
+                    description: p.description,
+                    active_task_count: p.active_task_count,
+                })
+                .collect(),
+        })
+    }
+
+    #[tool(
+        name = "list_active_tasks",
+        description = "List active (in-progress) tasks for a project"
+    )]
+    fn list_active_tasks(
+        &self,
+        Parameters(param): Parameters<ProjectSlugParam>,
+    ) -> Json<TaskListOutput> {
+        let tasks =
+            magical_merchant_core::list_active_tasks(&self.data_dir, &param.project_slug)
+                .unwrap_or_default();
+        Json(TaskListOutput {
+            tasks: tasks.iter().map(task_to_info).collect(),
+        })
+    }
+
+    #[tool(
+        name = "list_completed_tasks",
+        description = "List completed tasks for a project"
+    )]
+    fn list_completed_tasks(
+        &self,
+        Parameters(param): Parameters<ProjectSlugParam>,
+    ) -> Json<TaskListOutput> {
+        let tasks = magical_merchant_core::list_done_tasks(&self.data_dir, &param.project_slug)
+            .unwrap_or_default();
+        Json(TaskListOutput {
+            tasks: tasks.iter().map(task_to_info).collect(),
+        })
+    }
+
+    #[tool(
+        name = "get_task_history",
+        description = "Get completed task history across all projects within a date range (YYYY-MM-DD)"
+    )]
+    fn get_task_history(
+        &self,
+        Parameters(param): Parameters<DateRangeParam>,
+    ) -> Json<ActivityOutput> {
+        let start = NaiveDate::parse_from_str(&param.start_date, "%Y-%m-%d")
+            .unwrap_or(NaiveDate::from_ymd_opt(2000, 1, 1).unwrap());
+        let end = NaiveDate::parse_from_str(&param.end_date, "%Y-%m-%d")
+            .unwrap_or(NaiveDate::from_ymd_opt(2099, 12, 31).unwrap());
+
+        let summaries =
+            magical_merchant_core::get_project_activity_summary(&self.data_dir, start, end)
+                .unwrap_or_default();
+
+        Json(ActivityOutput {
+            summaries: summaries
+                .into_iter()
+                .map(|s| ActivityInfo {
+                    slug: s.slug,
+                    name: s.name,
+                    completed_tasks: s.completed_tasks.iter().map(task_to_info).collect(),
+                    active_task_count: s.active_task_count,
+                })
+                .collect(),
+        })
+    }
+}
+
+impl ServerHandler for McpServer {
+    fn get_info(&self) -> ServerInfo {
+        let mut info = ServerInfo::new(ServerCapabilities::default());
+        info.server_info.name = "magical-merchant".into();
+        info.server_info.version = "0.1.0".into();
+        info.instructions = Some("Magical Merchant project and task management server".into());
+        info
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        let items = self.tool_router.list_all();
+        Ok(ListToolsResult::with_all_items(items))
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
+        self.tool_router.call(tcc).await
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    let server = McpServer::new(cli.data_dir);
+    let transport = rmcp::transport::io::stdio();
+    let _server = server.serve(transport).await?;
+    _server.waiting().await?;
+    Ok(())
 }

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -58,9 +58,8 @@ fn create_project(
     description: String,
 ) -> Result<String, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    let path =
-        magical_merchant_core::create_project(&base_dir, &slug, &name, &description)
-            .map_err(|e| e.to_string())?;
+    let path = magical_merchant_core::create_project(&base_dir, &slug, &name, &description)
+        .map_err(|e| e.to_string())?;
     Ok(path.to_string_lossy().to_string())
 }
 
@@ -79,38 +78,25 @@ fn create_task(
     body: String,
 ) -> Result<String, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    let path =
-        magical_merchant_core::create_task(&base_dir, &project_slug, &title, &tags, &body)
-            .map_err(|e| e.to_string())?;
+    let path = magical_merchant_core::create_task(&base_dir, &project_slug, &title, &tags, &body)
+        .map_err(|e| e.to_string())?;
     Ok(path.to_string_lossy().to_string())
 }
 
 #[tauri::command]
-fn list_active_tasks(
-    handle: AppHandle,
-    project_slug: String,
-) -> Result<Vec<TaskSummary>, String> {
+fn list_active_tasks(handle: AppHandle, project_slug: String) -> Result<Vec<TaskSummary>, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    magical_merchant_core::list_active_tasks(&base_dir, &project_slug)
-        .map_err(|e| e.to_string())
+    magical_merchant_core::list_active_tasks(&base_dir, &project_slug).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
-fn list_done_tasks(
-    handle: AppHandle,
-    project_slug: String,
-) -> Result<Vec<TaskSummary>, String> {
+fn list_done_tasks(handle: AppHandle, project_slug: String) -> Result<Vec<TaskSummary>, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    magical_merchant_core::list_done_tasks(&base_dir, &project_slug)
-        .map_err(|e| e.to_string())
+    magical_merchant_core::list_done_tasks(&base_dir, &project_slug).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
-fn complete_task(
-    handle: AppHandle,
-    project_slug: String,
-    filename: String,
-) -> Result<(), String> {
+fn complete_task(handle: AppHandle, project_slug: String, filename: String) -> Result<(), String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
     magical_merchant_core::complete_task(&base_dir, &project_slug, &filename)
         .map_err(|e| e.to_string())

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-use magical_merchant_core::{DeviceContext, NoteSummary};
+use magical_merchant_core::{DeviceContext, NoteSummary, ProjectSummary, TaskSummary};
 use tauri::{AppHandle, Manager};
 
 #[tauri::command]
@@ -50,6 +50,86 @@ fn read_timeline(handle: AppHandle) -> Result<Vec<String>, String> {
     magical_merchant_core::read_timeline(&base_dir, today).map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+fn create_project(
+    handle: AppHandle,
+    slug: String,
+    name: String,
+    description: String,
+) -> Result<String, String> {
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    let path =
+        magical_merchant_core::create_project(&base_dir, &slug, &name, &description)
+            .map_err(|e| e.to_string())?;
+    Ok(path.to_string_lossy().to_string())
+}
+
+#[tauri::command]
+fn list_projects(handle: AppHandle) -> Result<Vec<ProjectSummary>, String> {
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    magical_merchant_core::list_projects(&base_dir).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn create_task(
+    handle: AppHandle,
+    project_slug: String,
+    title: String,
+    tags: Vec<String>,
+    body: String,
+) -> Result<String, String> {
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    let path =
+        magical_merchant_core::create_task(&base_dir, &project_slug, &title, &tags, &body)
+            .map_err(|e| e.to_string())?;
+    Ok(path.to_string_lossy().to_string())
+}
+
+#[tauri::command]
+fn list_active_tasks(
+    handle: AppHandle,
+    project_slug: String,
+) -> Result<Vec<TaskSummary>, String> {
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    magical_merchant_core::list_active_tasks(&base_dir, &project_slug)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn list_done_tasks(
+    handle: AppHandle,
+    project_slug: String,
+) -> Result<Vec<TaskSummary>, String> {
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    magical_merchant_core::list_done_tasks(&base_dir, &project_slug)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn complete_task(
+    handle: AppHandle,
+    project_slug: String,
+    filename: String,
+) -> Result<(), String> {
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    magical_merchant_core::complete_task(&base_dir, &project_slug, &filename)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn update_task(
+    handle: AppHandle,
+    project_slug: String,
+    filename: String,
+    title: String,
+    tags: Vec<String>,
+    body: String,
+) -> Result<(), String> {
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    magical_merchant_core::update_task(&base_dir, &project_slug, &filename, &title, &tags, &body)
+        .map_err(|e| e.to_string())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -61,6 +141,13 @@ pub fn run() {
             list_notes,
             read_note,
             read_timeline,
+            create_project,
+            list_projects,
+            create_task,
+            list_active_tasks,
+            list_done_tasks,
+            complete_task,
+            update_task,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## Summary
- **core**: プロジェクトとタスクのCRUD操作、日付範囲による実績クエリ機能を追加
- **tauri**: プロジェクト・タスク管理のTauriコマンドを追加
- **mcp-cli**: rmcp SDKを使用したMCPサーバーを実装（list_projects, list_active_tasks, list_completed_tasks, get_task_history）

## Test plan
- [x] パス関数のユニットテスト（7テスト）
- [x] プロジェクトCRUDのユニットテスト（slug検証、作成、一覧、読み取り）
- [x] タスクCRUDのユニットテスト（作成、一覧、完了移動、更新）
- [x] 実績クエリのユニットテスト（日付フィルタ、複数プロジェクト横断、空結果）
- [x] cargo clippy --workspace（警告なし）
- [x] cargo fmt --all --check（フォーマット済み）
- [x] cargo test --workspace（全43テスト通過）