### PR TITLE
chore: modular justfile and GitHub Actions CI with Nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: nixbuild/nix-quick-install-action@v34
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev \
+            libappindicator3-dev librsvg2-dev patchelf
+      - run: nix develop --command just check
+      - run: nix fmt -- --check
+    timeout-minutes: 15
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: nixbuild/nix-quick-install-action@v34
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev \
+            libappindicator3-dev librsvg2-dev patchelf
+      - run: nix develop --command just test
+    timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: nixbuild/nix-quick-install-action@v34
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev \
-            libappindicator3-dev librsvg2-dev patchelf
       - run: nix develop --command just check
       - run: nix fmt -- --fail-on-change
     timeout-minutes: 15
@@ -26,10 +21,5 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: nixbuild/nix-quick-install-action@v34
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev \
-            libappindicator3-dev librsvg2-dev patchelf
       - run: nix develop --command just test
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: nixbuild/nix-quick-install-action@v34
+      - uses: DeterminateSystems/magic-nix-cache-action@v9
       - run: nix develop --command just check
       - run: nix fmt -- --fail-on-change
     timeout-minutes: 15
@@ -21,5 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: nixbuild/nix-quick-install-action@v34
+      - uses: DeterminateSystems/magic-nix-cache-action@v9
       - run: nix develop --command just test
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev \
             libappindicator3-dev librsvg2-dev patchelf
       - run: nix develop --command just check
-      - run: nix fmt -- --check
+      - run: nix fmt -- --fail-on-change
     timeout-minutes: 15
 
   test:

--- a/core/src/frontmatter.rs
+++ b/core/src/frontmatter.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, FixedOffset};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::error::CoreError;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,15 +7,15 @@ mod project;
 mod save;
 
 pub use error::CoreError;
-pub use format::{format_note_markdown, format_timeline_line, DeviceContext};
-pub use note::{create_draft_note, list_notes, read_note, update_note, NoteSummary};
+pub use format::{DeviceContext, format_note_markdown, format_timeline_line};
+pub use note::{NoteSummary, create_draft_note, list_notes, read_note, update_note};
 pub use path::{
     active_tasks_dir, done_tasks_dir, note_file_path, project_dir, project_file_path, projects_dir,
     timeline_file_path,
 };
 pub use project::{
-    complete_task, create_project, create_task, get_project_activity_summary, list_active_tasks,
-    list_done_tasks, list_projects, read_project, update_task, ProjectActivitySummary,
-    ProjectSummary, TaskSummary,
+    ProjectActivitySummary, ProjectSummary, TaskSummary, complete_task, create_project,
+    create_task, get_project_activity_summary, list_active_tasks, list_done_tasks, list_projects,
+    read_project, update_task,
 };
 pub use save::{read_timeline, save_note, save_timeline_entry};

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, FixedOffset, Local};
 use serde::Serialize;
 
 use crate::error::CoreError;
-use crate::format::{format_note_markdown, DeviceContext};
+use crate::format::{DeviceContext, format_note_markdown};
 use crate::frontmatter::{self, NoteFrontmatter};
 use crate::path::note_file_path;
 

--- a/core/src/save.rs
+++ b/core/src/save.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use chrono::{Local, NaiveDate};
 
 use crate::error::CoreError;
-use crate::format::{format_note_markdown, format_timeline_line, DeviceContext};
+use crate::format::{DeviceContext, format_note_markdown, format_timeline_line};
 use crate::path::{note_file_path, timeline_file_path};
 
 fn ensure_dir(path: &Path) -> Result<(), CoreError> {

--- a/flake.nix
+++ b/flake.nix
@@ -69,17 +69,26 @@
         formatter = treefmtEval.config.build.wrapper;
         checks.formatting = treefmtEval.config.build.check;
         devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            rustToolchain
-            just
-            nodejs_22
-            pnpm
-            cargo-tauri
-            jdk17
-            androidSdk
-            oxlint
-            typescript-go
-          ];
+          buildInputs =
+            with pkgs;
+            [
+              rustToolchain
+              just
+              nodejs_22
+              pnpm
+              cargo-tauri
+              jdk17
+              androidSdk
+              oxlint
+              typescript-go
+            ]
+            ++ lib.optionals stdenv.isLinux [
+              webkitgtk_4_1.dev
+              libappindicator-gtk3.dev
+              librsvg.dev
+              patchelf
+              pkg-config
+            ];
           ANDROID_HOME = "${androidSdk}/libexec/android-sdk";
           NDK_HOME = "${androidSdk}/libexec/android-sdk/ndk/29.0.14206865";
           shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
           programs.nixfmt.enable = true;
           programs.rustfmt.enable = true;
           programs.taplo.enable = true;
