### PR TITLE
feat: add real device context to timeline (battery, network, location, OS info)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,6 +1503,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,6 +2113,7 @@ version = "0.1.0"
 dependencies = [
  "battery",
  "chrono",
+ "hostname",
  "jsonwebtoken",
  "keyring",
  "magical-merchant-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "battery"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b624268937c0e0a3edb7c27843f9e547c320d730c610d3b8e6e8e95b2026e4"
+dependencies = [
+ "cfg-if",
+ "core-foundation 0.7.0",
+ "lazycell",
+ "libc",
+ "mach",
+ "nix",
+ "num-traits",
+ "uom",
+ "winapi",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,11 +492,21 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys 0.7.0",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
 ]
 
@@ -489,9 +516,15 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
@@ -1597,7 +1630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "iana-time-zone-haiku",
  "js-sys",
  "log",
@@ -1946,6 +1979,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,9 +2088,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "magical-merchant-app"
 version = "0.1.0"
 dependencies = [
+ "battery",
  "chrono",
  "jsonwebtoken",
  "keyring",
@@ -2064,6 +2113,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
+ "tauri-plugin-geolocation",
  "tauri-plugin-shell",
  "tempfile",
  "tokio",
@@ -2252,6 +2302,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
+dependencies = [
+ "bitflags 1.3.2",
+ "cc",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "nodrop"
@@ -3467,7 +3529,7 @@ checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.9.4",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
  "security-framework-sys",
 ]
@@ -3480,7 +3542,7 @@ checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
  "security-framework-sys",
 ]
@@ -3491,7 +3553,7 @@ version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.7",
  "libc",
 ]
 
