### PR TITLE
feat(flake): add Nix package and nix-darwin module

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,47 @@ just dev
 
 ## Build & Install (macOS)
 
+### Option 1: Nix (Recommended)
+
 ```sh
-# Build the .app bundle (Apple Silicon)
+# Build the .app bundle from source
+nix build .#default
+
+# The app is at result/Applications/Magical Merchant.app
+open result/Applications/Magical\ Merchant.app
+```
+
+### Option 2: nix-darwin module
+
+Add the flake input and enable the module in your nix-darwin configuration:
+
+```nix
+# flake.nix
+{
+  inputs.magical-merchant.url = "github:Xantibody/magical-merchant";
+
+  outputs = { magical-merchant, ... }: {
+    darwinConfigurations.myMac = darwin.lib.darwinSystem {
+      modules = [
+        magical-merchant.darwinModules.default
+        {
+          services.magical-merchant = {
+            enable = true;
+            workersUrl = "https://your-worker.example.workers.dev"; # R2 sync URL
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
+The module installs the app to `/Applications/Nix Apps/` and writes `sync-config.json` with the configured `workersUrl`.
+
+### Option 3: Manual build
+
+```sh
+# Build the .app bundle
 just build
 
 # Copy to Applications

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Add the flake input and enable the module in your nix-darwin configuration:
         {
           services.magical-merchant = {
             enable = true;
-            workersUrl = "https://your-worker.example.workers.dev"; # R2 sync URL
+            workersUrl = "https://your-worker.example.workers.dev"; # R2 sync URL; must not end with a trailing slash, or sync requests may become `//files`
           };
         }
       ];

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,7 @@
         playwrightBrowsers = pkgs.playwright-driver.browsers;
       in
       {
+        packages.default = pkgs.callPackage ./nix/package.nix { };
         formatter = treefmtEval.config.build.wrapper;
         checks.formatting = treefmtEval.config.build.check self;
         devShells.default = pkgs.mkShell (
@@ -119,5 +120,8 @@
           }
         );
       }
-    );
+    )
+    // {
+      darwinModules.default = import ./nix/darwin-module.nix;
+    };
 }

--- a/nix/darwin-module.nix
+++ b/nix/darwin-module.nix
@@ -1,0 +1,36 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.magical-merchant;
+in
+{
+  options.services.magical-merchant = {
+    enable = lib.mkEnableOption "Magical Merchant app";
+
+    package = lib.mkPackageOption pkgs "magical-merchant" { };
+
+    workersUrl = lib.mkOption {
+      type = lib.types.str;
+      default = "";
+      description = "Cloudflare Workers URL for R2 sync.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    system.activationScripts.postUserActivation.text = lib.mkAfter (
+      lib.optionalString (cfg.workersUrl != "") ''
+        SYNC_DIR="$HOME/Library/Application Support/com.magical-merchant.app"
+        mkdir -p "$SYNC_DIR"
+        printf '%s\n' ${
+          lib.escapeShellArg (builtins.toJSON { workers_url = cfg.workersUrl; })
+        } > "$SYNC_DIR/sync-config.json"
+      ''
+    );
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  cargo-tauri,
+  rustPlatform,
+  nodejs_22,
+  pnpm_10,
+  pnpmConfigHook,
+  fetchPnpmDeps,
+  typescript-go,
+  pkg-config,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "magical-merchant";
+  version = "0.1.0";
+
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../Cargo.toml
+      ../Cargo.lock
+      ../core
+      # mcp-cli included for workspace resolution only
+      ../mcp-cli/Cargo.toml
+      ../mcp-cli/src
+      ../tauri-app/src-tauri
+      ../tauri-app/src
+      ../tauri-app/package.json
+      ../tauri-app/pnpm-lock.yaml
+      ../tauri-app/index.html
+      ../tauri-app/vite.config.ts
+      ../tauri-app/tsconfig.json
+    ];
+  };
+
+  cargoDeps = rustPlatform.importCargoLock {
+    lockFile = ../Cargo.lock;
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
+    sourceRoot = "${finalAttrs.src.name}/tauri-app";
+    fetcherVersion = 3;
+    hash = "sha256-4A2Xd2vCGTs+RvTt2+Wl+SCpMv9IsHOxnFI4wlYagOE=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    rustPlatform.cargoSetupHook
+    nodejs_22
+    pnpm_10
+    pnpmConfigHook
+    typescript-go
+    pkg-config
+  ];
+
+  buildAndTestSubdir = "tauri-app/src-tauri";
+  pnpmRoot = "tauri-app";
+
+  env.tauriBundleType = "app";
+
+  meta = {
+    description = "Minimal note-taking desktop app";
+    inherit (cargo-tauri.hook.meta) platforms;
+  };
+})


### PR DESCRIPTION
## Summary

- `nix build .#default` で Tauri アプリをソースからビルド可能に（`cargo-tauri.hook` + `pnpmConfigHook`）
- nix-darwin モジュール（`darwinModules.default`）でアプリのインストールと R2 sync 設定（`workersUrl`）の宣言的管理を提供

## Usage

```nix
# nix-darwin configuration
services.magical-merchant = {
  enable = true;
  workersUrl = "https://magical-merchant-sync.example.workers.dev";
};
```

## Test plan

- [x] `nix build .#default` → `result/Applications/Magical Merchant.app` 生成を確認
- [x] ビルドしたアプリの起動を確認
- [x] nix-darwin モジュールを実際の darwin 設定に組み込みテスト

Closes #33