### PR TITLE
feat(build): add macOS production build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ just dev
 | Android  | JDK 17, Android SDK (API 36), NDK 29             |
 | Format   | nix fmt (treefmt: nixfmt, rustfmt, taplo, oxfmt) |
 
+## Build & Install (macOS)
+
+```sh
+# Build the .app bundle (Apple Silicon)
+just build
+
+# Copy to Applications
+cp -r "tauri-app/src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Magical Merchant.app" /Applications/
+
+# Remove Gatekeeper quarantine (unsigned app)
+xattr -cr "/Applications/Magical Merchant.app"
+```
+
 ## Environment Variables
 
 | Variable                           | Description                            | Set by       |
@@ -110,6 +123,7 @@ Communicates via stdio transport and provides the following tools:
 | `just android-init`  | Initialize Android target           |     |
 | `just android-dev`   | Development on Android device       |     |
 | `just android-build` | Build Android APK                   |     |
+| `just build`         | Build macOS .app (Apple Silicon)    |     |
 
 ### Rust recipes (`rust::`)
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ just dev
 just build
 
 # Copy to Applications
-cp -r "tauri-app/src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Magical Merchant.app" /Applications/
+cp -r "target/release/bundle/macos/Magical Merchant.app" /Applications/
 
 # Remove Gatekeeper quarantine (unsigned app)
 xattr -cr "/Applications/Magical Merchant.app"

--- a/justfile
+++ b/justfile
@@ -23,3 +23,5 @@ android-init: tauri_app::android-init
 android-dev: tauri_app::android-dev
 
 android-build: tauri_app::android-build
+
+build: tauri_app::build

--- a/tauri-app/justfile
+++ b/tauri-app/justfile
@@ -27,3 +27,6 @@ android-dev:
 
 android-build:
   pnpm tauri android build
+
+build:
+  pnpm tauri build --bundles app --target aarch64-apple-darwin

--- a/tauri-app/justfile
+++ b/tauri-app/justfile
@@ -29,4 +29,4 @@ android-build:
   pnpm tauri android build
 
 build:
-  pnpm tauri build --bundles app --target aarch64-apple-darwin
+  pnpm tauri build --bundles app

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsgo -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary
- `just build` コマンドを追加（Apple Silicon向け `.app` バンドル生成）
- READMEにビルド・インストール手順を追記（Gatekeeper回避含む）

Closes #30

## Test plan
- [x] `just build` でビルドが成功すること
- [x] 生成された `.app` を `/Applications` にコピーして起動できること
- [ ] メモの保存・読み込みが正常に動作すること