### PR TITLE
ci: debug Playwright browsers path on Linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,6 @@ jobs:
       - name: check
         if: steps.filter.outputs.frontend == 'true' || github.event_name != 'pull_request'
         run: nix develop --command just tauri_app::check
-      - name: debug playwright browsers
-        if: steps.filter.outputs.frontend == 'true' || github.event_name != 'pull_request'
-        run: nix develop --command bash -c 'echo "PLAYWRIGHT_BROWSERS_PATH=$PLAYWRIGHT_BROWSERS_PATH" && ls -la $PLAYWRIGHT_BROWSERS_PATH/ && ls -la $PLAYWRIGHT_BROWSERS_PATH/chromium_headless_shell-1208/ && ls -la $PLAYWRIGHT_BROWSERS_PATH/chromium-1208/'
       - name: test
         if: steps.filter.outputs.frontend == 'true' || github.event_name != 'pull_request'
         run: nix develop --command just tauri_app::test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
       - name: check
         if: steps.filter.outputs.frontend == 'true' || github.event_name != 'pull_request'
         run: nix develop --command just tauri_app::check
+      - name: debug playwright browsers
+        if: steps.filter.outputs.frontend == 'true' || github.event_name != 'pull_request'
+        run: nix develop --command bash -c 'echo "PLAYWRIGHT_BROWSERS_PATH=$PLAYWRIGHT_BROWSERS_PATH" && ls -la $PLAYWRIGHT_BROWSERS_PATH/ && ls -la $PLAYWRIGHT_BROWSERS_PATH/chromium_headless_shell-1208/ && ls -la $PLAYWRIGHT_BROWSERS_PATH/chromium-1208/'
       - name: test
         if: steps.filter.outputs.frontend == 'true' || github.event_name != 'pull_request'
         run: nix develop --command just tauri_app::test

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770689213,
-        "narHash": "sha256-N6JiSpfi0s8NjUTnjwo3c+YAmvYhCDzjCKCrTUC97xM=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "49d75834011c94a120a9cb874ac1c4d8b7bfc767",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -94,7 +94,7 @@
               ];
             ANDROID_HOME = "${androidSdk}/libexec/android-sdk";
             NDK_HOME = "${androidSdk}/libexec/android-sdk/ndk/29.0.14206865";
-            PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = if pkgs.stdenv.isLinux then "1" else "0";
+            PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
             shellHook = ''
               # Create a rustup shim that no-ops for tauri android init
               mkdir -p "$PWD/.nix-shims"
@@ -111,7 +111,7 @@
               export PATH="$PWD/.nix-shims:$PATH"
             '';
           }
-          // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+          // {
             PLAYWRIGHT_BROWSERS_PATH = "${playwrightBrowsers}";
           }
         );


### PR DESCRIPTION
## Summary
- CI上でNixの `playwright-browsers` パッケージの中身を確認するデバッグステップを追加
- `chromium_headless_shell-1208/` と `chromium-1208/` のディレクトリ内容を `ls` で出力

## Context
CI が `browserType.launch: Executable doesn't exist at .../chromium_headless_shell-1208/chrome-headless-shell-linux64/chrome-headless-shell` で失敗している。Nix の `playwright-driver.browsers` が Linux 用バイナリを正しく配置しているか確認する。

## Test plan
- [x] CI の `debug playwright browsers` ステップの出力を確認
- [x] 結果に基づいて修正方針を決定
- [x] デバッグステップを削除