### PR TITLE
fix: verify toolchain (oxlint config + recipe rename)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  core:
+  app:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -20,25 +20,25 @@ jobs:
         id: filter
         with:
           filters: |
-            core:
+            app:
               - 'core/**'
               - 'tauri-app/src-tauri/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust/justfile'
       - name: Free disk space
-        if: steps.filter.outputs.core == 'true' || github.event_name != 'pull_request'
+        if: steps.filter.outputs.app == 'true' || github.event_name != 'pull_request'
         run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
-      - if: steps.filter.outputs.core == 'true' || github.event_name != 'pull_request'
+      - if: steps.filter.outputs.app == 'true' || github.event_name != 'pull_request'
         uses: nixbuild/nix-quick-install-action@v34
-      - if: steps.filter.outputs.core == 'true' || github.event_name != 'pull_request'
+      - if: steps.filter.outputs.app == 'true' || github.event_name != 'pull_request'
         uses: DeterminateSystems/magic-nix-cache-action@v9
       - name: check
-        if: steps.filter.outputs.core == 'true' || github.event_name != 'pull_request'
-        run: nix develop --command just rust::check-core
+        if: steps.filter.outputs.app == 'true' || github.event_name != 'pull_request'
+        run: nix develop --command just rust::check-app
       - name: test
-        if: steps.filter.outputs.core == 'true' || github.event_name != 'pull_request'
-        run: nix develop --command just rust::test-core
+        if: steps.filter.outputs.app == 'true' || github.event_name != 'pull_request'
+        run: nix develop --command just rust::test-app
     timeout-minutes: 15
 
   cli:

--- a/rust/justfile
+++ b/rust/justfile
@@ -12,10 +12,10 @@ test:
 
 # --- Per-crate recipes ---
 
-check-core:
+check-app:
   cargo clippy -p magical-merchant-core -p magical-merchant-app -- -D warnings
 
-test-core:
+test-app:
   cargo test -p magical-merchant-core -p magical-merchant-app
 
 check-cli:

--- a/tauri-app/.oxlintrc.json
+++ b/tauri-app/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-unassigned-vars": "off"
+  }
+}


### PR DESCRIPTION
## Summary

- oxlint の `no-unassigned-vars` ルールを無効化（SolidJS の `ref` パターンの false positive 解消）
- `rust::check-core` / `rust::test-core` レシピを `check-app` / `test-app` にリネーム（実態に合わせた命名）
- CI ワークフローのジョブ名・レシピ呼び出しを合わせて更新

Closes #43

## Test plan

- [x] `just verify` が warning 0 / エラー 0 で完了
- [x] `just rust::check-app` / `just rust::test-app` が正常動作
- [x] `just rust::check-cli` / `just rust::test-cli` に regression なし