### PR TITLE
feat(ui): add flick gesture for ActionBar on mobile

### DIFF
--- a/tauri-app/src/components/ActionBar.test.tsx
+++ b/tauri-app/src/components/ActionBar.test.tsx
@@ -5,6 +5,40 @@ import ActionBar from "./ActionBar";
 
 afterEach(() => cleanup());
 
+function makeTouch(target: Element, clientY: number): Touch {
+  return new Touch({ identifier: 0, target, clientY, clientX: 0 });
+}
+
+function flick(target: Element, startY: number, endY: number) {
+  target.dispatchEvent(
+    new TouchEvent("touchstart", {
+      bubbles: true,
+      touches: [makeTouch(target, startY)],
+    }),
+  );
+  target.dispatchEvent(
+    new TouchEvent("touchend", {
+      bubbles: true,
+      changedTouches: [makeTouch(target, endY)],
+    }),
+  );
+}
+
+function tap(target: Element, clientY = 0) {
+  target.dispatchEvent(
+    new TouchEvent("touchstart", {
+      bubbles: true,
+      touches: [makeTouch(target, clientY)],
+    }),
+  );
+  target.dispatchEvent(
+    new TouchEvent("touchend", {
+      bubbles: true,
+      changedTouches: [makeTouch(target, clientY)],
+    }),
+  );
+}
+
 describe("ActionBar", () => {
   it("renders children", async () => {
     const { baseElement } = render(() => (
@@ -26,5 +60,93 @@ describe("ActionBar", () => {
 
     expect(baseElement.querySelector(".action-bar-zone")).not.toBeNull();
     expect(baseElement.querySelector(".action-bar")).not.toBeNull();
+  });
+
+  describe("flick gesture", () => {
+    it("adds visible class on upward flick", () => {
+      const { baseElement } = render(() => (
+        <ActionBar>
+          <button>Action</button>
+        </ActionBar>
+      ));
+      const zone = baseElement.querySelector(".action-bar-zone")!;
+      const bar = baseElement.querySelector(".action-bar")!;
+
+      flick(zone, 300, 250); // upward: deltaY = -50
+
+      expect(bar.classList.contains("action-bar--visible")).toBe(true);
+    });
+
+    it("removes visible class on downward flick", () => {
+      const { baseElement } = render(() => (
+        <ActionBar>
+          <button>Action</button>
+        </ActionBar>
+      ));
+      const zone = baseElement.querySelector(".action-bar-zone")!;
+      const bar = baseElement.querySelector(".action-bar")!;
+
+      // First show it
+      flick(zone, 300, 250);
+      expect(bar.classList.contains("action-bar--visible")).toBe(true);
+
+      // Then hide it
+      flick(zone, 250, 300); // downward: deltaY = +50
+
+      expect(bar.classList.contains("action-bar--visible")).toBe(false);
+    });
+
+    it("does not react to movement below threshold", () => {
+      const { baseElement } = render(() => (
+        <ActionBar>
+          <button>Action</button>
+        </ActionBar>
+      ));
+      const zone = baseElement.querySelector(".action-bar-zone")!;
+      const bar = baseElement.querySelector(".action-bar")!;
+
+      flick(zone, 300, 290); // deltaY = -10, below 30px threshold
+
+      expect(bar.classList.contains("action-bar--visible")).toBe(false);
+    });
+
+    it("hides on tap outside the action bar", () => {
+      const { baseElement } = render(() => (
+        <ActionBar>
+          <button>Action</button>
+        </ActionBar>
+      ));
+      const zone = baseElement.querySelector(".action-bar-zone")!;
+      const bar = baseElement.querySelector(".action-bar")!;
+
+      // Show it first
+      flick(zone, 300, 250);
+      expect(bar.classList.contains("action-bar--visible")).toBe(true);
+
+      // Tap outside (on document body, not on the bar)
+      tap(document.body);
+
+      expect(bar.classList.contains("action-bar--visible")).toBe(false);
+    });
+
+    it("does not hide on tap inside the action bar", () => {
+      const { baseElement } = render(() => (
+        <ActionBar>
+          <button>Action</button>
+        </ActionBar>
+      ));
+      const zone = baseElement.querySelector(".action-bar-zone")!;
+      const bar = baseElement.querySelector(".action-bar")!;
+
+      // Show it first
+      flick(zone, 300, 250);
+      expect(bar.classList.contains("action-bar--visible")).toBe(true);
+
+      // Tap inside the bar
+      const button = bar.querySelector("button")!;
+      tap(button);
+
+      expect(bar.classList.contains("action-bar--visible")).toBe(true);
+    });
   });
 });

--- a/tauri-app/src/components/ActionBar.tsx
+++ b/tauri-app/src/components/ActionBar.tsx
@@ -1,13 +1,51 @@
-import type { JSX } from "solid-js";
+import { type JSX, createSignal, onMount, onCleanup } from "solid-js";
 
 interface ActionBarProps {
   children: JSX.Element;
 }
 
+const FLICK_DISTANCE = 30;
+const FLICK_MAX_DURATION = 300;
+
 export default function ActionBar(props: ActionBarProps) {
+  const [visible, setVisible] = createSignal(false);
+  let barRef!: HTMLDivElement;
+
+  let touchStartY = 0;
+  let touchStartTime = 0;
+
+  const onTouchStart = (e: TouchEvent) => {
+    touchStartY = e.touches[0].clientY;
+    touchStartTime = Date.now();
+  };
+
+  const onTouchEnd = (e: TouchEvent) => {
+    const deltaY = e.changedTouches[0].clientY - touchStartY;
+    const elapsed = Date.now() - touchStartTime;
+
+    if (Math.abs(deltaY) >= FLICK_DISTANCE && elapsed <= FLICK_MAX_DURATION) {
+      setVisible(deltaY < 0);
+    }
+  };
+
+  const onDocumentTouchStart = (e: TouchEvent) => {
+    if (visible() && !barRef.contains(e.target as Node)) {
+      setVisible(false);
+    }
+  };
+
+  onMount(() => {
+    document.addEventListener("touchstart", onDocumentTouchStart);
+  });
+  onCleanup(() => {
+    document.removeEventListener("touchstart", onDocumentTouchStart);
+  });
+
   return (
-    <div class="action-bar-zone">
-      <div class="action-bar">{props.children}</div>
+    <div class="action-bar-zone" onTouchStart={onTouchStart} onTouchEnd={onTouchEnd}>
+      <div class="action-bar" classList={{ "action-bar--visible": visible() }} ref={barRef}>
+        {props.children}
+      </div>
     </div>
   );
 }

--- a/tauri-app/src/styles/action-bar.css
+++ b/tauri-app/src/styles/action-bar.css
@@ -13,10 +13,31 @@
   transition: opacity 150ms var(--ease-2);
 }
 
-.action-bar-zone:hover .action-bar,
+/* Keyboard accessibility — all devices */
 .action-bar:focus-within {
   opacity: 1;
   pointer-events: auto;
+}
+
+/* Desktop: show on hover */
+@media (hover: hover) {
+  .action-bar-zone:hover .action-bar {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+/* Touch devices: show via JS class */
+@media (hover: none) {
+  .action-bar-zone {
+    left: 0;
+    padding: var(--size-8) var(--size-5);
+  }
+
+  .action-bar--visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
 }
 
 .action-bar button {


### PR DESCRIPTION
## Summary
- タッチデバイスでActionBarをフリック操作で表示/非表示できるようにした
- CSS `:hover` ルールを `@media (hover: hover)` に分離し、タッチデバイスではクラスベースの表示切替に変更
- 上フリック(30px+, 300ms以内)で表示、下フリックまたは外側タップで非表示

## Test plan
- [x] 上フリックで `action-bar--visible` クラスが付与される
- [x] 下フリックで非表示になる
- [x] 閾値未満の移動では反応しない
- [x] 外側タップで非表示になる
- [x] 内側タップでは非表示にならない
- [x] 既存テスト全パス (28/28)
- [x] 実機(Android)でフリック操作を確認