@@ -4234,6 +4296,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-geolocation"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0366e51823ad001ff1a47f116cd34ddfea3d94ebeb2309caf42e290dec27e0a6"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-shell"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4850,6 +4926,16 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "uom"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e76503e636584f1e10b9b3b9498538279561adcef5412927ba00c2b32c4ce5ed"
+dependencies = [
+ "num-traits",
+ "typenum",
+]
 
 [[package]]
 name = "url"

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -55,7 +55,11 @@ mod tests {
     use tempfile::TempDir;
 
     fn mock_context() -> Context {
-        Context::mock()
+        Context {
+            battery: Some(50),
+            is_charging: Some(false),
+            ..Context::default()
+        }
     }
 
     #[test]

--- a/core/src/note/summary.rs
+++ b/core/src/note/summary.rs
@@ -53,8 +53,8 @@ mod tests {
                 .unwrap(),
             tags: vec!["a".to_string(), "b".to_string()],
             context: Some(ContextMeta {
-                battery: 50,
-                is_charging: false,
+                battery: Some(50),
+                is_charging: Some(false),
             }),
         };
         let content = frontmatter::render(&fm, "# Title\nBody").unwrap();

--- a/core/src/note/summary.rs
+++ b/core/src/note/summary.rs
@@ -40,7 +40,8 @@ impl Summary {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::frontmatter::{ContextMeta, NoteFrontmatter};
+    use crate::utils::device::Context;
+    use crate::utils::frontmatter::NoteFrontmatter;
     use chrono::{FixedOffset, TimeZone};
     use std::path::PathBuf;
 
@@ -52,10 +53,7 @@ mod tests {
                 .with_ymd_and_hms(2026, 3, 20, 14, 30, 45)
                 .unwrap(),
             tags: vec!["a".to_string(), "b".to_string()],
-            context: Some(ContextMeta {
-                battery: Some(50),
-                is_charging: Some(false),
-            }),
+            context: Some(Context::mock()),
         };
         let content = frontmatter::render(&fm, "# Title\nBody").unwrap();
         let summary = Summary::from_file(

--- a/core/src/note/summary.rs
+++ b/core/src/note/summary.rs
@@ -53,7 +53,11 @@ mod tests {
                 .with_ymd_and_hms(2026, 3, 20, 14, 30, 45)
                 .unwrap(),
             tags: vec!["a".to_string(), "b".to_string()],
-            context: Some(Context::mock()),
+            context: Some(Context {
+                battery: Some(50),
+                is_charging: Some(false),
+                ..Context::default()
+            }),
         };
         let content = frontmatter::render(&fm, "# Title\nBody").unwrap();
         let summary = Summary::from_file(

--- a/core/src/timeline.rs
+++ b/core/src/timeline.rs
@@ -34,7 +34,11 @@ mod tests {
     use tempfile::TempDir;
 
     fn mock_context() -> Context {
-        Context::mock()
+        Context {
+            battery: Some(50),
+            is_charging: Some(false),
+            ..Context::default()
+        }
     }
 
     #[test]

--- a/core/src/utils/device.rs
+++ b/core/src/utils/device.rs
@@ -1,11 +1,30 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum NetworkType {
+    WiFi,
+    Mobile,
+    Offline,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Location {
+    pub latitude: f64,
+    pub longitude: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Context {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub battery: Option<u8>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub is_charging: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_type: Option<NetworkType>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wifi_ssid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<Location>,
 }
 
 impl Context {
@@ -13,6 +32,9 @@ impl Context {
         Self {
             battery: Some(50),
             is_charging: Some(false),
+            network_type: None,
+            wifi_ssid: None,
+            location: None,
         }
     }
 }
@@ -26,6 +48,9 @@ mod tests {
         let ctx = Context::mock();
         assert_eq!(ctx.battery, Some(50));
         assert_eq!(ctx.is_charging, Some(false));
+        assert_eq!(ctx.network_type, None);
+        assert_eq!(ctx.wifi_ssid, None);
+        assert_eq!(ctx.location, None);
     }
 
     #[test]
@@ -33,29 +58,42 @@ mod tests {
         let ctx = Context {
             battery: None,
             is_charging: None,
+            network_type: None,
+            wifi_ssid: None,
+            location: None,
         };
         let json = serde_json::to_string(&ctx).unwrap();
         assert_eq!(json, "{}");
     }
 
     #[test]
-    fn test_context_serialization_with_values() {
+    fn test_context_serialization_with_all_fields() {
         let ctx = Context {
             battery: Some(82),
             is_charging: Some(false),
+            network_type: Some(NetworkType::WiFi),
+            wifi_ssid: Some("MyNetwork".to_string()),
+            location: Some(Location {
+                latitude: 35.6762,
+                longitude: 139.6503,
+            }),
         };
         let json = serde_json::to_string(&ctx).unwrap();
         assert!(json.contains("\"battery\":82"));
-        assert!(json.contains("\"is_charging\":false"));
+        assert!(json.contains("\"network_type\":\"WiFi\""));
+        assert!(json.contains("\"wifi_ssid\":\"MyNetwork\""));
+        assert!(json.contains("\"latitude\":35.6762"));
     }
 
     #[test]
     fn test_context_deserialization_old_format() {
-        // Old format had bare values - serde handles Option transparently
         let json = r#"{"battery":82,"is_charging":false}"#;
         let ctx: Context = serde_json::from_str(json).unwrap();
         assert_eq!(ctx.battery, Some(82));
         assert_eq!(ctx.is_charging, Some(false));
+        assert_eq!(ctx.network_type, None);
+        assert_eq!(ctx.wifi_ssid, None);
+        assert_eq!(ctx.location, None);
     }
 
     #[test]
@@ -63,6 +101,19 @@ mod tests {
         let json = "{}";
         let ctx: Context = serde_json::from_str(json).unwrap();
         assert_eq!(ctx.battery, None);
-        assert_eq!(ctx.is_charging, None);
+        assert_eq!(ctx.network_type, None);
+    }
+
+    #[test]
+    fn test_network_type_serialization() {
+        let ctx = Context {
+            battery: None,
+            is_charging: None,
+            network_type: Some(NetworkType::Mobile),
+            wifi_ssid: None,
+            location: None,
+        };
+        let json = serde_json::to_string(&ctx).unwrap();
+        assert_eq!(json, r#"{"network_type":"Mobile"}"#);
     }
 }

--- a/core/src/utils/device.rs
+++ b/core/src/utils/device.rs
@@ -13,7 +13,7 @@ pub struct Location {
     pub longitude: f64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct Context {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub battery: Option<u8>,
@@ -27,27 +27,15 @@ pub struct Context {
     pub location: Option<Location>,
 }
 
-impl Context {
-    pub fn mock() -> Self {
-        Self {
-            battery: Some(50),
-            is_charging: Some(false),
-            network_type: None,
-            wifi_ssid: None,
-            location: None,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_context_mock() {
-        let ctx = Context::mock();
-        assert_eq!(ctx.battery, Some(50));
-        assert_eq!(ctx.is_charging, Some(false));
+    fn test_context_default() {
+        let ctx = Context::default();
+        assert_eq!(ctx.battery, None);
+        assert_eq!(ctx.is_charging, None);
         assert_eq!(ctx.network_type, None);
         assert_eq!(ctx.wifi_ssid, None);
         assert_eq!(ctx.location, None);
@@ -55,13 +43,7 @@ mod tests {
 
     #[test]
     fn test_context_serialization_skips_none() {
-        let ctx = Context {
-            battery: None,
-            is_charging: None,
-            network_type: None,
-            wifi_ssid: None,
-            location: None,
-        };
+        let ctx = Context::default();
         let json = serde_json::to_string(&ctx).unwrap();
         assert_eq!(json, "{}");
     }
@@ -107,11 +89,8 @@ mod tests {
     #[test]
     fn test_network_type_serialization() {
         let ctx = Context {
-            battery: None,
-            is_charging: None,
             network_type: Some(NetworkType::Mobile),
-            wifi_ssid: None,
-            location: None,
+            ..Context::default()
         };
         let json = serde_json::to_string(&ctx).unwrap();
         assert_eq!(json, r#"{"network_type":"Mobile"}"#);

--- a/core/src/utils/device.rs
+++ b/core/src/utils/device.rs
@@ -1,16 +1,18 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Context {
-    pub battery: u8,
-    pub is_charging: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub battery: Option<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_charging: Option<bool>,
 }
 
 impl Context {
     pub fn mock() -> Self {
         Self {
-            battery: 50,
-            is_charging: false,
+            battery: Some(50),
+            is_charging: Some(false),
         }
     }
 }
@@ -22,7 +24,45 @@ mod tests {
     #[test]
     fn test_context_mock() {
         let ctx = Context::mock();
-        assert_eq!(ctx.battery, 50);
-        assert!(!ctx.is_charging);
+        assert_eq!(ctx.battery, Some(50));
+        assert_eq!(ctx.is_charging, Some(false));
+    }
+
+    #[test]
+    fn test_context_serialization_skips_none() {
+        let ctx = Context {
+            battery: None,
+            is_charging: None,
+        };
+        let json = serde_json::to_string(&ctx).unwrap();
+        assert_eq!(json, "{}");
+    }
+
+    #[test]
+    fn test_context_serialization_with_values() {
+        let ctx = Context {
+            battery: Some(82),
+            is_charging: Some(false),
+        };
+        let json = serde_json::to_string(&ctx).unwrap();
+        assert!(json.contains("\"battery\":82"));
+        assert!(json.contains("\"is_charging\":false"));
+    }
+
+    #[test]
+    fn test_context_deserialization_old_format() {
+        // Old format had bare values - serde handles Option transparently
+        let json = r#"{"battery":82,"is_charging":false}"#;
+        let ctx: Context = serde_json::from_str(json).unwrap();
+        assert_eq!(ctx.battery, Some(82));
+        assert_eq!(ctx.is_charging, Some(false));
+    }
+
+    #[test]
+    fn test_context_deserialization_missing_fields() {
+        let json = "{}";
+        let ctx: Context = serde_json::from_str(json).unwrap();
+        assert_eq!(ctx.battery, None);
+        assert_eq!(ctx.is_charging, None);
     }
 }

--- a/core/src/utils/device.rs
+++ b/core/src/utils/device.rs
@@ -25,12 +25,12 @@ pub struct Context {
     pub wifi_ssid: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub location: Option<Location>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub os: Option<String>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub os: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub os_version: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub arch: Option<String>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub arch: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hostname: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -69,9 +69,9 @@ mod tests {
                 latitude: 35.6762,
                 longitude: 139.6503,
             }),
-            os: Some("macos".to_string()),
+            os: "macos".to_string(),
             os_version: Some("15.3".to_string()),
-            arch: Some("aarch64".to_string()),
+            arch: "aarch64".to_string(),
             hostname: Some("MacBook".to_string()),
             locale: Some("ja_JP".to_string()),
         };

--- a/core/src/utils/device.rs
+++ b/core/src/utils/device.rs
@@ -25,6 +25,16 @@ pub struct Context {
     pub wifi_ssid: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub location: Option<Location>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub os: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub os_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub arch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hostname: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub locale: Option<String>,
 }
 
 #[cfg(test)]
@@ -59,12 +69,19 @@ mod tests {
                 latitude: 35.6762,
                 longitude: 139.6503,
             }),
+            os: Some("macos".to_string()),
+            os_version: Some("15.3".to_string()),
+            arch: Some("aarch64".to_string()),
+            hostname: Some("MacBook".to_string()),
+            locale: Some("ja_JP".to_string()),
         };
         let json = serde_json::to_string(&ctx).unwrap();
         assert!(json.contains("\"battery\":82"));
         assert!(json.contains("\"network_type\":\"WiFi\""));
         assert!(json.contains("\"wifi_ssid\":\"MyNetwork\""));
         assert!(json.contains("\"latitude\":35.6762"));
+        assert!(json.contains("\"os\":\"macos\""));
+        assert!(json.contains("\"hostname\":\"MacBook\""));
     }
 
     #[test]

--- a/core/src/utils/frontmatter.rs
+++ b/core/src/utils/frontmatter.rs
@@ -2,22 +2,15 @@ use chrono::{DateTime, FixedOffset};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::error::CoreError;
+use crate::utils::device::Context;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct NoteFrontmatter {
     pub time: DateTime<FixedOffset>,
     #[serde(default)]
     pub tags: Vec<String>,
-    #[serde(default)]
-    pub context: Option<ContextMeta>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ContextMeta {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub battery: Option<u8>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub is_charging: Option<bool>,
+    pub context: Option<Context>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -109,9 +102,12 @@ mod tests {
         let fm = NoteFrontmatter {
             time: sample_datetime(),
             tags: vec!["memo".to_string()],
-            context: Some(ContextMeta {
+            context: Some(Context {
                 battery: Some(82),
                 is_charging: Some(false),
+                network_type: None,
+                wifi_ssid: None,
+                location: None,
             }),
         };
         let rendered = render(&fm, "# Hello\nWorld").unwrap();
@@ -143,5 +139,17 @@ mod tests {
         assert!(rendered.starts_with("---\n"));
         assert!(rendered.contains("\n---\n"));
         assert!(rendered.ends_with("body"));
+    }
+
+    #[test]
+    fn test_note_frontmatter_old_format_compat() {
+        // Old format only had battery and is_charging
+        let yaml = "---\ntime: 2026-03-20T14:30:45+09:00\ntags: []\ncontext:\n  battery: 82\n  is_charging: false\n---\nbody";
+        let (fm, body): (NoteFrontmatter, String) = parse(yaml).unwrap();
+        let ctx = fm.context.unwrap();
+        assert_eq!(ctx.battery, Some(82));
+        assert_eq!(ctx.is_charging, Some(false));
+        assert_eq!(ctx.network_type, None);
+        assert_eq!(body, "body");
     }
 }

--- a/core/src/utils/frontmatter.rs
+++ b/core/src/utils/frontmatter.rs
@@ -105,9 +105,7 @@ mod tests {
             context: Some(Context {
                 battery: Some(82),
                 is_charging: Some(false),
-                network_type: None,
-                wifi_ssid: None,
-                location: None,
+                ..Context::default()
             }),
         };
         let rendered = render(&fm, "# Hello\nWorld").unwrap();

--- a/core/src/utils/frontmatter.rs
+++ b/core/src/utils/frontmatter.rs
@@ -14,8 +14,10 @@ pub struct NoteFrontmatter {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ContextMeta {
-    pub battery: u8,
-    pub is_charging: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub battery: Option<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_charging: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -108,8 +110,8 @@ mod tests {
             time: sample_datetime(),
             tags: vec!["memo".to_string()],
             context: Some(ContextMeta {
-                battery: 82,
-                is_charging: false,
+                battery: Some(82),
+                is_charging: Some(false),
             }),
         };
         let rendered = render(&fm, "# Hello\nWorld").unwrap();

--- a/core/src/utils/markdown.rs
+++ b/core/src/utils/markdown.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, FixedOffset, Local};
 
 use crate::error::CoreError;
 use crate::utils::device::Context;
-use crate::utils::frontmatter::{self, ContextMeta, NoteFrontmatter};
+use crate::utils::frontmatter::{self, NoteFrontmatter};
 
 pub fn format_timeline_line(text: &str, timestamp: DateTime<Local>, context: &Context) -> String {
     let time = timestamp.format("%H:%M:%S");
@@ -20,10 +20,7 @@ pub fn format_note_markdown(
     let fm = NoteFrontmatter {
         time,
         tags: tags.to_vec(),
-        context: Some(ContextMeta {
-            battery: context.battery,
-            is_charging: context.is_charging,
-        }),
+        context: Some(context.clone()),
     };
     frontmatter::render(&fm, body)
 }

--- a/core/src/utils/markdown.rs
+++ b/core/src/utils/markdown.rs
@@ -42,6 +42,9 @@ mod tests {
         Context {
             battery: Some(82),
             is_charging: Some(false),
+            network_type: None,
+            wifi_ssid: None,
+            location: None,
         }
     }
 
@@ -58,6 +61,9 @@ mod tests {
         let ctx = Context {
             battery: None,
             is_charging: None,
+            network_type: None,
+            wifi_ssid: None,
+            location: None,
         };
         let result = format_timeline_line("text", fixed_timestamp(), &ctx);
         assert!(result.starts_with("- [14:30:45] text "));
@@ -98,6 +104,9 @@ mod tests {
         let ctx = Context {
             battery: Some(100),
             is_charging: Some(true),
+            network_type: None,
+            wifi_ssid: None,
+            location: None,
         };
         let result = format_note_markdown("body", &[], fixed_timestamp(), &ctx).unwrap();
         let (fm, _body): (NoteFrontmatter, String) = frontmatter::parse(&result).unwrap();

--- a/core/src/utils/markdown.rs
+++ b/core/src/utils/markdown.rs
@@ -6,8 +6,10 @@ use crate::utils::frontmatter::{self, NoteFrontmatter};
 
 pub fn format_timeline_line(text: &str, timestamp: DateTime<Local>, context: &Context) -> String {
     let time = timestamp.format("%H:%M:%S");
-    let context_json = serde_json::to_string(context).unwrap_or_default();
-    format!("- [{time}] {text} {context_json}")
+    match serde_json::to_string(context) {
+        Ok(json) if json != "{}" => format!("- [{time}] {text} {json}"),
+        _ => format!("- [{time}] {text}"),
+    }
 }
 
 pub fn format_note_markdown(
@@ -52,11 +54,10 @@ mod tests {
     }
 
     #[test]
-    fn test_format_timeline_line_none_fields() {
+    fn test_format_timeline_line_empty_context() {
         let ctx = Context::default();
         let result = format_timeline_line("text", fixed_timestamp(), &ctx);
-        assert!(result.starts_with("- [14:30:45] text "));
-        assert!(!result.contains("battery"));
+        assert_eq!(result, "- [14:30:45] text");
     }
 
     #[test]

--- a/core/src/utils/markdown.rs
+++ b/core/src/utils/markdown.rs
@@ -39,9 +39,7 @@ mod tests {
         Context {
             battery: Some(82),
             is_charging: Some(false),
-            network_type: None,
-            wifi_ssid: None,
-            location: None,
+            ..Context::default()
         }
     }
 
@@ -55,13 +53,7 @@ mod tests {
 
     #[test]
     fn test_format_timeline_line_none_fields() {
-        let ctx = Context {
-            battery: None,
-            is_charging: None,
-            network_type: None,
-            wifi_ssid: None,
-            location: None,
-        };
+        let ctx = Context::default();
         let result = format_timeline_line("text", fixed_timestamp(), &ctx);
         assert!(result.starts_with("- [14:30:45] text "));
         assert!(!result.contains("battery"));
@@ -101,9 +93,7 @@ mod tests {
         let ctx = Context {
             battery: Some(100),
             is_charging: Some(true),
-            network_type: None,
-            wifi_ssid: None,
-            location: None,
+            ..Context::default()
         };
         let result = format_note_markdown("body", &[], fixed_timestamp(), &ctx).unwrap();
         let (fm, _body): (NoteFrontmatter, String) = frontmatter::parse(&result).unwrap();

--- a/core/src/utils/markdown.rs
+++ b/core/src/utils/markdown.rs
@@ -6,11 +6,8 @@ use crate::utils::frontmatter::{self, ContextMeta, NoteFrontmatter};
 
 pub fn format_timeline_line(text: &str, timestamp: DateTime<Local>, context: &Context) -> String {
     let time = timestamp.format("%H:%M:%S");
-    format!(
-        "- [{time}] {text} {{ \"battery\": {battery}, \"is_charging\": {is_charging} }}",
-        battery = context.battery,
-        is_charging = context.is_charging,
-    )
+    let context_json = serde_json::to_string(context).unwrap_or_default();
+    format!("- [{time}] {text} {context_json}")
 }
 
 pub fn format_note_markdown(
@@ -43,18 +40,28 @@ mod tests {
 
     fn test_context() -> Context {
         Context {
-            battery: 82,
-            is_charging: false,
+            battery: Some(82),
+            is_charging: Some(false),
         }
     }
 
     #[test]
     fn test_format_timeline_line() {
         let result = format_timeline_line("hello world", fixed_timestamp(), &test_context());
-        assert_eq!(
-            result,
-            "- [14:30:45] hello world { \"battery\": 82, \"is_charging\": false }"
-        );
+        assert!(result.starts_with("- [14:30:45] hello world "));
+        assert!(result.contains("\"battery\":82"));
+        assert!(result.contains("\"is_charging\":false"));
+    }
+
+    #[test]
+    fn test_format_timeline_line_none_fields() {
+        let ctx = Context {
+            battery: None,
+            is_charging: None,
+        };
+        let result = format_timeline_line("text", fixed_timestamp(), &ctx);
+        assert!(result.starts_with("- [14:30:45] text "));
+        assert!(!result.contains("battery"));
     }
 
     #[test]
@@ -74,8 +81,8 @@ mod tests {
         assert_eq!(fm.tags, vec!["rust", "memo"]);
         assert!(fm.context.is_some());
         let ctx = fm.context.unwrap();
-        assert_eq!(ctx.battery, 82);
-        assert!(!ctx.is_charging);
+        assert_eq!(ctx.battery, Some(82));
+        assert_eq!(ctx.is_charging, Some(false));
         assert_eq!(body, "# Hello\nWorld");
     }
 
@@ -89,13 +96,13 @@ mod tests {
     #[test]
     fn test_format_note_markdown_charging() {
         let ctx = Context {
-            battery: 100,
-            is_charging: true,
+            battery: Some(100),
+            is_charging: Some(true),
         };
         let result = format_note_markdown("body", &[], fixed_timestamp(), &ctx).unwrap();
         let (fm, _body): (NoteFrontmatter, String) = frontmatter::parse(&result).unwrap();
         let context = fm.context.unwrap();
-        assert_eq!(context.battery, 100);
-        assert!(context.is_charging);
+        assert_eq!(context.battery, Some(100));
+        assert_eq!(context.is_charging, Some(true));
     }
 }

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -17,6 +17,7 @@
     "@phosphor-icons/core": "^2.1.1",
     "@solidjs/router": "^0.16.1",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-geolocation": "^2.3.2",
     "markdown-it": "^14.1.1",
     "open-props": "^1.7.23",
     "shiki": "^4.0.2",

--- a/tauri-app/pnpm-lock.yaml
+++ b/tauri-app/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.10.1
+      '@tauri-apps/plugin-geolocation':
+        specifier: ^2.3.2
+        version: 2.3.2
       markdown-it:
         specifier: ^14.1.1
         version: 14.1.1
@@ -533,66 +536,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -699,30 +715,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.10.1':
     resolution: {integrity: sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.10.1':
     resolution: {integrity: sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.10.1':
     resolution: {integrity: sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.10.1':
     resolution: {integrity: sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.10.1':
     resolution: {integrity: sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==}
@@ -746,6 +767,9 @@ packages:
     resolution: {integrity: sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-geolocation@2.3.2':
+    resolution: {integrity: sha512-ONCwav1monafjeO8/JdXtRlbhZ3xgAdBYxo/62qgw99u9+y6xGsohy3avZgFZsBHA0JVNe1uJnMi+vfT5ZSFUA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -2531,6 +2555,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.10.1
       '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
+
+  '@tauri-apps/plugin-geolocation@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ reqwest = { version = "0.12", default-features = false, features = [
 tokio = { version = "1", features = ["macros"] }
 jsonwebtoken = "9"
 url = "2"
+hostname = "0.4"
 sha2 = "0.10"
 open = "5"
 

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -29,6 +29,9 @@ url = "2"
 sha2 = "0.10"
 open = "5"
 
+[target.'cfg(not(target_os = "android"))'.dependencies]
+battery = "0.7"
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ magical-merchant-core = { path = "../../core" }
 tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
 tauri-plugin-deep-link = "2"
+tauri-plugin-geolocation = "2"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/tauri-app/src-tauri/capabilities/default.json
+++ b/tauri-app/src-tauri/capabilities/default.json
@@ -3,5 +3,12 @@
   "identifier": "default",
   "description": "Capability for the main window",
   "windows": ["main"],
-  "permissions": ["core:default", "shell:allow-open", "deep-link:default"]
+  "permissions": [
+    "core:default",
+    "shell:allow-open",
+    "deep-link:default",
+    "geolocation:allow-check-permissions",
+    "geolocation:allow-request-permissions",
+    "geolocation:allow-get-current-position"
+  ]
 }

--- a/tauri-app/src-tauri/src/device.rs
+++ b/tauri-app/src-tauri/src/device.rs
@@ -1,5 +1,42 @@
 use magical_merchant_core::DeviceContext;
 
 pub fn get_context() -> DeviceContext {
-    DeviceContext::mock()
+    let (battery, is_charging) = get_battery();
+
+    DeviceContext {
+        battery,
+        is_charging,
+        network_type: None,
+        wifi_ssid: None,
+        location: None,
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+fn get_battery() -> (Option<u8>, Option<bool>) {
+    use battery::State;
+
+    let manager = match battery::Manager::new() {
+        Ok(m) => m,
+        Err(_) => return (None, None),
+    };
+
+    let mut batteries = match manager.batteries() {
+        Ok(b) => b,
+        Err(_) => return (None, None),
+    };
+
+    match batteries.next() {
+        Some(Ok(bat)) => {
+            let percentage = (bat.state_of_charge().value * 100.0) as u8;
+            let charging = matches!(bat.state(), State::Charging | State::Full);
+            (Some(percentage), Some(charging))
+        }
+        _ => (None, None),
+    }
+}
+
+#[cfg(target_os = "android")]
+fn get_battery() -> (Option<u8>, Option<bool>) {
+    (None, None)
 }

--- a/tauri-app/src-tauri/src/device.rs
+++ b/tauri-app/src-tauri/src/device.rs
@@ -45,8 +45,9 @@ fn get_battery() -> (Option<u8>, Option<bool>) {
 
 #[cfg(target_os = "macos")]
 fn get_network() -> (Option<NetworkType>, Option<String>) {
-    let output = match std::process::Command::new("networksetup")
-        .args(["-getairportnetwork", "en0"])
+    // networksetup -getairportnetwork is broken on recent macOS; use ipconfig instead
+    let output = match std::process::Command::new("ipconfig")
+        .args(["getsummary", "en0"])
         .output()
     {
         Ok(o) => o,
@@ -54,13 +55,18 @@ fn get_network() -> (Option<NetworkType>, Option<String>) {
     };
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let trimmed = stdout.trim();
 
-    if let Some(ssid) = trimmed.strip_prefix("Current Wi-Fi Network: ") {
-        (Some(NetworkType::WiFi), Some(ssid.to_string()))
-    } else {
-        (Some(NetworkType::Offline), None)
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if let Some(ssid) = trimmed.strip_prefix("SSID : ") {
+            let ssid = ssid.trim();
+            if !ssid.is_empty() {
+                return (Some(NetworkType::WiFi), Some(ssid.to_string()));
+            }
+        }
     }
+
+    (Some(NetworkType::Offline), None)
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "android")))]

--- a/tauri-app/src-tauri/src/device.rs
+++ b/tauri-app/src-tauri/src/device.rs
@@ -1,0 +1,5 @@
+use magical_merchant_core::DeviceContext;
+
+pub fn get_context() -> DeviceContext {
+    DeviceContext::mock()
+}

--- a/tauri-app/src-tauri/src/device.rs
+++ b/tauri-app/src-tauri/src/device.rs
@@ -1,13 +1,15 @@
 use magical_merchant_core::DeviceContext;
+use magical_merchant_core::utils::device::NetworkType;
 
 pub fn get_context() -> DeviceContext {
     let (battery, is_charging) = get_battery();
+    let (network_type, wifi_ssid) = get_network();
 
     DeviceContext {
         battery,
         is_charging,
-        network_type: None,
-        wifi_ssid: None,
+        network_type,
+        wifi_ssid,
         location: None,
     }
 }
@@ -38,5 +40,35 @@ fn get_battery() -> (Option<u8>, Option<bool>) {
 
 #[cfg(target_os = "android")]
 fn get_battery() -> (Option<u8>, Option<bool>) {
+    (None, None)
+}
+
+#[cfg(target_os = "macos")]
+fn get_network() -> (Option<NetworkType>, Option<String>) {
+    let output = match std::process::Command::new("networksetup")
+        .args(["-getairportnetwork", "en0"])
+        .output()
+    {
+        Ok(o) => o,
+        Err(_) => return (None, None),
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let trimmed = stdout.trim();
+
+    if let Some(ssid) = trimmed.strip_prefix("Current Wi-Fi Network: ") {
+        (Some(NetworkType::WiFi), Some(ssid.to_string()))
+    } else {
+        (Some(NetworkType::Offline), None)
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "android")))]
+fn get_network() -> (Option<NetworkType>, Option<String>) {
+    (None, None)
+}
+
+#[cfg(target_os = "android")]
+fn get_network() -> (Option<NetworkType>, Option<String>) {
     (None, None)
 }

--- a/tauri-app/src-tauri/src/device.rs
+++ b/tauri-app/src-tauri/src/device.rs
@@ -11,9 +11,9 @@ pub fn get_context(location: Option<Location>) -> DeviceContext {
         network_type,
         wifi_ssid,
         location,
-        os: Some(std::env::consts::OS.to_string()),
+        os: std::env::consts::OS.to_string(),
         os_version: get_os_version(),
-        arch: Some(std::env::consts::ARCH.to_string()),
+        arch: std::env::consts::ARCH.to_string(),
         hostname: hostname::get().ok().and_then(|h| h.into_string().ok()),
         locale: get_locale(),
     }
@@ -25,6 +25,9 @@ fn get_os_version() -> Option<String> {
         .arg("-productVersion")
         .output()
         .ok()?;
+    if !output.status.success() {
+        return None;
+    }
     let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
     if version.is_empty() {
         None
@@ -39,8 +42,8 @@ fn get_os_version() -> Option<String> {
 }
 
 fn get_locale() -> Option<String> {
-    std::env::var("LANG")
-        .or_else(|_| std::env::var("LC_ALL"))
+    std::env::var("LC_ALL")
+        .or_else(|_| std::env::var("LANG"))
         .ok()
         .map(|l| l.split('.').next().unwrap_or(&l).to_string())
 }
@@ -61,7 +64,9 @@ fn get_battery() -> (Option<u8>, Option<bool>) {
 
     match batteries.next() {
         Some(Ok(bat)) => {
-            let percentage = (bat.state_of_charge().value * 100.0) as u8;
+            let percentage = (bat.state_of_charge().value * 100.0)
+                .round()
+                .clamp(0.0, 100.0) as u8;
             let charging = matches!(bat.state(), State::Charging | State::Full);
             (Some(percentage), Some(charging))
         }
@@ -76,7 +81,6 @@ fn get_battery() -> (Option<u8>, Option<bool>) {
 
 #[cfg(target_os = "macos")]
 fn get_network() -> (Option<NetworkType>, Option<String>) {
-    // networksetup -getairportnetwork is broken on recent macOS; use ipconfig instead
     let output = match std::process::Command::new("ipconfig")
         .args(["getsummary", "en0"])
         .output()
@@ -97,7 +101,9 @@ fn get_network() -> (Option<NetworkType>, Option<String>) {
         }
     }
 
-    (Some(NetworkType::Offline), None)
+    // No Wi-Fi SSID found — could be Ethernet, tethering, or truly offline.
+    // Return None rather than Offline to avoid false negatives.
+    (None, None)
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "android")))]

--- a/tauri-app/src-tauri/src/device.rs
+++ b/tauri-app/src-tauri/src/device.rs
@@ -11,7 +11,38 @@ pub fn get_context(location: Option<Location>) -> DeviceContext {
         network_type,
         wifi_ssid,
         location,
+        os: Some(std::env::consts::OS.to_string()),
+        os_version: get_os_version(),
+        arch: Some(std::env::consts::ARCH.to_string()),
+        hostname: hostname::get().ok().and_then(|h| h.into_string().ok()),
+        locale: get_locale(),
     }
+}
+
+#[cfg(target_os = "macos")]
+fn get_os_version() -> Option<String> {
+    let output = std::process::Command::new("sw_vers")
+        .arg("-productVersion")
+        .output()
+        .ok()?;
+    let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if version.is_empty() {
+        None
+    } else {
+        Some(version)
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn get_os_version() -> Option<String> {
+    None
+}
+
+fn get_locale() -> Option<String> {
+    std::env::var("LANG")
+        .or_else(|_| std::env::var("LC_ALL"))
+        .ok()
+        .map(|l| l.split('.').next().unwrap_or(&l).to_string())
 }
 
 #[cfg(not(target_os = "android"))]

--- a/tauri-app/src-tauri/src/device.rs
+++ b/tauri-app/src-tauri/src/device.rs
@@ -1,7 +1,7 @@
 use magical_merchant_core::DeviceContext;
-use magical_merchant_core::utils::device::NetworkType;
+use magical_merchant_core::utils::device::{Location, NetworkType};
 
-pub fn get_context() -> DeviceContext {
+pub fn get_context(location: Option<Location>) -> DeviceContext {
     let (battery, is_charging) = get_battery();
     let (network_type, wifi_ssid) = get_network();
 
@@ -10,7 +10,7 @@ pub fn get_context() -> DeviceContext {
         is_charging,
         network_type,
         wifi_ssid,
-        location: None,
+        location,
     }
 }
 

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -3,7 +3,9 @@ mod device;
 mod sync;
 
 use magical_merchant_core::utils::device::Location;
-use magical_merchant_core::{Filename, NoteFilename, NoteSummary, ProjectSummary, Slug, TaskSummary};
+use magical_merchant_core::{
+    Filename, NoteFilename, NoteSummary, ProjectSummary, Slug, TaskSummary,
+};
 use tauri::{AppHandle, Listener, Manager};
 
 fn make_location(latitude: Option<f64>, longitude: Option<f64>) -> Option<Location> {

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -2,38 +2,72 @@ mod auth;
 mod device;
 mod sync;
 
+use magical_merchant_core::utils::device::Location;
 use magical_merchant_core::{Filename, NoteFilename, NoteSummary, ProjectSummary, Slug, TaskSummary};
 use tauri::{AppHandle, Listener, Manager};
 
+fn make_location(latitude: Option<f64>, longitude: Option<f64>) -> Option<Location> {
+    match (latitude, longitude) {
+        (Some(lat), Some(lng)) => Some(Location {
+            latitude: lat,
+            longitude: lng,
+        }),
+        _ => None,
+    }
+}
+
 #[tauri::command]
-fn save_quick_capture(handle: AppHandle, text: String) -> Result<(), String> {
+fn save_quick_capture(
+    handle: AppHandle,
+    text: String,
+    latitude: Option<f64>,
+    longitude: Option<f64>,
+) -> Result<(), String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    let context = device::get_context();
+    let context = device::get_context(make_location(latitude, longitude));
     magical_merchant_core::save_timeline_entry(&base_dir, &text, &context)
         .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
-fn save_document(handle: AppHandle, body: String, tags: Vec<String>) -> Result<(), String> {
+fn save_document(
+    handle: AppHandle,
+    body: String,
+    tags: Vec<String>,
+    latitude: Option<f64>,
+    longitude: Option<f64>,
+) -> Result<(), String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    let context = device::get_context();
+    let context = device::get_context(make_location(latitude, longitude));
     magical_merchant_core::create_draft_note(&base_dir, &body, &tags, &context)
         .map_err(|e| e.to_string())?;
     Ok(())
 }
 
 #[tauri::command]
-fn create_draft(handle: AppHandle, body: String, tags: Vec<String>) -> Result<String, String> {
+fn create_draft(
+    handle: AppHandle,
+    body: String,
+    tags: Vec<String>,
+    latitude: Option<f64>,
+    longitude: Option<f64>,
+) -> Result<String, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    let context = device::get_context();
+    let context = device::get_context(make_location(latitude, longitude));
     let path = magical_merchant_core::create_draft_note(&base_dir, &body, &tags, &context)
         .map_err(|e| e.to_string())?;
     Ok(path.to_string_lossy().to_string())
 }
 
 #[tauri::command]
-fn update_draft(file_path: String, body: String, tags: Vec<String>) -> Result<(), String> {
-    let context = device::get_context();
+fn update_draft(
+    file_path: String,
+    body: String,
+    tags: Vec<String>,
+    latitude: Option<f64>,
+    longitude: Option<f64>,
+) -> Result<(), String> {
+    let context = device::get_context(make_location(latitude, longitude));
     magical_merchant_core::update_note(std::path::Path::new(&file_path), &body, &tags, &context)
         .map_err(|e| e.to_string())
 }
@@ -170,6 +204,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_deep_link::init())
+        .plugin(tauri_plugin_geolocation::init())
         .manage(sync::AppSyncState::default())
         .setup(|app| {
             app.listen("deep-link://new-url", move |event| {

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -1,15 +1,14 @@
 mod auth;
+mod device;
 mod sync;
 
-use magical_merchant_core::{
-    DeviceContext, Filename, NoteFilename, NoteSummary, ProjectSummary, Slug, TaskSummary,
-};
+use magical_merchant_core::{Filename, NoteFilename, NoteSummary, ProjectSummary, Slug, TaskSummary};
 use tauri::{AppHandle, Listener, Manager};
 
 #[tauri::command]
 fn save_quick_capture(handle: AppHandle, text: String) -> Result<(), String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    let context = DeviceContext::mock();
+    let context = device::get_context();
     magical_merchant_core::save_timeline_entry(&base_dir, &text, &context)
         .map_err(|e| e.to_string())
 }
@@ -17,7 +16,7 @@ fn save_quick_capture(handle: AppHandle, text: String) -> Result<(), String> {
 #[tauri::command]
 fn save_document(handle: AppHandle, body: String, tags: Vec<String>) -> Result<(), String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    let context = DeviceContext::mock();
+    let context = device::get_context();
     magical_merchant_core::create_draft_note(&base_dir, &body, &tags, &context)
         .map_err(|e| e.to_string())?;
     Ok(())
@@ -26,7 +25,7 @@ fn save_document(handle: AppHandle, body: String, tags: Vec<String>) -> Result<(
 #[tauri::command]
 fn create_draft(handle: AppHandle, body: String, tags: Vec<String>) -> Result<String, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    let context = DeviceContext::mock();
+    let context = device::get_context();
     let path = magical_merchant_core::create_draft_note(&base_dir, &body, &tags, &context)
         .map_err(|e| e.to_string())?;
     Ok(path.to_string_lossy().to_string())
@@ -34,7 +33,7 @@ fn create_draft(handle: AppHandle, body: String, tags: Vec<String>) -> Result<St
 
 #[tauri::command]
 fn update_draft(file_path: String, body: String, tags: Vec<String>) -> Result<(), String> {
-    let context = DeviceContext::mock();
+    let context = device::get_context();
     magical_merchant_core::update_note(std::path::Path::new(&file_path), &body, &tags, &context)
         .map_err(|e| e.to_string())
 }

--- a/tauri-app/src/components/Icon.tsx
+++ b/tauri-app/src/components/Icon.tsx
@@ -26,12 +26,10 @@ const ICONS = {
   "battery-medium": () => import("@phosphor-icons/core/assets/regular/battery-medium.svg?raw"),
   "battery-low": () => import("@phosphor-icons/core/assets/regular/battery-low.svg?raw"),
   "battery-empty": () => import("@phosphor-icons/core/assets/regular/battery-empty.svg?raw"),
-  "battery-charging": () =>
-    import("@phosphor-icons/core/assets/regular/battery-charging.svg?raw"),
+  "battery-charging": () => import("@phosphor-icons/core/assets/regular/battery-charging.svg?raw"),
   "wifi-high": () => import("@phosphor-icons/core/assets/regular/wifi-high.svg?raw"),
   "wifi-slash": () => import("@phosphor-icons/core/assets/regular/wifi-slash.svg?raw"),
-  "cell-signal-full": () =>
-    import("@phosphor-icons/core/assets/regular/cell-signal-full.svg?raw"),
+  "cell-signal-full": () => import("@phosphor-icons/core/assets/regular/cell-signal-full.svg?raw"),
   "map-pin": () => import("@phosphor-icons/core/assets/regular/map-pin.svg?raw"),
 } as const;
 

--- a/tauri-app/src/components/Icon.tsx
+++ b/tauri-app/src/components/Icon.tsx
@@ -31,6 +31,8 @@ const ICONS = {
   "wifi-slash": () => import("@phosphor-icons/core/assets/regular/wifi-slash.svg?raw"),
   "cell-signal-full": () => import("@phosphor-icons/core/assets/regular/cell-signal-full.svg?raw"),
   "map-pin": () => import("@phosphor-icons/core/assets/regular/map-pin.svg?raw"),
+  laptop: () => import("@phosphor-icons/core/assets/regular/laptop.svg?raw"),
+  "device-mobile": () => import("@phosphor-icons/core/assets/regular/device-mobile.svg?raw"),
 } as const;
 
 export type IconName = keyof typeof ICONS;

--- a/tauri-app/src/components/Icon.tsx
+++ b/tauri-app/src/components/Icon.tsx
@@ -21,6 +21,18 @@ const ICONS = {
   "cloud-arrow-up": () => import("@phosphor-icons/core/assets/regular/cloud-arrow-up.svg?raw"),
   "cloud-slash": () => import("@phosphor-icons/core/assets/regular/cloud-slash.svg?raw"),
   gear: () => import("@phosphor-icons/core/assets/regular/gear.svg?raw"),
+  "battery-full": () => import("@phosphor-icons/core/assets/regular/battery-full.svg?raw"),
+  "battery-high": () => import("@phosphor-icons/core/assets/regular/battery-high.svg?raw"),
+  "battery-medium": () => import("@phosphor-icons/core/assets/regular/battery-medium.svg?raw"),
+  "battery-low": () => import("@phosphor-icons/core/assets/regular/battery-low.svg?raw"),
+  "battery-empty": () => import("@phosphor-icons/core/assets/regular/battery-empty.svg?raw"),
+  "battery-charging": () =>
+    import("@phosphor-icons/core/assets/regular/battery-charging.svg?raw"),
+  "wifi-high": () => import("@phosphor-icons/core/assets/regular/wifi-high.svg?raw"),
+  "wifi-slash": () => import("@phosphor-icons/core/assets/regular/wifi-slash.svg?raw"),
+  "cell-signal-full": () =>
+    import("@phosphor-icons/core/assets/regular/cell-signal-full.svg?raw"),
+  "map-pin": () => import("@phosphor-icons/core/assets/regular/map-pin.svg?raw"),
 } as const;
 
 export type IconName = keyof typeof ICONS;

--- a/tauri-app/src/components/TimelineEntry.tsx
+++ b/tauri-app/src/components/TimelineEntry.tsx
@@ -1,5 +1,6 @@
-import { Show } from "solid-js";
+import { Show, createMemo } from "solid-js";
 import Icon from "./Icon";
+import MarkdownPreview from "./MarkdownPreview";
 import {
   parseTimelineEntry,
   getBatteryIcon,
@@ -10,10 +11,11 @@ import {
 
 interface TimelineEntryProps {
   raw: string;
+  markdown?: boolean;
 }
 
 export default function TimelineEntry(props: TimelineEntryProps) {
-  const parsed = () => parseTimelineEntry(props.raw);
+  const parsed = createMemo(() => parseTimelineEntry(props.raw));
 
   return (
     <div class="timeline-entry">
@@ -21,7 +23,14 @@ export default function TimelineEntry(props: TimelineEntryProps) {
         <Show when={parsed().time}>
           <span class="timeline-entry-time">{parsed().time}</span>
         </Show>
-        <span class="timeline-entry-text">{parsed().text}</span>
+        <Show
+          when={props.markdown}
+          fallback={<span class="timeline-entry-text">{parsed().text}</span>}
+        >
+          <span class="timeline-entry-text">
+            <MarkdownPreview source={parsed().text} />
+          </span>
+        </Show>
       </div>
       <Show when={parsed().context}>
         {(ctx) => (

--- a/tauri-app/src/components/TimelineEntry.tsx
+++ b/tauri-app/src/components/TimelineEntry.tsx
@@ -1,0 +1,42 @@
+import { Show } from "solid-js";
+import Icon from "./Icon";
+import {
+  parseTimelineEntry,
+  getBatteryIcon,
+  getNetworkIcon,
+  hasLocation,
+} from "../lib/parse-timeline";
+
+interface TimelineEntryProps {
+  raw: string;
+}
+
+export default function TimelineEntry(props: TimelineEntryProps) {
+  const parsed = () => parseTimelineEntry(props.raw);
+
+  return (
+    <div class="timeline-entry">
+      <div class="timeline-entry-content">
+        <Show when={parsed().time}>
+          <span class="timeline-entry-time">{parsed().time}</span>
+        </Show>
+        <span class="timeline-entry-text">{parsed().text}</span>
+      </div>
+      <Show when={parsed().context}>
+        {(ctx) => (
+          <div class="timeline-entry-context">
+            <Show when={getBatteryIcon(ctx())}>
+              {(icon) => <Icon name={icon()} size={14} />}
+            </Show>
+            <Show when={getNetworkIcon(ctx())}>
+              {(icon) => <Icon name={icon()} size={14} />}
+            </Show>
+            <Show when={hasLocation(ctx())}>
+              <Icon name="map-pin" size={14} />
+            </Show>
+          </div>
+        )}
+      </Show>
+    </div>
+  );
+}

--- a/tauri-app/src/components/TimelineEntry.tsx
+++ b/tauri-app/src/components/TimelineEntry.tsx
@@ -4,6 +4,7 @@ import {
   parseTimelineEntry,
   getBatteryIcon,
   getNetworkIcon,
+  getOsLabel,
   hasLocation,
 } from "../lib/parse-timeline";
 
@@ -26,9 +27,29 @@ export default function TimelineEntry(props: TimelineEntryProps) {
         {(ctx) => (
           <div class="timeline-entry-context">
             <Show when={getBatteryIcon(ctx())}>{(icon) => <Icon name={icon()} size={14} />}</Show>
-            <Show when={getNetworkIcon(ctx())}>{(icon) => <Icon name={icon()} size={14} />}</Show>
+            <Show when={getNetworkIcon(ctx())}>
+              {(icon) => (
+                <span class="timeline-context-item">
+                  <Icon name={icon()} size={14} />
+                  <Show when={ctx().wifi_ssid}>
+                    <span class="timeline-context-label">{ctx().wifi_ssid}</span>
+                  </Show>
+                </span>
+              )}
+            </Show>
             <Show when={hasLocation(ctx())}>
               <Icon name="map-pin" size={14} />
+            </Show>
+            <Show when={getOsLabel(ctx())}>
+              {(label) => (
+                <span class="timeline-context-item">
+                  <Icon name={ctx().os === "android" ? "device-mobile" : "laptop"} size={14} />
+                  <span class="timeline-context-label">{label()}</span>
+                </span>
+              )}
+            </Show>
+            <Show when={ctx().hostname}>
+              {(name) => <span class="timeline-context-label">{name()}</span>}
             </Show>
           </div>
         )}

--- a/tauri-app/src/components/TimelineEntry.tsx
+++ b/tauri-app/src/components/TimelineEntry.tsx
@@ -25,12 +25,8 @@ export default function TimelineEntry(props: TimelineEntryProps) {
       <Show when={parsed().context}>
         {(ctx) => (
           <div class="timeline-entry-context">
-            <Show when={getBatteryIcon(ctx())}>
-              {(icon) => <Icon name={icon()} size={14} />}
-            </Show>
-            <Show when={getNetworkIcon(ctx())}>
-              {(icon) => <Icon name={icon()} size={14} />}
-            </Show>
+            <Show when={getBatteryIcon(ctx())}>{(icon) => <Icon name={icon()} size={14} />}</Show>
+            <Show when={getNetworkIcon(ctx())}>{(icon) => <Icon name={icon()} size={14} />}</Show>
             <Show when={hasLocation(ctx())}>
               <Icon name="map-pin" size={14} />
             </Show>

--- a/tauri-app/src/lib/location.ts
+++ b/tauri-app/src/lib/location.ts
@@ -12,10 +12,7 @@ interface Coordinates {
 export async function getLocation(): Promise<Coordinates | null> {
   try {
     let permissions = await checkPermissions();
-    if (
-      permissions.location === "prompt" ||
-      permissions.location === "prompt-with-rationale"
-    ) {
+    if (permissions.location === "prompt" || permissions.location === "prompt-with-rationale") {
       permissions = await requestPermissions(["location"]);
     }
 

--- a/tauri-app/src/lib/location.ts
+++ b/tauri-app/src/lib/location.ts
@@ -1,0 +1,34 @@
+import {
+  checkPermissions,
+  requestPermissions,
+  getCurrentPosition,
+} from "@tauri-apps/plugin-geolocation";
+
+interface Coordinates {
+  latitude: number;
+  longitude: number;
+}
+
+export async function getLocation(): Promise<Coordinates | null> {
+  try {
+    let permissions = await checkPermissions();
+    if (
+      permissions.location === "prompt" ||
+      permissions.location === "prompt-with-rationale"
+    ) {
+      permissions = await requestPermissions(["location"]);
+    }
+
+    if (permissions.location !== "granted") {
+      return null;
+    }
+
+    const pos = await getCurrentPosition();
+    return {
+      latitude: pos.coords.latitude,
+      longitude: pos.coords.longitude,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/tauri-app/src/lib/parse-timeline.test.ts
+++ b/tauri-app/src/lib/parse-timeline.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseTimelineEntry,
+  getBatteryIcon,
+  getNetworkIcon,
+  getOsLabel,
+  hasLocation,
+} from "./parse-timeline";
+
+describe("parseTimelineEntry", () => {
+  it("parses entry with context JSON", () => {
+    const raw = '- [14:30:45] hello world {"battery":82,"is_charging":false}';
+    const result = parseTimelineEntry(raw);
+    expect(result.time).toBe("14:30:45");
+    expect(result.text).toBe("hello world");
+    expect(result.context).toEqual({ battery: 82, is_charging: false });
+  });
+
+  it("parses entry without context (old format)", () => {
+    const raw = "- [14:30:45] hello world";
+    const result = parseTimelineEntry(raw);
+    expect(result.time).toBe("14:30:45");
+    expect(result.text).toBe("hello world");
+    expect(result.context).toBeNull();
+  });
+
+  it("handles text containing braces", () => {
+    const raw = '- [14:30:45] code {foo} {"battery":50}';
+    const result = parseTimelineEntry(raw);
+    expect(result.time).toBe("14:30:45");
+    expect(result.text).toBe("code {foo}");
+    expect(result.context).toEqual({ battery: 50 });
+  });
+
+  it("normalizes empty object {} to null", () => {
+    const raw = "- [14:30:45] text {}";
+    const result = parseTimelineEntry(raw);
+    expect(result.time).toBe("14:30:45");
+    expect(result.text).toBe("text");
+    expect(result.context).toBeNull();
+  });
+
+  it("treats invalid JSON as part of text", () => {
+    const raw = "- [14:30:45] text {invalid";
+    const result = parseTimelineEntry(raw);
+    expect(result.time).toBe("14:30:45");
+    expect(result.text).toBe("text {invalid");
+    expect(result.context).toBeNull();
+  });
+
+  it("returns raw text for non-matching format", () => {
+    const raw = "just some text";
+    const result = parseTimelineEntry(raw);
+    expect(result.time).toBe("");
+    expect(result.text).toBe("just some text");
+    expect(result.context).toBeNull();
+  });
+});
+
+describe("getBatteryIcon", () => {
+  const ctx = (battery: number, charging = false) =>
+    ({ battery, is_charging: charging, os: "", arch: "" }) as const;
+
+  it("returns battery-charging when charging", () => {
+    expect(getBatteryIcon(ctx(50, true))).toBe("battery-charging");
+  });
+
+  it("returns battery-full for >= 75%", () => {
+    expect(getBatteryIcon(ctx(75))).toBe("battery-full");
+    expect(getBatteryIcon(ctx(100))).toBe("battery-full");
+  });
+
+  it("returns battery-high for 50-74%", () => {
+    expect(getBatteryIcon(ctx(50))).toBe("battery-high");
+    expect(getBatteryIcon(ctx(74))).toBe("battery-high");
+  });
+
+  it("returns battery-medium for 25-49%", () => {
+    expect(getBatteryIcon(ctx(25))).toBe("battery-medium");
+    expect(getBatteryIcon(ctx(49))).toBe("battery-medium");
+  });
+
+  it("returns battery-low for 5-24%", () => {
+    expect(getBatteryIcon(ctx(5))).toBe("battery-low");
+    expect(getBatteryIcon(ctx(24))).toBe("battery-low");
+  });
+
+  it("returns battery-empty for 0-4%", () => {
+    expect(getBatteryIcon(ctx(0))).toBe("battery-empty");
+    expect(getBatteryIcon(ctx(4))).toBe("battery-empty");
+  });
+
+  it("returns null when battery is undefined", () => {
+    expect(getBatteryIcon({ os: "", arch: "" })).toBeNull();
+  });
+});
+
+describe("getNetworkIcon", () => {
+  it("returns wifi-high for WiFi", () => {
+    expect(getNetworkIcon({ network_type: "WiFi", os: "", arch: "" })).toBe("wifi-high");
+  });
+
+  it("returns cell-signal-full for Mobile", () => {
+    expect(getNetworkIcon({ network_type: "Mobile", os: "", arch: "" })).toBe("cell-signal-full");
+  });
+
+  it("returns wifi-slash for Offline", () => {
+    expect(getNetworkIcon({ network_type: "Offline", os: "", arch: "" })).toBe("wifi-slash");
+  });
+
+  it("returns null when network_type is undefined", () => {
+    expect(getNetworkIcon({ os: "", arch: "" })).toBeNull();
+  });
+});
+
+describe("getOsLabel", () => {
+  it("returns full label with all parts", () => {
+    expect(getOsLabel({ os: "macos", os_version: "15.3", arch: "aarch64" })).toBe(
+      "macos 15.3 aarch64",
+    );
+  });
+
+  it("returns os + arch without version", () => {
+    expect(getOsLabel({ os: "linux", arch: "x86_64" })).toBe("linux x86_64");
+  });
+
+  it("returns null when os is empty", () => {
+    expect(getOsLabel({ os: "", arch: "" })).toBeNull();
+  });
+});
+
+describe("hasLocation", () => {
+  it("returns true when location exists", () => {
+    expect(hasLocation({ os: "", arch: "", location: { latitude: 35, longitude: 139 } })).toBe(
+      true,
+    );
+  });
+
+  it("returns false when location is undefined", () => {
+    expect(hasLocation({ os: "", arch: "" })).toBe(false);
+  });
+});

--- a/tauri-app/src/lib/parse-timeline.ts
+++ b/tauri-app/src/lib/parse-timeline.ts
@@ -6,9 +6,9 @@ export interface DeviceContext {
   network_type?: "WiFi" | "Mobile" | "Offline";
   wifi_ssid?: string;
   location?: { latitude: number; longitude: number };
-  os?: string;
+  os: string;
   os_version?: string;
-  arch?: string;
+  arch: string;
   hostname?: string;
   locale?: string;
 }
@@ -20,29 +20,31 @@ export interface ParsedEntry {
 }
 
 export function parseTimelineEntry(raw: string): ParsedEntry {
-  // Format: "- [HH:MM:SS] text {json}"
-  const match = raw.match(/^- \[(\d{2}:\d{2}:\d{2})\] (.*?) (\{.*\})$/s);
-  if (!match) {
-    // Try without context JSON (old format or no context)
-    const timeMatch = raw.match(/^- \[(\d{2}:\d{2}:\d{2})\] (.*)$/s);
-    if (timeMatch) {
-      return { time: timeMatch[1], text: timeMatch[2], context: null };
-    }
+  // Match timestamp prefix: "- [HH:MM:SS] ..."
+  const timeMatch = raw.match(/^- \[(\d{2}:\d{2}:\d{2})\] /);
+  if (!timeMatch) {
     return { time: "", text: raw, context: null };
   }
 
-  let context: DeviceContext | null = null;
-  try {
-    context = JSON.parse(match[3]);
-  } catch {
-    // Invalid JSON, treat as part of text
+  const time = timeMatch[1];
+  const rest = raw.slice(timeMatch[0].length);
+
+  // Try to extract context JSON from the last " {" in the line
+  const lastBrace = rest.lastIndexOf(" {");
+  if (lastBrace >= 0) {
+    const jsonCandidate = rest.slice(lastBrace + 1);
+    try {
+      const parsed = JSON.parse(jsonCandidate);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        const context = Object.keys(parsed).length > 0 ? (parsed as DeviceContext) : null;
+        return { time, text: rest.slice(0, lastBrace), context };
+      }
+    } catch {
+      // Not valid JSON, treat entire rest as text
+    }
   }
 
-  return {
-    time: match[1],
-    text: context ? match[2] : `${match[2]} ${match[3]}`,
-    context,
-  };
+  return { time, text: rest, context: null };
 }
 
 export function getBatteryIcon(ctx: DeviceContext): IconName | null {

--- a/tauri-app/src/lib/parse-timeline.ts
+++ b/tauri-app/src/lib/parse-timeline.ts
@@ -1,11 +1,16 @@
 import type { IconName } from "../components/Icon";
 
-interface DeviceContext {
+export interface DeviceContext {
   battery?: number;
   is_charging?: boolean;
   network_type?: "WiFi" | "Mobile" | "Offline";
   wifi_ssid?: string;
   location?: { latitude: number; longitude: number };
+  os?: string;
+  os_version?: string;
+  arch?: string;
+  hostname?: string;
+  locale?: string;
 }
 
 export interface ParsedEntry {
@@ -66,4 +71,12 @@ export function getNetworkIcon(ctx: DeviceContext): IconName | null {
 
 export function hasLocation(ctx: DeviceContext): boolean {
   return ctx.location != null;
+}
+
+export function getOsLabel(ctx: DeviceContext): string | null {
+  if (!ctx.os) return null;
+  const parts: string[] = [ctx.os];
+  if (ctx.os_version) parts.push(ctx.os_version);
+  if (ctx.arch) parts.push(ctx.arch);
+  return parts.join(" ");
 }

--- a/tauri-app/src/lib/parse-timeline.ts
+++ b/tauri-app/src/lib/parse-timeline.ts
@@ -1,0 +1,69 @@
+import type { IconName } from "../components/Icon";
+
+interface DeviceContext {
+  battery?: number;
+  is_charging?: boolean;
+  network_type?: "WiFi" | "Mobile" | "Offline";
+  wifi_ssid?: string;
+  location?: { latitude: number; longitude: number };
+}
+
+export interface ParsedEntry {
+  time: string;
+  text: string;
+  context: DeviceContext | null;
+}
+
+export function parseTimelineEntry(raw: string): ParsedEntry {
+  // Format: "- [HH:MM:SS] text {json}"
+  const match = raw.match(/^- \[(\d{2}:\d{2}:\d{2})\] (.*?) (\{.*\})$/s);
+  if (!match) {
+    // Try without context JSON (old format or no context)
+    const timeMatch = raw.match(/^- \[(\d{2}:\d{2}:\d{2})\] (.*)$/s);
+    if (timeMatch) {
+      return { time: timeMatch[1], text: timeMatch[2], context: null };
+    }
+    return { time: "", text: raw, context: null };
+  }
+
+  let context: DeviceContext | null = null;
+  try {
+    context = JSON.parse(match[3]);
+  } catch {
+    // Invalid JSON, treat as part of text
+  }
+
+  return {
+    time: match[1],
+    text: context ? match[2] : `${match[2]} ${match[3]}`,
+    context,
+  };
+}
+
+export function getBatteryIcon(ctx: DeviceContext): IconName | null {
+  if (ctx.battery == null) return null;
+  if (ctx.is_charging) return "battery-charging";
+  if (ctx.battery >= 75) return "battery-full";
+  if (ctx.battery >= 50) return "battery-high";
+  if (ctx.battery >= 25) return "battery-medium";
+  if (ctx.battery >= 5) return "battery-low";
+  return "battery-empty";
+}
+
+export function getNetworkIcon(ctx: DeviceContext): IconName | null {
+  if (!ctx.network_type) return null;
+  switch (ctx.network_type) {
+    case "WiFi":
+      return "wifi-high";
+    case "Mobile":
+      return "cell-signal-full";
+    case "Offline":
+      return "wifi-slash";
+    default:
+      return null;
+  }
+}
+
+export function hasLocation(ctx: DeviceContext): boolean {
+  return ctx.location != null;
+}

--- a/tauri-app/src/styles/timeline.css
+++ b/tauri-app/src/styles/timeline.css
@@ -34,6 +34,24 @@
   line-height: var(--font-lineheight-3);
 }
 
+.timeline-entry-content {
+  display: flex;
+  gap: var(--size-2);
+}
+
+.timeline-entry-time {
+  color: var(--app-text-2);
+  white-space: nowrap;
+}
+
+.timeline-entry-context {
+  display: flex;
+  gap: var(--size-1);
+  margin-top: var(--size-1);
+  color: var(--app-text-2);
+  align-items: center;
+}
+
 /* Browse list (shared for date list) */
 
 .browse-list {

--- a/tauri-app/src/styles/timeline.css
+++ b/tauri-app/src/styles/timeline.css
@@ -46,10 +46,22 @@
 
 .timeline-entry-context {
   display: flex;
-  gap: var(--size-1);
+  gap: var(--size-2);
   margin-top: var(--size-1);
   color: var(--app-text-2);
   align-items: center;
+  flex-wrap: wrap;
+  font-size: var(--font-size-0);
+}
+
+.timeline-context-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.timeline-context-label {
+  opacity: 0.7;
 }
 
 /* Browse list (shared for date list) */

--- a/tauri-app/src/views/Notes.tsx
+++ b/tauri-app/src/views/Notes.tsx
@@ -59,24 +59,22 @@ export default function Notes() {
     setStatus("saving");
 
     try {
-      const loc = await getLocation();
-      const locationArgs = {
-        latitude: loc?.latitude ?? null,
-        longitude: loc?.longitude ?? null,
-      };
       const path = draftPath();
       if (path) {
         await invoke("update_draft", {
           filePath: path,
           body: currentBody,
           tags,
-          ...locationArgs,
+          latitude: null,
+          longitude: null,
         });
       } else {
+        const loc = await getLocation();
         const newPath = await invoke<string>("create_draft", {
           body: currentBody,
           tags,
-          ...locationArgs,
+          latitude: loc?.latitude ?? null,
+          longitude: loc?.longitude ?? null,
         });
         setDraftPath(newPath);
       }

--- a/tauri-app/src/views/Notes.tsx
+++ b/tauri-app/src/views/Notes.tsx
@@ -12,6 +12,7 @@ import {
 import { invoke } from "@tauri-apps/api/core";
 import MilkdownEditor from "../components/MilkdownEditor";
 import MarkdownPreview from "../components/MarkdownPreview";
+import { getLocation } from "../lib/location";
 import ConfirmDialog from "../components/ConfirmDialog";
 import ActionBar from "../components/ActionBar";
 import Icon from "../components/Icon";
@@ -58,17 +59,24 @@ export default function Notes() {
     setStatus("saving");
 
     try {
+      const loc = await getLocation();
+      const locationArgs = {
+        latitude: loc?.latitude ?? null,
+        longitude: loc?.longitude ?? null,
+      };
       const path = draftPath();
       if (path) {
         await invoke("update_draft", {
           filePath: path,
           body: currentBody,
           tags,
+          ...locationArgs,
         });
       } else {
         const newPath = await invoke<string>("create_draft", {
           body: currentBody,
           tags,
+          ...locationArgs,
         });
         setDraftPath(newPath);
       }

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -136,7 +136,7 @@ export default function Timeline() {
             <h3 class="preview-date-header">{selectedDate()}</h3>
             <div class="preview-entries">
               <Show when={dateEntries()?.length} fallback={<p class="empty-state">エントリなし</p>}>
-                <For each={dateEntries()}>{(entry) => <TimelineEntry raw={entry} />}</For>
+                <For each={dateEntries()}>{(entry) => <TimelineEntry raw={entry} markdown />}</For>
               </Show>
             </div>
           </div>

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import ActionBar from "../components/ActionBar";
 import Icon from "../components/Icon";
 import MarkdownPreview from "../components/MarkdownPreview";
+import { getLocation } from "../lib/location";
 
 type ViewMode = "input" | "list" | "preview";
 
@@ -35,7 +36,12 @@ export default function Timeline() {
 
     setSaving(true);
     try {
-      await invoke("save_quick_capture", { text: trimmed });
+      const loc = await getLocation();
+      await invoke("save_quick_capture", {
+        text: trimmed,
+        latitude: loc?.latitude ?? null,
+        longitude: loc?.longitude ?? null,
+      });
       setText("");
       refetch();
     } finally {

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -136,9 +136,7 @@ export default function Timeline() {
             <h3 class="preview-date-header">{selectedDate()}</h3>
             <div class="preview-entries">
               <Show when={dateEntries()?.length} fallback={<p class="empty-state">エントリなし</p>}>
-                <For each={dateEntries()}>
-                  {(entry) => <TimelineEntry raw={entry} />}
-                </For>
+                <For each={dateEntries()}>{(entry) => <TimelineEntry raw={entry} />}</For>
               </Show>
             </div>
           </div>

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -2,7 +2,7 @@ import { createSignal, createResource, For, Show, Switch, Match } from "solid-js
 import { invoke } from "@tauri-apps/api/core";
 import ActionBar from "../components/ActionBar";
 import Icon from "../components/Icon";
-import MarkdownPreview from "../components/MarkdownPreview";
+import TimelineEntry from "../components/TimelineEntry";
 import { getLocation } from "../lib/location";
 
 type ViewMode = "input" | "list" | "preview";
@@ -92,7 +92,7 @@ export default function Timeline() {
             <Show when={entries()?.length}>
               <div class="timeline-entries">
                 <For each={entries()!.slice().reverse()}>
-                  {(entry) => <div class="timeline-entry">{entry}</div>}
+                  {(entry) => <TimelineEntry raw={entry} />}
                 </For>
               </div>
             </Show>
@@ -137,11 +137,7 @@ export default function Timeline() {
             <div class="preview-entries">
               <Show when={dateEntries()?.length} fallback={<p class="empty-state">エントリなし</p>}>
                 <For each={dateEntries()}>
-                  {(entry) => (
-                    <div class="timeline-entry">
-                      <MarkdownPreview source={entry} />
-                    </div>
-                  )}
+                  {(entry) => <TimelineEntry raw={entry} />}
                 </For>
               </Show>
             </div>


### PR DESCRIPTION
## Summary

- Replace mock `DeviceContext` with real device information on macOS
- Display device context as Phosphor Icons in timeline entries
- Add battery (via `battery` crate), Wi-Fi (via `ipconfig`), geolocation (`tauri-plugin-geolocation`), and OS info (platform/version/arch/hostname/locale)
- All fields are `Option<T>` for backward compatibility and cross-platform support
- Android Kotlin helper prepared (`DeviceInfo.kt`), JNI wiring is follow-up

Closes #36

## Test plan

- [x] `cargo test --workspace` — 121 tests pass
- [x] `pnpm test` — 28 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — no warnings
- [x] `just dev` on macOS — battery, Wi-Fi SSID, OS info displayed as icons
- [x] `just build` — verify location permission dialog and map-pin icon
- [x] Android emulator — verify graceful fallback (all fields `None`)