### PR TITLE
fix(flake): override platform-tools v37.0.0 macOS hash mismatch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770689213,
-        "narHash": "sha256-N6JiSpfi0s8NjUTnjwo3c+YAmvYhCDzjCKCrTUC97xM=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "49d75834011c94a120a9cb874ac1c4d8b7bfc767",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,8 @@
           config.allowUnfree = true;
           config.android_sdk.accept_license = true;
         };
+        # Workaround: see nix/android-repo-fix.nix and #26
+        fixedRepoFile = import ./nix/android-repo-fix.nix { inherit pkgs; };
         rustToolchain = pkgs.rust-bin.stable.latest.default.override {
           extensions = [
             "rust-src"
@@ -53,6 +55,7 @@
           programs.oxfmt.enable = true;
         };
         androidComposition = pkgs.androidenv.composeAndroidPackages {
+          repoJson = fixedRepoFile;
           platformVersions = [ "36" ];
           buildToolsVersions = [
             "35.0.0"

--- a/nix/android-repo-fix.nix
+++ b/nix/android-repo-fix.nix
@@ -1,0 +1,26 @@
+# Workaround: platform-tools v37.0.0 hash mismatch on macOS.
+# Google rebuilt the zip at the same URL, changing the hash.
+# See: https://github.com/Xantibody/magical-merchant/issues/26
+# Remove this file once nixpkgs upstream updates the hash.
+{ pkgs }:
+let
+  originalRepoJson = builtins.fromJSON (
+    builtins.readFile "${pkgs.path}/pkgs/development/mobile/androidenv/repo.json"
+  );
+  fixedRepoJson = originalRepoJson // {
+    packages = originalRepoJson.packages // {
+      platform-tools = originalRepoJson.packages.platform-tools // {
+        "37.0.0" = originalRepoJson.packages.platform-tools."37.0.0" // {
+          archives = map (
+            archive:
+            if archive.os == "macosx" then
+              archive // { sha1 = "8c4c926d0ca192376b2a04b0318484724319e67c"; }
+            else
+              archive
+          ) originalRepoJson.packages.platform-tools."37.0.0".archives;
+        };
+      };
+    };
+  };
+in
+pkgs.writeText "repo.json" (builtins.toJSON fixedRepoJson)


### PR DESCRIPTION
## Summary
- nixpkgs unstable 更新後、Google が `platform-tools_r37.0.0-darwin.zip` を同一 URL で再ビルドしたため `nix develop` がハッシュミスマッチで失敗する問題を修正
- `nix/android-repo-fix.nix` に修正用 sha1 オーバーライドを分離し、upstream 修正後に削除しやすくした
- nixpkgs を `b86751bc` (2026-04-16) に更新

## Test plan
- [x] `nix develop --command echo "dev shell OK"` が成功することを確認済み

Closes #26