### PR TITLE
build: add android debug build and install recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -24,4 +24,8 @@ android-dev: tauri_app::android-dev
 
 android-build: tauri_app::android-build
 
+android-build-debug: tauri_app::android-build-debug
+
+android-install: tauri_app::android-install
+
 build: tauri_app::build

--- a/tauri-app/justfile
+++ b/tauri-app/justfile
@@ -28,5 +28,11 @@ android-dev:
 android-build:
   pnpm tauri android build
 
+android-build-debug:
+  pnpm tauri android build --debug --target aarch64
+
+android-install: android-build-debug
+  adb install src-tauri/gen/android/app/build/outputs/apk/universal/debug/app-universal-debug.apk
+
 build:
   pnpm tauri build --bundles app


### PR DESCRIPTION
## Summary
- `android-build-debug`: aarch64向けdebug APKビルドレシピを追加
- `android-install`: debug APKのビルド＋adbサイドロードを一発で実行するレシピを追加

Closes #37