### PR TITLE
refactor: extract string constants into centralized modules

### DIFF
--- a/core/src/note/repository.rs
+++ b/core/src/note/repository.rs
@@ -7,7 +7,7 @@ use crate::error::CoreError;
 use crate::utils::device::Context;
 use crate::utils::fs::{ensure_dir, list_md_files};
 use crate::utils::markdown::format_note_markdown;
-use crate::utils::paths::note_file_path;
+use crate::utils::paths::{note_file_path, notes_dir};
 use crate::utils::validated::NoteFilename;
 
 use super::summary::Summary as NoteSummary;
@@ -22,7 +22,7 @@ impl Notes {
     }
 
     fn notes_dir(&self) -> PathBuf {
-        self.base_dir.join("data").join("notes")
+        notes_dir(&self.base_dir)
     }
 
     pub fn create(

--- a/core/src/sync.rs
+++ b/core/src/sync.rs
@@ -245,7 +245,7 @@ impl<C: SyncClient> SyncEngine<C> {
     }
 
     fn data_path(&self, key: &str) -> PathBuf {
-        self.base_dir.join("data").join(key)
+        crate::utils::paths::data_dir(&self.base_dir).join(key)
     }
 }
 

--- a/core/src/sync/scan.rs
+++ b/core/src/sync/scan.rs
@@ -5,8 +5,8 @@ use std::time::SystemTime;
 use chrono::{DateTime, Utc};
 use sha2::{Digest, Sha256};
 
-use crate::utils::paths;
 use crate::CoreError;
