### PR TITLE
fix: make Playwright work locally on macOS and fix CI browser mismatch

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,1 @@
 use flake
-
-export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,12 +89,6 @@ jobs:
       - name: check
         if: steps.filter.outputs.frontend == 'true' || github.event_name != 'pull_request'
         run: nix develop --command just tauri_app::check
-      - name: setup playwright browsers
-        if: steps.filter.outputs.frontend == 'true' || github.event_name != 'pull_request'
-        run: |
-          path=$(nix build nixpkgs#playwright-driver.browsers --no-link --print-out-paths)
-          echo "PLAYWRIGHT_BROWSERS_PATH=$path" >> "$GITHUB_ENV"
-          echo "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1" >> "$GITHUB_ENV"
       - name: test
         if: steps.filter.outputs.frontend == 'true' || github.event_name != 'pull_request'
         run: nix develop --command just tauri_app::test

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ A minimal note-taking desktop app with a Rust core and a lightweight UI.
 - **Theme**: system / light / dark (syncs with OS setting)
 - **Editor principles**: Minimize DOM nodes, localized conversion only, preserve scroll & selection
 
+## Testing (Playwright)
+
+Browser tests use Vitest Browser Mode + Playwright.
+
+- **Linux (CI)**: Nix `playwright-driver.browsers` is configured automatically
+- **macOS (local)**: One-time browser install required
+
+```sh
+cd tauri-app && pnpm exec playwright install chromium
+```
+
 ## Build & Run
 
 ```sh

--- a/flake.nix
+++ b/flake.nix
@@ -69,48 +69,51 @@
       {
         formatter = treefmtEval.config.build.wrapper;
         checks.formatting = treefmtEval.config.build.check;
-        devShells.default = pkgs.mkShell ({
-          buildInputs =
-            with pkgs;
-            [
-              rustToolchain
-              just
-              nodejs_22
-              pnpm
-              cargo-tauri
-              jdk17
-              androidSdk
-              oxlint
-              typescript-go
-            ]
-            ++ lib.optionals stdenv.isLinux [
-              webkitgtk_4_1.dev
-              libappindicator-gtk3.dev
-              librsvg.dev
-              patchelf
-              pkg-config
-            ];
-          ANDROID_HOME = "${androidSdk}/libexec/android-sdk";
-          NDK_HOME = "${androidSdk}/libexec/android-sdk/ndk/29.0.14206865";
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = if pkgs.stdenv.isLinux then "1" else "0";
-          shellHook = ''
-            # Create a rustup shim that no-ops for tauri android init
-            mkdir -p "$PWD/.nix-shims"
-            cat > "$PWD/.nix-shims/rustup" << 'SHIM'
-            #!/usr/bin/env bash
-            # Nix manages Rust targets, so rustup calls are no-ops
-            if [[ "$1" == "target" && "$2" == "add" ]]; then
-              echo "info: target '$3' is already installed (managed by Nix)"
-              exit 0
-            fi
-            exec "$@"
-            SHIM
-            chmod +x "$PWD/.nix-shims/rustup"
-            export PATH="$PWD/.nix-shims:$PATH"
-          '';
-        } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
-          PLAYWRIGHT_BROWSERS_PATH = "${playwrightBrowsers}";
-        });
+        devShells.default = pkgs.mkShell (
+          {
+            buildInputs =
+              with pkgs;
+              [
+                rustToolchain
+                just
+                nodejs_22
+                pnpm
+                cargo-tauri
+                jdk17
+                androidSdk
+                oxlint
+                typescript-go
+              ]
+              ++ lib.optionals stdenv.isLinux [
+                webkitgtk_4_1.dev
+                libappindicator-gtk3.dev
+                librsvg.dev
+                patchelf
+                pkg-config
+              ];
+            ANDROID_HOME = "${androidSdk}/libexec/android-sdk";
+            NDK_HOME = "${androidSdk}/libexec/android-sdk/ndk/29.0.14206865";
+            PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = if pkgs.stdenv.isLinux then "1" else "0";
+            shellHook = ''
+              # Create a rustup shim that no-ops for tauri android init
+              mkdir -p "$PWD/.nix-shims"
+              cat > "$PWD/.nix-shims/rustup" << 'SHIM'
+              #!/usr/bin/env bash
+              # Nix manages Rust targets, so rustup calls are no-ops
+              if [[ "$1" == "target" && "$2" == "add" ]]; then
+                echo "info: target '$3' is already installed (managed by Nix)"
+                exit 0
+              fi
+              exec "$@"
+              SHIM
+              chmod +x "$PWD/.nix-shims/rustup"
+              export PATH="$PWD/.nix-shims:$PATH"
+            '';
+          }
+          // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+            PLAYWRIGHT_BROWSERS_PATH = "${playwrightBrowsers}";
+          }
+        );
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,7 @@
       {
         formatter = treefmtEval.config.build.wrapper;
         checks.formatting = treefmtEval.config.build.check;
-        devShells.default = pkgs.mkShell {
+        devShells.default = pkgs.mkShell ({
           buildInputs =
             with pkgs;
             [
@@ -92,8 +92,7 @@
             ];
           ANDROID_HOME = "${androidSdk}/libexec/android-sdk";
           NDK_HOME = "${androidSdk}/libexec/android-sdk/ndk/29.0.14206865";
-          PLAYWRIGHT_BROWSERS_PATH = "${playwrightBrowsers}";
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = if pkgs.stdenv.isLinux then "1" else "0";
           shellHook = ''
             # Create a rustup shim that no-ops for tauri android init
             mkdir -p "$PWD/.nix-shims"
@@ -109,7 +108,9 @@
             chmod +x "$PWD/.nix-shims/rustup"
             export PATH="$PWD/.nix-shims:$PATH"
           '';
-        };
+        } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+          PLAYWRIGHT_BROWSERS_PATH = "${playwrightBrowsers}";
+        });
       }
     );
 }


### PR DESCRIPTION
## Summary
- CI: remove separate `nix build nixpkgs#playwright-driver.browsers` step that caused chromium version mismatch — let `nix develop` use the flake's pinned browsers instead
- macOS: make `PLAYWRIGHT_BROWSERS_PATH` Linux-only and set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=0` so Playwright downloads native browsers locally
- Add testing setup section to README

Closes #22

## Test plan
- [ ] CI frontend job passes on Linux
- [ ] `pnpm exec playwright install chromium && pnpm test` works on macOS