-          programs.prettier.enable = true;
+          programs.oxfmt.enable = true;
         };
         androidComposition = pkgs.androidenv.composeAndroidPackages {
           platformVersions = [ "36" ];
@@ -77,6 +77,7 @@
             cargo-tauri
             jdk17
             androidSdk
+            oxlint
           ];
           ANDROID_HOME = "${androidSdk}/libexec/android-sdk";
           NDK_HOME = "${androidSdk}/libexec/android-sdk/ndk/29.0.14206865";

--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,7 @@
             jdk17
             androidSdk
             oxlint
+            typescript-go
           ];
           ANDROID_HOME = "${androidSdk}/libexec/android-sdk";
           NDK_HOME = "${androidSdk}/libexec/android-sdk/ndk/29.0.14206865";

--- a/justfile
+++ b/justfile
@@ -1,47 +1,25 @@
-tauri-app := "tauri-app"
+mod rust
+mod tauri_app 'tauri-app'
 
-# Run clippy for linting
-lint:
-    cargo clippy --workspace -- -D warnings
+[private]
+default:
+  @just --list
 
-# Run formatter
-format:
-    cargo fmt --all
+fmt:
+  nix fmt
 
-# Run formatter check (CI用)
-format-check:
-    cargo fmt --all --check
+check: rust::check tauri_app::check
 
-# Run tests
-test:
-    cargo test --workspace
+test: rust::test
 
-# Run all checks (lint + format-check + test)
-check: lint format-check test
+verify: fmt check test
 
-# Install frontend dependencies
-fe-install:
-    cd {{tauri-app}} && pnpm install
+# --- Dev shortcuts ---
 
-# Build frontend
-fe-build:
-    cd {{tauri-app}} && pnpm build
+dev: tauri_app::dev
 
-# Run tauri desktop dev
-dev:
-    cd {{tauri-app}} && pnpm tauri dev
+android-init: tauri_app::android-init
 
-# Run tauri android init
-android-init:
-    cd {{tauri-app}} && pnpm tauri android init
+android-dev: tauri_app::android-dev
 
-# Run tauri android dev (実機 or エミュレータ)
-android-dev:
-    cd {{tauri-app}} && pnpm tauri android dev
-
-# Run tauri android build (release APK)
-android-build:
-    cd {{tauri-app}} && pnpm tauri android build
-
-# Full verify: rust checks + frontend build
-verify: check fe-build
+android-build: tauri_app::android-build

--- a/mcp-cli/Cargo.toml
+++ b/mcp-cli/Cargo.toml
@@ -5,7 +5,12 @@ edition = "2021"
 
 [dependencies]
 magical-merchant-core = { path = "../core" }
-rmcp = { version = "1", features = ["server", "macros", "transport-io", "schemars"] }
+rmcp = { version = "1", features = [
+  "server",
+  "macros",
+  "transport-io",
+  "schemars",
+] }
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/mcp-cli/src/main.rs
+++ b/mcp-cli/src/main.rs
@@ -9,7 +9,7 @@ use rmcp::model::{
     ServerCapabilities, ServerInfo,
 };
 use rmcp::service::RequestContext;
-use rmcp::{schemars, tool, tool_router, ErrorData, RoleServer, ServerHandler, ServiceExt};
+use rmcp::{ErrorData, RoleServer, ServerHandler, ServiceExt, schemars, tool, tool_router};
 use serde::{Deserialize, Serialize};
 
 #[derive(Parser)]

--- a/rust/justfile
+++ b/rust/justfile
@@ -1,0 +1,11 @@
+set working-directory := ".."
+
+[private]
+default:
+  @just --list
+
+check:
+  cargo clippy --workspace -- -D warnings
+
+test:
+  cargo test --workspace

--- a/tauri-app/justfile
+++ b/tauri-app/justfile
@@ -1,0 +1,26 @@
+[private]
+default:
+  @just --list
+
+[private]
+setup:
+  pnpm install
+
+assets: setup
+  pnpm run build
+
+check: setup
+  oxlint src/
+  tsgo -b --noEmit
+
+dev:
+  pnpm tauri dev
+
+android-init:
+  pnpm tauri android init
+
+android-dev:
+  pnpm tauri android dev
+
+android-build:
+  pnpm tauri android build

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "magical-merchant",
-  "private": true,
   "version": "0.1.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -21,11 +21,6 @@
     "react-dom": "^19.0.0",
     "shiki": "^4.0.2"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
-  },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",
     "@tauri-apps/cli": "^2",
