### PR TITLE
feat: migrate frontend from React to SolidJS with Milkdown editor

### DIFF
--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -12,9 +12,11 @@
   "dependencies": {
     "@milkdown/kit": "^7.20.0",
     "@milkdown/plugin-highlight": "^7.20.0",
+    "@phosphor-icons/core": "^2.1.1",
     "@solidjs/router": "^0.16.1",
     "@tauri-apps/api": "^2",
     "markdown-it": "^14.1.1",
+    "open-props": "^1.7.23",
     "shiki": "^4.0.2",
     "solid-js": "^1.9.12"
   },

--- a/tauri-app/pnpm-lock.yaml
+++ b/tauri-app/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@milkdown/plugin-highlight':
         specifier: ^7.20.0
         version: 7.20.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.0.2)(@types/hast@3.0.4)(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
+      '@phosphor-icons/core':
+        specifier: ^2.1.1
+        version: 2.1.1
       '@solidjs/router':
         specifier: ^0.16.1
         version: 0.16.1(solid-js@1.9.12)
@@ -23,6 +26,9 @@ importers:
       markdown-it:
         specifier: ^14.1.1
         version: 14.1.1
+      open-props:
+        specifier: ^1.7.23
+        version: 1.7.23
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
@@ -400,6 +406,9 @@ packages:
 
   '@ocavue/utils@1.6.0':
     resolution: {integrity: sha512-8W3q1hxx9qFdrYgPtbElllG/tqYkO/dMhlRUiqasO0SuDFTj78azSQjhIrBTFWxlBPPsSZN6zXYHmb3RwN2Jtg==}
+
+  '@phosphor-icons/core@2.1.1':
+    resolution: {integrity: sha512-v4ARvrip4qBCImOE5rmPUylOEK4iiED9ZyKjcvzuezqMaiRASCHKcRIuvvxL/twvLpkfnEODCOJp5dM4eZilxQ==}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -1061,6 +1070,9 @@ packages:
 
   oniguruma-to-es@4.3.5:
     resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
+
+  open-props@1.7.23:
+    resolution: {integrity: sha512-+xyrJmxV9QUBFbSwPROYhOg/FLXry+uuPr4R+B5EaE4556Oc18/8ZC/fL5A+/lbRSwNvA0Alh+C0KpyFWLmLZg==}
 
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
@@ -1875,6 +1887,8 @@ snapshots:
 
   '@ocavue/utils@1.6.0': {}
 
+  '@phosphor-icons/core@2.1.1': {}
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
@@ -2672,6 +2686,8 @@ snapshots:
       oniguruma-parser: 0.12.1
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  open-props@1.7.23: {}
 
   orderedmap@2.1.1: {}
 

--- a/tauri-app/src/styles/base.css
+++ b/tauri-app/src/styles/base.css
@@ -1,5 +1,5 @@
-@import "open-props/style";
-@import "open-props/normalize";
+@import "open-props/open-props.min.css";
+@import "open-props/normalize.min.css";
 
 :root {
   --app-surface: var(--gray-0);


### PR DESCRIPTION
## Summary

- Migrate the frontend framework from React to SolidJS for fine-grained reactivity
- Integrate Milkdown as the Markdown editor with Shiki syntax highlighting
- Implement 3-view layout: Timeline (quick capture), Notes (editor with autosave), Tasks (project management)
- Add Open Props design tokens, Phosphor Icons, and theme toggle
- Add CI workflow with Nix devShell, modular justfile structure

## Test plan

- [x] Verify app launches with `pnpm tauri dev`
- [x] Test Timeline view: create and view memos
- [x] Test Notes view: edit markdown, verify autosave, check Shiki highlighting
- [x] Test Tasks view: create projects and tasks
- [x] Test theme toggle (light/dark)
- [x] Verify CI passes on GitHub Actions