### PR TITLE
docs: add project design priorities and UI component skill

### DIFF
--- a/.claude/skills/ui-component/SKILL.md
+++ b/.claude/skills/ui-component/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: ui-component
+description: UI component patterns for the desktop app. Use this skill when creating or modifying UI components to ensure consistency with the project's design system, layout conventions, and interaction patterns.
+---
+
+# UI Component Patterns
+
+Use this skill when building UI components for the desktop app.
+
+## Design System
+
+### Styling: Open Props
+
+All styling uses Open Props CSS custom properties. Never use hardcoded values for colors, spacing, or typography.
+
+```css
+/* Good */
+color: var(--text-1);
+padding: var(--size-3);
+border-radius: var(--radius-2);
+font-size: var(--font-size-1);
+
+/* Bad */
+color: #333;
+padding: 12px;
+border-radius: 8px;
+```
+
+### Icons: Phosphor Icons
+
+Use Phosphor Icons (SVG files) for all iconography.
+
+### Color Scheme
+
+- Light mode: Open Props defaults
+- Dark mode: `@media (prefers-color-scheme: dark)` with CSS custom property overrides
+- Accent adjustments: Nightfox Dawnfox (light) / Duskfox (dark) palette when needed
+
+## Component Patterns
+
+### Layout Rules
+
+1. **Full-screen memo area** — The memo/editor always occupies all available space
+2. **Minimal header** — Only toggle button + current mode icon
+3. **No visible chrome** — Borders, shadows, and decorations are minimal or absent
+4. **Breathing room** — Use `var(--size-*)` tokens for consistent spacing
+
+### Action Bar (Hidden Actions)
+
+Actions are hidden by default and revealed on interaction:
+
+```css
+.action-bar {
+    opacity: 0;
+    transition: opacity 150ms var(--ease-2);
+    pointer-events: none;
+}
+
+.memo-area:hover .action-bar,
+.action-bar.visible {
+    opacity: 1;
+    pointer-events: auto;
+}
+```
+
+### Text Input
+
+Full-width, borderless textarea that blends into the memo area:
+
+```css
+.memo-input {
+    width: 100%;
+    height: 100%;
+    border: none;
+    outline: none;
+    resize: none;
+    font-family: var(--font-sans);
+    font-size: var(--font-size-2);
+    line-height: var(--font-lineheight-3);
+    background: transparent;
+    color: var(--text-1);
+}
+```
+
+### Markdown Preview
+
+Style with Open Props typography tokens:
+
+```css
+.markdown-preview {
+    font-family: var(--font-sans);
+    line-height: var(--font-lineheight-4);
+    color: var(--text-1);
+}
+
+.markdown-preview h1 { font-size: var(--font-size-5); font-weight: var(--font-weight-7); }
+.markdown-preview h2 { font-size: var(--font-size-4); font-weight: var(--font-weight-6); }
+.markdown-preview h3 { font-size: var(--font-size-3); font-weight: var(--font-weight-6); }
+.markdown-preview code { font-family: var(--font-mono); background: var(--surface-2); padding: var(--size-1); border-radius: var(--radius-1); }
+.markdown-preview pre { background: var(--surface-2); padding: var(--size-3); border-radius: var(--radius-2); overflow-x: auto; }
+```
+
+## Priority Checklist
+
+Before merging any UI component, verify against design priorities:
+
+1. **Simple** — Does it add unnecessary visual complexity? Can it be simpler?
+2. **Lightweight** — Does it add weight (deps, DOM nodes, CSS)? Can it be lighter?
+3. **Stylish** — Does it look clean and intentional? Does it use design tokens consistently?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# Magical Merchant
+
+A minimal note-taking desktop app with Rust core logic and a lightweight UI.
+
+## Design Priorities (in order)
+
+1. **Simple UI** — Minimal chrome, full-screen memo area, hidden actions
+2. **Lightweight** — Small bundle, fast startup, no unnecessary dependencies
+3. **Stylish** — Clean aesthetics with design tokens (Open Props) and Phosphor Icons
+
+When making UI decisions, always evaluate against these priorities in order.
+If a feature adds visual complexity, it must justify itself against simplicity.
+If a dependency adds weight, it must justify itself against lightness.
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Core logic | Rust (`core/` crate, framework-independent) |
+| Desktop app | TBD (Tauri + React or Dioxus) |
+| Styling | Open Props (CSS custom properties) |
+| Icons | Phosphor Icons (SVG files) |
+
+## UI Architecture
+
+- **Header**: Toggle button (menu open/close) + current mode icon only
+- **Toggle menu**: 3 modes — Timeline / Notes / Tasks
+- **Memo area**: Occupies the full screen
+- **Actions**: Hidden by default, shown on hover (PC) / flick (mobile)
+- **Editing**: Inline Markdown live conversion (Typora-style)


### PR DESCRIPTION
## Summary

- `CLAUDE.md`にデザイン優先順位（Simple > Lightweight > Stylish）、テックスタック、UI設計方針を追加
- `.claude/skills/ui-component/SKILL.md`にOpen Props CSSパターンとPhosphor Iconsの規約を追加
- #6 からフレームワーク非依存のドキュメント部分のみを抽出

## Test plan

- [ ] `CLAUDE.md`の内容がプロジェクト方針と一致していること
- [ ] `SKILL.md`にフレームワーク固有のコード例が含まれていないこと