@@ -38,5 +33,10 @@
     "tailwindcss": "^3.4.0",
     "typescript": "^5.6.0",
     "vite": "^6.0.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -24,10 +24,6 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "icon": [
-      "icons/32x32.png",
-      "icons/128x128.png",
-      "icons/128x128@2x.png"
-    ]
+    "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png"]
   }
 }

--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -21,9 +21,7 @@ function App() {
           <button
             key={tab.key}
             className={`flex-1 py-3 text-sm font-medium ${
-              activeTab === tab.key
-                ? "text-blue-600 border-b-2 border-blue-600"
-                : "text-gray-500"
+              activeTab === tab.key ? "text-blue-600 border-b-2 border-blue-600" : "text-gray-500"
             }`}
             onClick={() => setActiveTab(tab.key)}
           >

--- a/tauri-app/src/components/NotesList.tsx
+++ b/tauri-app/src/components/NotesList.tsx
@@ -65,10 +65,7 @@ function NotesList() {
   if (selectedNote) {
     return (
       <div className="flex flex-col gap-3 h-full">
-        <button
-          className="flex items-center gap-1 text-sm text-blue-600"
-          onClick={handleBack}
-        >
+        <button className="flex items-center gap-1 text-sm text-blue-600" onClick={handleBack}>
           <ChevronLeft size={16} />
           Back
         </button>
@@ -104,11 +101,7 @@ function NotesList() {
     <div className="flex flex-col gap-3 h-full">
       <div className="flex items-center justify-between">
         <h2 className="text-sm font-medium text-gray-700">Saved Notes</h2>
-        <button
-          className="p-1 text-gray-500"
-          onClick={fetchNotes}
-          disabled={loading}
-        >
+        <button className="p-1 text-gray-500" onClick={fetchNotes} disabled={loading}>
           <RefreshCw size={16} className={loading ? "animate-spin" : ""} />
         </button>
       </div>
@@ -122,9 +115,7 @@ function NotesList() {
               className="w-full text-left p-3 bg-white border border-gray-200 rounded-lg"
               onClick={() => handleSelect(note)}
             >
-              <div className="text-xs text-gray-500 mb-1">
-                {note.time ?? note.filename}
-              </div>
+              <div className="text-xs text-gray-500 mb-1">{note.time ?? note.filename}</div>
               {note.tags.length > 0 && (
                 <div className="flex gap-1 flex-wrap mb-1">
                   {note.tags.map((tag) => (

--- a/tauri-app/src/components/QuickCapture.tsx
+++ b/tauri-app/src/components/QuickCapture.tsx
@@ -62,10 +62,7 @@ function QuickCapture() {
             .slice()
             .reverse()
             .map((entry, i) => (
-              <div
-                key={i}
-                className="p-2 bg-white border border-gray-200 rounded-lg text-sm"
-              >
+              <div key={i} className="p-2 bg-white border border-gray-200 rounded-lg text-sm">
                 {entry}
               </div>
             ))}

--- a/tauri-app/src/lib/markdown.ts
+++ b/tauri-app/src/lib/markdown.ts
@@ -22,8 +22,7 @@ md.renderer.rules.fence = (tokens, idx, _options, env, _self) => {
 };
 
 export async function renderMarkdown(source: string): Promise<string> {
-  const env: { __shikiBlocks?: { id: string; code: string; lang: string }[] } =
-    {};
+  const env: { __shikiBlocks?: { id: string; code: string; lang: string }[] } = {};
   let html = md.render(source, env);
 
   const blocks = env.__shikiBlocks || [];


### PR DESCRIPTION
## Summary
- **justfile**: Artoパターンに倣い、モジュラー構造に分割（`mod rust` + `mod tauri_app`）
- **flake.nix**: prettier → oxfmt に差し替え、oxlint + typescript-go をdevShellに追加
- **CI**: Nix devShell経由のGitHub Actions（check + test ジョブ）

## Changes
| File | Description |
|------|-------------|
| `rust/justfile` | Cargo workspace操作モジュール（clippy, test） |
| `tauri-app/justfile` | フロントエンドモジュール（oxlint, tsgo, dev, android-*） |
| `justfile` | ルート集約（fmt = `nix fmt`、check/test = モジュール委譲） |
| `flake.nix` | treefmt: prettier→oxfmt、devShell: +oxlint +typescript-go |
| `.github/workflows/ci.yml` | `nix develop --command just check/test` + `nix fmt --fail-on-change` |

## Test plan
- [x] `just rust::check` — clippy 0 warnings
- [x] `just rust::test` — 54テスト全通過
- [x] `nix fmt -- --fail-on-change` — フォーマットクリーン
- [ ] GitHub Actions CI動作確認（このPRで自動実行）