+use crate::utils::paths;
 
 #[derive(Debug, Clone)]
 pub struct LocalFile {

--- a/core/src/sync/scan.rs
+++ b/core/src/sync/scan.rs
@@ -5,6 +5,7 @@ use std::time::SystemTime;
 use chrono::{DateTime, Utc};
 use sha2::{Digest, Sha256};
 
+use crate::utils::paths;
 use crate::CoreError;
 
 #[derive(Debug, Clone)]
@@ -15,7 +16,7 @@ pub struct LocalFile {
 }
 
 pub fn scan_local_files(base_dir: &Path) -> Result<Vec<LocalFile>, CoreError> {
-    let data_dir = base_dir.join("data");
+    let data_dir = paths::data_dir(base_dir);
     if !data_dir.exists() {
         return Ok(Vec::new());
     }

--- a/core/src/timeline/repository.rs
+++ b/core/src/timeline/repository.rs
@@ -7,7 +7,7 @@ use crate::error::CoreError;
 use crate::utils::device::Context;
 use crate::utils::fs::ensure_dir;
 use crate::utils::markdown::format_timeline_line;
-use crate::utils::paths::timeline_file_path;
+use crate::utils::paths::{self, timeline_file_path};
 
 pub struct Timeline {
     base_dir: PathBuf,
@@ -42,7 +42,7 @@ impl Timeline {
     }
 
     pub fn list_dates(&self) -> Result<Vec<NaiveDate>, CoreError> {
-        let timeline_dir = self.base_dir.join("data").join("timeline");
+        let timeline_dir = paths::data_dir(&self.base_dir).join(paths::TIMELINE_DIR);
         if !timeline_dir.exists() {
             return Ok(Vec::new());
         }

--- a/core/src/utils/paths.rs
+++ b/core/src/utils/paths.rs
@@ -1,22 +1,36 @@
 use chrono::{DateTime, Local, NaiveDate};
 use std::path::{Path, PathBuf};
 
+pub const DATA_DIR: &str = "data";
+pub const TIMELINE_DIR: &str = "timeline";
+pub const NOTES_DIR: &str = "notes";
+pub const PROJECTS_DIR: &str = "projects";
+pub const ACTIVE_DIR: &str = "active";
+pub const DONE_DIR: &str = "done";
+pub const PROJECT_FILE: &str = "project.md";
+
+pub fn data_dir(base_dir: &Path) -> PathBuf {
+    base_dir.join(DATA_DIR)
+}
+
 pub fn timeline_file_path(base_dir: &Path, date: NaiveDate) -> PathBuf {
-    base_dir
-        .join("data")
-        .join("timeline")
+    data_dir(base_dir)
+        .join(TIMELINE_DIR)
         .join(format!("{}.md", date.format("%Y-%m-%d")))
 }
 
 pub fn note_file_path(base_dir: &Path, timestamp: DateTime<Local>) -> PathBuf {
-    base_dir
-        .join("data")
-        .join("notes")
+    data_dir(base_dir)
+        .join(NOTES_DIR)
         .join(format!("{}.md", timestamp.format("%Y%m%d_%H%M%S")))
 }
 
+pub fn notes_dir(base_dir: &Path) -> PathBuf {
+    data_dir(base_dir).join(NOTES_DIR)
+}
+
 pub fn projects_dir(base_dir: &Path) -> PathBuf {
-    base_dir.join("data").join("projects")
+    data_dir(base_dir).join(PROJECTS_DIR)
 }
 
 pub fn project_dir(base_dir: &Path, slug: &str) -> PathBuf {
@@ -24,15 +38,15 @@ pub fn project_dir(base_dir: &Path, slug: &str) -> PathBuf {
 }
 
 pub fn project_file_path(base_dir: &Path, slug: &str) -> PathBuf {
-    project_dir(base_dir, slug).join("project.md")
+    project_dir(base_dir, slug).join(PROJECT_FILE)
 }
 
 pub fn active_tasks_dir(base_dir: &Path, slug: &str) -> PathBuf {
-    project_dir(base_dir, slug).join("active")
+    project_dir(base_dir, slug).join(ACTIVE_DIR)
 }
 
 pub fn done_tasks_dir(base_dir: &Path, slug: &str) -> PathBuf {
-    project_dir(base_dir, slug).join("done")
+    project_dir(base_dir, slug).join(DONE_DIR)
 }
 
 #[cfg(test)]

--- a/tauri-app/src-tauri/src/sync.rs
+++ b/tauri-app/src-tauri/src/sync.rs
@@ -10,6 +10,9 @@ use tauri::{AppHandle, Emitter, Manager, State};
 
 use crate::auth;
 
+const EVENT_SYNC_COMPLETE: &str = "sync-complete";
+const EVENT_SYNC_ERROR: &str = "sync-error";
+
 #[derive(Debug, Clone, Serialize)]
 pub struct SyncStatusInfo {
     pub is_syncing: bool,
@@ -181,11 +184,11 @@ pub async fn sync_start(
         Ok(sync_result) => {
             *state.last_synced_at.lock().unwrap() = Some(Utc::now());
             *state.last_error.lock().unwrap() = None;
-            let _ = handle.emit("sync-complete", sync_result);
+            let _ = handle.emit(EVENT_SYNC_COMPLETE, sync_result);
         }
         Err(err) => {
             *state.last_error.lock().unwrap() = Some(err.clone());
-            let _ = handle.emit("sync-error", err);
+            let _ = handle.emit(EVENT_SYNC_ERROR, err);
         }
     }
 

--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -4,14 +4,15 @@ import Timeline from "./views/Timeline";
 import Notes from "./views/Notes";
 import Tasks from "./views/Tasks";
 import Settings from "./views/Settings";
+import { ROUTES } from "./lib/routes";
 
 export default function App() {
   return (
     <Router root={AppLayout}>
-      <Route path="/" component={Timeline} />
-      <Route path="/notes" component={Notes} />
-      <Route path="/tasks" component={Tasks} />
-      <Route path="/settings" component={Settings} />
+      <Route path={ROUTES.TIMELINE} component={Timeline} />
+      <Route path={ROUTES.NOTES} component={Notes} />
+      <Route path={ROUTES.TASKS} component={Tasks} />
+      <Route path={ROUTES.SETTINGS} component={Settings} />
     </Router>
   );
 }

--- a/tauri-app/src/components/SyncButton.tsx
+++ b/tauri-app/src/components/SyncButton.tsx
@@ -1,6 +1,7 @@
 import { createSignal, onMount, onCleanup } from "solid-js";
 import { useNavigate } from "@solidjs/router";
 import { typedInvoke } from "../lib/commands";
+import { EVENTS } from "../lib/events";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import Icon, { type IconName } from "./Icon";
 
@@ -23,14 +24,14 @@ export default function SyncButton() {
     }
 
     unlisteners.push(
-      await listen("sync-complete", () => {
+      await listen(EVENTS.SYNC_COMPLETE, () => {
         setStatus("success");
         successTimer = setTimeout(() => setStatus("idle"), 3000);
       }),
     );
 
     unlisteners.push(
-      await listen("sync-error", () => {
+      await listen(EVENTS.SYNC_ERROR, () => {
         setStatus("error");
       }),
     );

--- a/tauri-app/src/components/SyncButton.tsx
+++ b/tauri-app/src/components/SyncButton.tsx
@@ -1,6 +1,6 @@
 import { createSignal, onMount, onCleanup } from "solid-js";
 import { useNavigate } from "@solidjs/router";
-import { invoke } from "@tauri-apps/api/core";
+import { typedInvoke } from "../lib/commands";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import Icon, { type IconName } from "./Icon";
 
@@ -14,7 +14,7 @@ export default function SyncButton() {
 
   onMount(async () => {
     try {
-      const config = await invoke<{ workers_url: string }>("get_sync_config");
+      const config = await typedInvoke("get_sync_config");
       if (!config.workers_url) {
         setStatus("not-configured");
       }
@@ -51,7 +51,7 @@ export default function SyncButton() {
 
     setStatus("syncing");
     try {
-      await invoke("sync_start");
+      await typedInvoke("sync_start");
     } catch {
       setStatus("error");
     }

--- a/tauri-app/src/components/SyncButton.tsx
+++ b/tauri-app/src/components/SyncButton.tsx
@@ -2,6 +2,7 @@ import { createSignal, onMount, onCleanup } from "solid-js";
 import { useNavigate } from "@solidjs/router";
 import { typedInvoke } from "../lib/commands";
 import { EVENTS } from "../lib/events";
+import { ROUTES } from "../lib/routes";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import Icon, { type IconName } from "./Icon";
 
@@ -46,7 +47,7 @@ export default function SyncButton() {
     const s = status();
     if (s === "syncing") return;
     if (s === "not-configured") {
-      navigate("/settings");
+      navigate(ROUTES.SETTINGS);
       return;
     }
 

--- a/tauri-app/src/components/ToggleMenu.tsx
+++ b/tauri-app/src/components/ToggleMenu.tsx
@@ -1,6 +1,7 @@
 import { type Accessor } from "solid-js";
 import { A } from "@solidjs/router";
 import Icon from "./Icon";
+import { ROUTES, MODE_ICONS, MODE_LABELS } from "../lib/routes";
 
 interface ToggleMenuProps {
   isOpen: Accessor<boolean>;
@@ -10,21 +11,21 @@ interface ToggleMenuProps {
 export default function ToggleMenu(props: ToggleMenuProps) {
   return (
     <nav class="toggle-menu" classList={{ open: props.isOpen() }}>
-      <A href="/" class="toggle-menu-item" activeClass="active" end onClick={props.onClose}>
-        <Icon name="lightning" size={20} />
-        Timeline
+      <A href={ROUTES.TIMELINE} class="toggle-menu-item" activeClass="active" end onClick={props.onClose}>
+        <Icon name={MODE_ICONS[ROUTES.TIMELINE]} size={20} />
+        {MODE_LABELS[ROUTES.TIMELINE]}
       </A>
-      <A href="/notes" class="toggle-menu-item" activeClass="active" onClick={props.onClose}>
-        <Icon name="note-pencil" size={20} />
-        Notes
+      <A href={ROUTES.NOTES} class="toggle-menu-item" activeClass="active" onClick={props.onClose}>
+        <Icon name={MODE_ICONS[ROUTES.NOTES]} size={20} />
+        {MODE_LABELS[ROUTES.NOTES]}
       </A>
-      <A href="/tasks" class="toggle-menu-item" activeClass="active" onClick={props.onClose}>
-        <Icon name="check-square" size={20} />
-        Tasks
+      <A href={ROUTES.TASKS} class="toggle-menu-item" activeClass="active" onClick={props.onClose}>
+        <Icon name={MODE_ICONS[ROUTES.TASKS]} size={20} />
+        {MODE_LABELS[ROUTES.TASKS]}
       </A>
-      <A href="/settings" class="toggle-menu-item" activeClass="active" onClick={props.onClose}>
-        <Icon name="gear" size={20} />
-        Settings
+      <A href={ROUTES.SETTINGS} class="toggle-menu-item" activeClass="active" onClick={props.onClose}>
+        <Icon name={MODE_ICONS[ROUTES.SETTINGS]} size={20} />
+        {MODE_LABELS[ROUTES.SETTINGS]}
       </A>
     </nav>
   );

--- a/tauri-app/src/components/ToggleMenu.tsx
+++ b/tauri-app/src/components/ToggleMenu.tsx
@@ -11,7 +11,13 @@ interface ToggleMenuProps {
 export default function ToggleMenu(props: ToggleMenuProps) {
   return (
     <nav class="toggle-menu" classList={{ open: props.isOpen() }}>
-      <A href={ROUTES.TIMELINE} class="toggle-menu-item" activeClass="active" end onClick={props.onClose}>
+      <A
+        href={ROUTES.TIMELINE}
+        class="toggle-menu-item"
+        activeClass="active"
+        end
+        onClick={props.onClose}
+      >
         <Icon name={MODE_ICONS[ROUTES.TIMELINE]} size={20} />
         {MODE_LABELS[ROUTES.TIMELINE]}
       </A>
@@ -23,7 +29,12 @@ export default function ToggleMenu(props: ToggleMenuProps) {
         <Icon name={MODE_ICONS[ROUTES.TASKS]} size={20} />
         {MODE_LABELS[ROUTES.TASKS]}
       </A>
-      <A href={ROUTES.SETTINGS} class="toggle-menu-item" activeClass="active" onClick={props.onClose}>
+      <A
+        href={ROUTES.SETTINGS}
+        class="toggle-menu-item"
+        activeClass="active"
+        onClick={props.onClose}
+      >
         <Icon name={MODE_ICONS[ROUTES.SETTINGS]} size={20} />
         {MODE_LABELS[ROUTES.SETTINGS]}
       </A>

--- a/tauri-app/src/layouts/AppLayout.tsx
+++ b/tauri-app/src/layouts/AppLayout.tsx
@@ -3,7 +3,7 @@ import { useLocation } from "@solidjs/router";
 import Icon, { type IconName } from "../components/Icon";
 import SyncButton from "../components/SyncButton";
 import ToggleMenu from "../components/ToggleMenu";
-import { MODE_ICONS, MODE_LABELS } from "../lib/routes";
+import { MODE_ICONS, MODE_LABELS, type RoutePath } from "../lib/routes";
 
 interface AppLayoutProps {
   children?: any;
@@ -50,8 +50,8 @@ export default function AppLayout(props: AppLayoutProps) {
     applyTheme(theme());
   });
 
-  const currentIcon = () => MODE_ICONS[location.pathname] ?? "lightning";
-  const currentLabel = () => MODE_LABELS[location.pathname] ?? "Timeline";
+  const currentIcon = () => MODE_ICONS[location.pathname as RoutePath] ?? "lightning";
+  const currentLabel = () => MODE_LABELS[location.pathname as RoutePath] ?? "Timeline";
 
   const cycleTheme = () => {
     const order: Theme[] = ["system", "light", "dark"];

--- a/tauri-app/src/layouts/AppLayout.tsx
+++ b/tauri-app/src/layouts/AppLayout.tsx
@@ -3,24 +3,11 @@ import { useLocation } from "@solidjs/router";
 import Icon, { type IconName } from "../components/Icon";
 import SyncButton from "../components/SyncButton";
 import ToggleMenu from "../components/ToggleMenu";
+import { MODE_ICONS, MODE_LABELS } from "../lib/routes";
 
 interface AppLayoutProps {
   children?: any;
 }
-
-const MODE_ICONS: Record<string, IconName> = {
-  "/": "lightning",
-  "/notes": "note-pencil",
-  "/tasks": "check-square",
-  "/settings": "gear",
-};
-
-const MODE_LABELS: Record<string, string> = {
-  "/": "Timeline",
-  "/notes": "Notes",
-  "/tasks": "Tasks",
-  "/settings": "Settings",
-};
 
 type Theme = "light" | "dark" | "system";
 

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -1,0 +1,88 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface Note {
+  path: string;
+  filename: string;
+  time?: string;
+  tags: string[];
+  preview: string;
+}
+
+export interface Project {
+  slug: string;
+  name: string;
+  description: string;
+}
+
+export interface Task {
+  filename: string;
+  title: string;
+  created: string;
+  completed?: string;
+  tags: string[];
+  body: string;
+}
+
+export interface SyncConfig {
+  workers_url: string;
+}
+
+interface LocationArgs {
+  latitude: number | null;
+  longitude: number | null;
+}
+
+type CommandMap = {
+  save_quick_capture: { args: { text: string } & LocationArgs; result: void };
+  read_timeline: { args: void; result: string[] };
+  list_timeline_dates: { args: void; result: string[] };
+  read_timeline_by_date: { args: { date: string }; result: string[] };
+  create_draft: { args: { body: string; tags: string[] } & LocationArgs; result: string };
+  update_draft: {
+    args: { filePath: string; body: string; tags: string[] } & LocationArgs;
+    result: void;
+  };
+  list_notes: { args: void; result: Note[] };
+  read_note: { args: { filename: string }; result: string };
+  delete_note: { args: { filename: string }; result: void };
+  save_document: { args: { body: string; tags: string[] } & LocationArgs; result: void };
+  create_project: {
+    args: { slug: string; name: string; description: string };
+    result: string;
+  };
+  list_projects: { args: void; result: Project[] };
+  create_task: {
+    args: { projectSlug: string; title: string; tags: string[]; body: string };
+    result: string;
+  };
+  list_active_tasks: { args: { projectSlug: string }; result: Task[] };
+  list_done_tasks: { args: { projectSlug: string }; result: Task[] };
+  complete_task: { args: { projectSlug: string; filename: string }; result: void };
+  update_task: {
+    args: {
+      projectSlug: string;
+      filename: string;
+      title: string;
+      tags: string[];
+      body: string;
+    };
+    result: void;
+  };
+  delete_task: { args: { projectSlug: string; filename: string }; result: void };
+  sync_start: { args: void; result: void };
+  sync_status: { args: void; result: unknown };
+  auth_login: { args: void; result: void };
+  auth_status: { args: void; result: boolean };
+  auth_logout: { args: void; result: void };
+  get_sync_config: { args: void; result: SyncConfig };
+  save_sync_config: { args: { config: SyncConfig }; result: void };
+};
+
+export type CommandName = keyof CommandMap;
+
+export async function typedInvoke<K extends CommandName>(
+  cmd: K,
+  ...args: CommandMap[K]["args"] extends void ? [] : [CommandMap[K]["args"]]
+): Promise<CommandMap[K]["result"]> {
+  return invoke<CommandMap[K]["result"]>(cmd, args[0] as Record<string, unknown>);
+}

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -84,5 +84,9 @@ export async function typedInvoke<K extends CommandName>(
   cmd: K,
   ...args: CommandMap[K]["args"] extends void ? [] : [CommandMap[K]["args"]]
 ): Promise<CommandMap[K]["result"]> {
+  if (args.length === 0) {
+    return invoke<CommandMap[K]["result"]>(cmd);
+  }
+
   return invoke<CommandMap[K]["result"]>(cmd, args[0] as Record<string, unknown>);
 }

--- a/tauri-app/src/lib/events.ts
+++ b/tauri-app/src/lib/events.ts
@@ -1,0 +1,4 @@
+export const EVENTS = {
+  SYNC_COMPLETE: "sync-complete",
+  SYNC_ERROR: "sync-error",
+} as const;

--- a/tauri-app/src/lib/routes.ts
+++ b/tauri-app/src/lib/routes.ts
@@ -1,0 +1,22 @@
+import type { IconName } from "../components/Icon";
+
+export const ROUTES = {
+  TIMELINE: "/",
+  NOTES: "/notes",
+  TASKS: "/tasks",
+  SETTINGS: "/settings",
+} as const;
+
+export const MODE_ICONS: Record<string, IconName> = {
+  [ROUTES.TIMELINE]: "lightning",
+  [ROUTES.NOTES]: "note-pencil",
+  [ROUTES.TASKS]: "check-square",
+  [ROUTES.SETTINGS]: "gear",
+};
+
+export const MODE_LABELS: Record<string, string> = {
+  [ROUTES.TIMELINE]: "Timeline",
+  [ROUTES.NOTES]: "Notes",
+  [ROUTES.TASKS]: "Tasks",
+  [ROUTES.SETTINGS]: "Settings",
+};

--- a/tauri-app/src/lib/routes.ts
+++ b/tauri-app/src/lib/routes.ts
@@ -7,14 +7,16 @@ export const ROUTES = {
   SETTINGS: "/settings",
 } as const;
 
-export const MODE_ICONS: Record<string, IconName> = {
+export type RoutePath = (typeof ROUTES)[keyof typeof ROUTES];
+
+export const MODE_ICONS: Record<RoutePath, IconName> = {
   [ROUTES.TIMELINE]: "lightning",
   [ROUTES.NOTES]: "note-pencil",
   [ROUTES.TASKS]: "check-square",
   [ROUTES.SETTINGS]: "gear",
 };
 
-export const MODE_LABELS: Record<string, string> = {
+export const MODE_LABELS: Record<RoutePath, string> = {
   [ROUTES.TIMELINE]: "Timeline",
   [ROUTES.NOTES]: "Notes",
   [ROUTES.TASKS]: "Tasks",

--- a/tauri-app/src/views/Notes.tsx
+++ b/tauri-app/src/views/Notes.tsx
@@ -9,7 +9,7 @@ import {
   Switch,
   Match,
 } from "solid-js";
-import { invoke } from "@tauri-apps/api/core";
+import { typedInvoke, type Note } from "../lib/commands";
 import MilkdownEditor from "../components/MilkdownEditor";
 import MarkdownPreview from "../components/MarkdownPreview";
 import { getLocation } from "../lib/location";
@@ -17,18 +17,10 @@ import ConfirmDialog from "../components/ConfirmDialog";
 import ActionBar from "../components/ActionBar";
 import Icon from "../components/Icon";
 
-interface Note {
-  path: string;
-  filename: string;
-  time?: string;
-  tags: string[];
-  preview: string;
-}
-
 type ViewMode = "editor" | "list" | "preview";
 
 async function fetchNotes(): Promise<Note[]> {
-  return invoke<Note[]>("list_notes");
+  return typedInvoke("list_notes");
 }
 
 export default function Notes() {
@@ -61,7 +53,7 @@ export default function Notes() {
     try {
       const path = draftPath();
       if (path) {
-        await invoke("update_draft", {
+        await typedInvoke("update_draft", {
           filePath: path,
           body: currentBody,
           tags,
@@ -70,7 +62,7 @@ export default function Notes() {
         });
       } else {
         const loc = await getLocation();
-        const newPath = await invoke<string>("create_draft", {
+        const newPath = await typedInvoke("create_draft", {
           body: currentBody,
           tags,
           latitude: loc?.latitude ?? null,
@@ -128,7 +120,7 @@ export default function Notes() {
   const openPreview = async (note: Note) => {
     try {
       setError("");
-      const content = await invoke<string>("read_note", { filename: note.filename });
+      const content = await typedInvoke("read_note", { filename: note.filename });
       setSelectedNote(note);
       setNoteContent(content);
       setViewMode("preview");
@@ -162,7 +154,7 @@ export default function Notes() {
     if (!note) return;
     setConfirmOpen(false);
     try {
-      await invoke("delete_note", { filename: note.filename });
+      await typedInvoke("delete_note", { filename: note.filename });
       setSelectedNote(null);
       setNoteContent("");
       refetchNotes();

--- a/tauri-app/src/views/Settings.tsx
+++ b/tauri-app/src/views/Settings.tsx
@@ -1,10 +1,6 @@
 import { createSignal, onMount } from "solid-js";
-import { invoke } from "@tauri-apps/api/core";
+import { typedInvoke } from "../lib/commands";
 import "../styles/settings.css";
-
-interface SyncConfig {
-  workers_url: string;
-}
 
 export default function Settings() {
   const [workersUrl, setWorkersUrl] = createSignal("");
@@ -14,14 +10,14 @@ export default function Settings() {
 
   onMount(async () => {
     try {
-      const config = await invoke<SyncConfig>("get_sync_config");
+      const config = await typedInvoke("get_sync_config");
       setWorkersUrl(config.workers_url);
     } catch {
       // Use defaults
     }
 
     try {
-      const status = await invoke<boolean>("auth_status");
+      const status = await typedInvoke("auth_status");
       setAuthenticated(status);
     } catch {
       setAuthenticated(false);
@@ -32,7 +28,7 @@ export default function Settings() {
     setSaving(true);
     setMessage("");
     try {
-      await invoke("save_sync_config", {
+      await typedInvoke("save_sync_config", {
         config: {
           workers_url: workersUrl(),
         },
@@ -49,7 +45,7 @@ export default function Settings() {
   const handleLogin = async () => {
     setMessage("");
     try {
-      await invoke("auth_login");
+      await typedInvoke("auth_login");
       setAuthenticated(true);
       setMessage("Authenticated");
       setTimeout(() => setMessage(""), 2000);
@@ -60,7 +56,7 @@ export default function Settings() {
 
   const handleLogout = async () => {
     try {
-      await invoke("auth_logout");
+      await typedInvoke("auth_logout");
       setAuthenticated(false);
       setMessage("Logged out");
       setTimeout(() => setMessage(""), 2000);

--- a/tauri-app/src/views/Tasks.tsx
+++ b/tauri-app/src/views/Tasks.tsx
@@ -9,27 +9,12 @@ import {
   Switch,
   Match,
 } from "solid-js";
-import { invoke } from "@tauri-apps/api/core";
+import { typedInvoke, type Project, type Task } from "../lib/commands";
 import Icon from "../components/Icon";
 import ActionBar from "../components/ActionBar";
 import MilkdownEditor from "../components/MilkdownEditor";
 import MarkdownPreview from "../components/MarkdownPreview";
 import ConfirmDialog from "../components/ConfirmDialog";
-
-interface Project {
-  slug: string;
-  name: string;
-  description: string;
-}
-
-interface Task {
-  filename: string;
-  title: string;
-  created: string;
-  completed?: string;
-  tags: string[];
-  body: string;
-}
 
 type ViewMode = "list" | "edit" | "preview";
 
@@ -42,7 +27,7 @@ function toSlug(name: string): string {
 }
 
 async function fetchProjects(): Promise<Project[]> {
-  return invoke<Project[]>("list_projects");
+  return typedInvoke("list_projects");
 }
 
 export default function Tasks() {
@@ -50,11 +35,11 @@ export default function Tasks() {
   const [projects, { refetch: refetchProjects }] = createResource(fetchProjects);
   const [tasks, { refetch: refetchTasks }] = createResource(selectedProject, (slug) => {
     if (!slug) return Promise.resolve([]);
-    return invoke<Task[]>("list_active_tasks", { projectSlug: slug });
+    return typedInvoke("list_active_tasks", { projectSlug: slug });
   });
   const [doneTasks, { refetch: refetchDoneTasks }] = createResource(selectedProject, (slug) => {
     if (!slug) return Promise.resolve([]);
-    return invoke<Task[]>("list_done_tasks", { projectSlug: slug });
+    return typedInvoke("list_done_tasks", { projectSlug: slug });
   });
 
   const [showProjectPicker, setShowProjectPicker] = createSignal(false);
@@ -86,7 +71,7 @@ export default function Tasks() {
 
     setSaveStatus("saving");
     try {
-      await invoke("update_task", {
+      await typedInvoke("update_task", {
         projectSlug: slug,
         filename: task.filename,
         title: taskTitle(),
@@ -152,7 +137,7 @@ export default function Tasks() {
       return;
     }
     try {
-      await invoke("create_project", { slug, name, description: "" });
+      await typedInvoke("create_project", { slug, name, description: "" });
       setNewProjectName("");
       setError("");
       setShowNewProject(false);
@@ -169,7 +154,7 @@ export default function Tasks() {
     const slug = selectedProject();
     if (!title || !slug) return;
     try {
-      await invoke("create_task", { projectSlug: slug, title, tags: [], body: "" });
+      await typedInvoke("create_task", { projectSlug: slug, title, tags: [], body: "" });
       setNewTaskTitle("");
       refetchTasks();
     } catch (e) {
@@ -181,7 +166,7 @@ export default function Tasks() {
     const slug = selectedProject();
     if (!slug) return;
     try {
-      await invoke("complete_task", { projectSlug: slug, filename });
+      await typedInvoke("complete_task", { projectSlug: slug, filename });
       refetchTasks();
       refetchDoneTasks();
     } catch (e) {
@@ -229,7 +214,7 @@ export default function Tasks() {
     setConfirmOpen(false);
     if (saveTimer) clearTimeout(saveTimer);
     try {
-      await invoke("delete_task", { projectSlug: slug, filename: task.filename });
+      await typedInvoke("delete_task", { projectSlug: slug, filename: task.filename });
       refetchTasks();
       refetchDoneTasks();
       navigateToList();
@@ -247,7 +232,7 @@ export default function Tasks() {
       if (viewMode() === "edit") {
         await saveTask();
       }
-      await invoke("complete_task", { projectSlug: slug, filename: task.filename });
+      await typedInvoke("complete_task", { projectSlug: slug, filename: task.filename });
       refetchTasks();
       refetchDoneTasks();
       navigateToList();

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -1,5 +1,5 @@
 import { createSignal, createResource, For, Show, Switch, Match } from "solid-js";
-import { invoke } from "@tauri-apps/api/core";
+import { typedInvoke } from "../lib/commands";
 import ActionBar from "../components/ActionBar";
 import Icon from "../components/Icon";
 import TimelineEntry from "../components/TimelineEntry";
@@ -8,15 +8,15 @@ import { getLocation } from "../lib/location";
 type ViewMode = "input" | "list" | "preview";
 
 async function fetchEntries(): Promise<string[]> {
-  return invoke<string[]>("read_timeline");
+  return typedInvoke("read_timeline");
 }
 
 async function fetchDates(): Promise<string[]> {
-  return invoke<string[]>("list_timeline_dates");
+  return typedInvoke("list_timeline_dates");
 }
 
 async function fetchEntriesByDate(date: string): Promise<string[]> {
-  return invoke<string[]>("read_timeline_by_date", { date });
+  return typedInvoke("read_timeline_by_date", { date });
 }
 
 export default function Timeline() {
@@ -37,7 +37,7 @@ export default function Timeline() {
     setSaving(true);
     try {
       const loc = await getLocation();
-      await invoke("save_quick_capture", {
+      await typedInvoke("save_quick_capture", {
         text: trimmed,
         latitude: loc?.latitude ?? null,
         longitude: loc?.longitude ?? null,


### PR DESCRIPTION
## Summary

Closes #47

- Rust側: パスセグメント定数を`paths`モジュールに集約、Tauriイベント名を定数化
- SolidJS側: ルートパスとモードマッピングを`routes.ts`に集約、Tauriコマンド呼び出しを型付きラッパー(`commands.ts`)に統一、イベント名を`events.ts`に抽出

固定文字列をconst/enumに集約することで、タイポ防止・変更時の一括修正・ビルド時の最適化を実現。

## Test plan

- [x] `cargo build` が成功すること
- [x] `pnpm build` が成功すること
- [x] アプリ起動後、Timeline / Notes / Tasks の各モード切り替えが正常に動作すること
- [ ] 同期ボタンのイベント送受信が正常に動作すること
- [ ] 設定画面の表示・操作が正常であること