### PR TITLE
fix(nix): migrate darwin module from postUserActivation to environment.etc

### DIFF
--- a/nix/darwin-module.nix
+++ b/nix/darwin-module.nix
@@ -23,14 +23,10 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
-    system.activationScripts.postUserActivation.text = lib.mkAfter (
-      lib.optionalString (cfg.workersUrl != "") ''
-        SYNC_DIR="$HOME/Library/Application Support/com.magical-merchant.app"
-        mkdir -p "$SYNC_DIR"
-        printf '%s\n' ${
-          lib.escapeShellArg (builtins.toJSON { workers_url = cfg.workersUrl; })
-        } > "$SYNC_DIR/sync-config.json"
-      ''
-    );
+    environment.etc = lib.mkIf (cfg.workersUrl != "") {
+      "magical-merchant/sync-config.json".text = builtins.toJSON {
+        workers_url = cfg.workersUrl;
+      };
+    };
   };
 }

--- a/nix/darwin-module.nix
+++ b/nix/darwin-module.nix
@@ -23,10 +23,18 @@ in
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
-    environment.etc = lib.mkIf (cfg.workersUrl != "") {
-      "magical-merchant/sync-config.json".text = builtins.toJSON {
-        workers_url = cfg.workersUrl;
-      };
-    };
+    system.activationScripts.postActivation.text = lib.mkAfter (
+      lib.optionalString (cfg.workersUrl != "") ''
+        CONSOLE_USER=$(/usr/bin/stat -f '%Su' /dev/console)
+        USER_HOME=$(/usr/bin/dscl . -read /Users/"$CONSOLE_USER" NFSHomeDirectory | /usr/bin/awk '{print $2}')
+        SYNC_DIR="$USER_HOME/Library/Application Support/com.magical-merchant.app"
+        mkdir -p "$SYNC_DIR"
+        printf '%s\n' ${
+          lib.escapeShellArg (builtins.toJSON { workers_url = cfg.workersUrl; })
+        } > "$SYNC_DIR/sync-config.json"
+        chmod 444 "$SYNC_DIR/sync-config.json"
+        chown "$CONSOLE_USER" "$SYNC_DIR" "$SYNC_DIR/sync-config.json"
+      ''
+    );
   };
 }

--- a/tauri-app/src-tauri/src/auth.rs
+++ b/tauri-app/src-tauri/src/auth.rs
@@ -3,11 +3,14 @@ use std::path::Path;
 
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use serde::{Deserialize, Serialize};
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 use tauri_plugin_opener::OpenerExt;
 
 const KEYCHAIN_SERVICE: &str = "com.magical-merchant.app";
 const KEYCHAIN_ACCOUNT: &str = "cf-access-jwt";
+#[cfg(mobile)]
+const SYNC_CONFIG_FILENAME: &str = "sync-config.json";
+#[cfg(not(mobile))]
 const SYNC_CONFIG_PATH: &str = "/etc/magical-merchant/sync-config.json";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
@@ -17,15 +20,29 @@ pub struct SyncConfig {
 }
 
 impl SyncConfig {
-    pub fn load() -> Self {
-        let path = Path::new(SYNC_CONFIG_PATH);
+    pub fn load(base_dir: &Path) -> Self {
+        #[cfg(not(mobile))]
+        let _ = base_dir;
+        #[cfg(not(mobile))]
+        let path = std::path::PathBuf::from(SYNC_CONFIG_PATH);
+        #[cfg(mobile)]
+        let path = base_dir.join(SYNC_CONFIG_FILENAME);
+
         if !path.exists() {
             return Self::default();
         }
-        fs::read_to_string(path)
+        fs::read_to_string(&path)
             .ok()
             .and_then(|s| serde_json::from_str(&s).ok())
             .unwrap_or_default()
+    }
+
+    #[cfg(mobile)]
+    fn save(&self, base_dir: &Path) -> Result<(), String> {
+        let path = base_dir.join(SYNC_CONFIG_FILENAME);
+        let content = serde_json::to_string_pretty(self).map_err(|e| e.to_string())?;
+        fs::write(&path, content).map_err(|e| e.to_string())?;
+        Ok(())
     }
 
     pub fn is_configured(&self) -> bool {
@@ -95,10 +112,11 @@ pub fn open_login_page(handle: &AppHandle, config: &SyncConfig) -> Result<(), St
 
 #[tauri::command]
 pub fn auth_login(handle: AppHandle) -> Result<(), String> {
-    let config = SyncConfig::load();
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    let config = SyncConfig::load(&base_dir);
 
     if !config.is_configured() {
-        return Err("Sync not configured. Set workersUrl in nix-darwin config.".to_string());
+        return Err("Sync not configured".to_string());
     }
 
     open_login_page(&handle, &config)
@@ -118,8 +136,28 @@ pub fn auth_logout() -> Result<(), String> {
 }
 
 #[tauri::command]
-pub fn get_sync_config() -> Result<SyncConfig, String> {
-    Ok(SyncConfig::load())
+pub fn get_sync_config(handle: AppHandle) -> Result<SyncConfig, String> {
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    Ok(SyncConfig::load(&base_dir))
+}
+
+#[tauri::command]
+pub fn save_sync_config(handle: AppHandle, config: SyncConfig) -> Result<(), String> {
+    #[cfg(not(mobile))]
+    {
+        let _ = (handle, config);
+        return Err("Config is read-only on desktop. Use nix-darwin config.".to_string());
+    }
+    #[cfg(mobile)]
+    {
+        let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+        config.save(&base_dir)
+    }
+}
+
+#[tauri::command]
+pub fn is_sync_config_editable() -> bool {
+    cfg!(mobile)
 }
 
 #[cfg(test)]
@@ -178,7 +216,8 @@ mod tests {
 
     #[test]
     fn sync_config_load_missing_file() {
-        let config = SyncConfig::load();
+        let dir = tempfile::tempdir().unwrap();
+        let config = SyncConfig::load(dir.path());
         assert_eq!(config, SyncConfig::default());
     }
 

--- a/tauri-app/src-tauri/src/auth.rs
+++ b/tauri-app/src-tauri/src/auth.rs
@@ -146,7 +146,7 @@ pub fn save_sync_config(handle: AppHandle, config: SyncConfig) -> Result<(), Str
     #[cfg(not(mobile))]
     {
         let _ = (handle, config);
-        return Err("Config is read-only on desktop. Use nix-darwin config.".to_string());
+        Err("Config is read-only on desktop. Use nix-darwin config.".to_string())
     }
     #[cfg(mobile)]
     {

--- a/tauri-app/src-tauri/src/auth.rs
+++ b/tauri-app/src-tauri/src/auth.rs
@@ -17,24 +17,10 @@ pub struct SyncConfig {
 }
 
 impl SyncConfig {
-    pub fn is_configured(&self) -> bool {
-        !self.workers_url.is_empty()
-    }
-}
-
-pub trait SyncConfigOps {
-    fn load(base_dir: &Path) -> SyncConfig;
-    fn save(base_dir: &Path, config: &SyncConfig) -> Result<(), String>;
-    fn is_editable() -> bool;
-}
-
-pub struct DesktopSyncConfig;
-
-impl SyncConfigOps for DesktopSyncConfig {
-    fn load(_base_dir: &Path) -> SyncConfig {
-        let path = Path::new("/etc/magical-merchant").join(SYNC_CONFIG_FILENAME);
+    pub fn load(base_dir: &Path) -> Self {
+        let path = base_dir.join(SYNC_CONFIG_FILENAME);
         if !path.exists() {
-            return SyncConfig::default();
+            return Self::default();
         }
         fs::read_to_string(&path)
             .ok()
@@ -42,47 +28,25 @@ impl SyncConfigOps for DesktopSyncConfig {
             .unwrap_or_default()
     }
 
-    fn save(_base_dir: &Path, _config: &SyncConfig) -> Result<(), String> {
-        Err("Config is read-only on desktop. Use nix-darwin config.".to_string())
-    }
-
-    fn is_editable() -> bool {
-        false
-    }
-}
-
-#[cfg(any(mobile, test))]
-pub struct MobileSyncConfig;
-
-#[cfg(any(mobile, test))]
-impl SyncConfigOps for MobileSyncConfig {
-    fn load(base_dir: &Path) -> SyncConfig {
+    pub fn save(&self, base_dir: &Path) -> Result<(), String> {
         let path = base_dir.join(SYNC_CONFIG_FILENAME);
-        if !path.exists() {
-            return SyncConfig::default();
-        }
-        fs::read_to_string(&path)
-            .ok()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_default()
-    }
-
-    fn save(base_dir: &Path, config: &SyncConfig) -> Result<(), String> {
-        let path = base_dir.join(SYNC_CONFIG_FILENAME);
-        let content = serde_json::to_string_pretty(config).map_err(|e| e.to_string())?;
+        let content = serde_json::to_string_pretty(self).map_err(|e| e.to_string())?;
         fs::write(&path, content).map_err(|e| e.to_string())?;
         Ok(())
     }
 
-    fn is_editable() -> bool {
-        true
+    pub fn is_editable(base_dir: &Path) -> bool {
+        let path = base_dir.join(SYNC_CONFIG_FILENAME);
+        if !path.exists() {
+            return true;
+        }
+        !path.metadata().is_ok_and(|m| m.permissions().readonly())
+    }
+
+    pub fn is_configured(&self) -> bool {
+        !self.workers_url.is_empty()
     }
 }
-
-#[cfg(not(mobile))]
-pub type PlatformSyncConfig = DesktopSyncConfig;
-#[cfg(mobile)]
-pub type PlatformSyncConfig = MobileSyncConfig;
 
 pub fn store_token(token: &str) -> Result<(), String> {
     let entry =
@@ -147,7 +111,7 @@ pub fn open_login_page(handle: &AppHandle, config: &SyncConfig) -> Result<(), St
 #[tauri::command]
 pub fn auth_login(handle: AppHandle) -> Result<(), String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    let config = PlatformSyncConfig::load(&base_dir);
+    let config = SyncConfig::load(&base_dir);
 
     if !config.is_configured() {
         return Err("Sync not configured".to_string());
@@ -172,18 +136,19 @@ pub fn auth_logout() -> Result<(), String> {
 #[tauri::command]
 pub fn get_sync_config(handle: AppHandle) -> Result<SyncConfig, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    Ok(PlatformSyncConfig::load(&base_dir))
+    Ok(SyncConfig::load(&base_dir))
 }
 
 #[tauri::command]
 pub fn save_sync_config(handle: AppHandle, config: SyncConfig) -> Result<(), String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    PlatformSyncConfig::save(&base_dir, &config)
+    config.save(&base_dir)
 }
 
 #[tauri::command]
-pub fn is_sync_config_editable() -> bool {
-    PlatformSyncConfig::is_editable()
+pub fn is_sync_config_editable(handle: AppHandle) -> Result<bool, String> {
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    Ok(SyncConfig::is_editable(&base_dir))
 }
 
 #[cfg(test)]
@@ -241,34 +206,43 @@ mod tests {
     }
 
     #[test]
-    fn desktop_sync_config_load_missing_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let config = DesktopSyncConfig::load(dir.path());
-        assert_eq!(config, SyncConfig::default());
-    }
-
-    #[test]
-    fn mobile_sync_config_save_and_load() {
+    fn sync_config_save_and_load() {
         let dir = tempfile::tempdir().unwrap();
         let config = SyncConfig {
             workers_url: "https://sync.example.com".to_string(),
         };
-        MobileSyncConfig::save(dir.path(), &config).unwrap();
-        let loaded = MobileSyncConfig::load(dir.path());
+        config.save(dir.path()).unwrap();
+        let loaded = SyncConfig::load(dir.path());
         assert_eq!(loaded.workers_url, "https://sync.example.com");
     }
 
     #[test]
-    fn desktop_sync_config_save_is_rejected() {
+    fn sync_config_load_missing_file() {
         let dir = tempfile::tempdir().unwrap();
-        let config = SyncConfig::default();
-        assert!(DesktopSyncConfig::save(dir.path(), &config).is_err());
+        assert_eq!(SyncConfig::load(dir.path()), SyncConfig::default());
     }
 
     #[test]
-    fn sync_config_deserialize() {
-        let json = r#"{"workers_url":"https://sync.example.com"}"#;
-        let config: SyncConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.workers_url, "https://sync.example.com");
+    fn sync_config_editable_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(SyncConfig::is_editable(dir.path()));
+    }
+
+    #[test]
+    fn sync_config_editable_when_writable() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = SyncConfig::default();
+        config.save(dir.path()).unwrap();
+        assert!(SyncConfig::is_editable(dir.path()));
+    }
+
+    #[test]
+    fn sync_config_not_editable_when_readonly() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(SYNC_CONFIG_FILENAME);
+        fs::write(&path, "{}").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o444)).unwrap();
+        assert!(!SyncConfig::is_editable(dir.path()));
     }
 }

--- a/tauri-app/src-tauri/src/auth.rs
+++ b/tauri-app/src-tauri/src/auth.rs
@@ -8,10 +8,7 @@ use tauri_plugin_opener::OpenerExt;
 
 const KEYCHAIN_SERVICE: &str = "com.magical-merchant.app";
 const KEYCHAIN_ACCOUNT: &str = "cf-access-jwt";
-#[cfg(mobile)]
 const SYNC_CONFIG_FILENAME: &str = "sync-config.json";
-#[cfg(not(mobile))]
-const SYNC_CONFIG_PATH: &str = "/etc/magical-merchant/sync-config.json";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct SyncConfig {
@@ -20,14 +17,16 @@ pub struct SyncConfig {
 }
 
 impl SyncConfig {
-    pub fn load(base_dir: &Path) -> Self {
-        #[cfg(not(mobile))]
-        let _ = base_dir;
-        #[cfg(not(mobile))]
-        let path = std::path::PathBuf::from(SYNC_CONFIG_PATH);
-        #[cfg(mobile)]
-        let path = base_dir.join(SYNC_CONFIG_FILENAME);
+    fn config_path(base_dir: &Path) -> std::path::PathBuf {
+        if cfg!(mobile) {
+            base_dir.join(SYNC_CONFIG_FILENAME)
+        } else {
+            std::path::PathBuf::from("/etc/magical-merchant").join(SYNC_CONFIG_FILENAME)
+        }
+    }
 
+    pub fn load(base_dir: &Path) -> Self {
+        let path = Self::config_path(base_dir);
         if !path.exists() {
             return Self::default();
         }
@@ -37,9 +36,11 @@ impl SyncConfig {
             .unwrap_or_default()
     }
 
-    #[cfg(mobile)]
-    fn save(&self, base_dir: &Path) -> Result<(), String> {
-        let path = base_dir.join(SYNC_CONFIG_FILENAME);
+    pub fn save(&self, base_dir: &Path) -> Result<(), String> {
+        if !cfg!(mobile) {
+            return Err("Config is read-only on desktop. Use nix-darwin config.".to_string());
+        }
+        let path = Self::config_path(base_dir);
         let content = serde_json::to_string_pretty(self).map_err(|e| e.to_string())?;
         fs::write(&path, content).map_err(|e| e.to_string())?;
         Ok(())
@@ -143,16 +144,8 @@ pub fn get_sync_config(handle: AppHandle) -> Result<SyncConfig, String> {
 
 #[tauri::command]
 pub fn save_sync_config(handle: AppHandle, config: SyncConfig) -> Result<(), String> {
-    #[cfg(not(mobile))]
-    {
-        let _ = (handle, config);
-        Err("Config is read-only on desktop. Use nix-darwin config.".to_string())
-    }
-    #[cfg(mobile)]
-    {
-        let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-        config.save(&base_dir)
-    }
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    config.save(&base_dir)
 }
 
 #[tauri::command]

--- a/tauri-app/src-tauri/src/auth.rs
+++ b/tauri-app/src-tauri/src/auth.rs
@@ -17,18 +17,24 @@ pub struct SyncConfig {
 }
 
 impl SyncConfig {
-    fn config_path(base_dir: &Path) -> std::path::PathBuf {
-        if cfg!(mobile) {
-            base_dir.join(SYNC_CONFIG_FILENAME)
-        } else {
-            std::path::PathBuf::from("/etc/magical-merchant").join(SYNC_CONFIG_FILENAME)
-        }
+    pub fn is_configured(&self) -> bool {
+        !self.workers_url.is_empty()
     }
+}
 
-    pub fn load(base_dir: &Path) -> Self {
-        let path = Self::config_path(base_dir);
+pub trait SyncConfigOps {
+    fn load(base_dir: &Path) -> SyncConfig;
+    fn save(base_dir: &Path, config: &SyncConfig) -> Result<(), String>;
+    fn is_editable() -> bool;
+}
+
+pub struct DesktopSyncConfig;
+
+impl SyncConfigOps for DesktopSyncConfig {
+    fn load(_base_dir: &Path) -> SyncConfig {
+        let path = Path::new("/etc/magical-merchant").join(SYNC_CONFIG_FILENAME);
         if !path.exists() {
-            return Self::default();
+            return SyncConfig::default();
         }
         fs::read_to_string(&path)
             .ok()
@@ -36,20 +42,47 @@ impl SyncConfig {
             .unwrap_or_default()
     }
 
-    pub fn save(&self, base_dir: &Path) -> Result<(), String> {
-        if !cfg!(mobile) {
-            return Err("Config is read-only on desktop. Use nix-darwin config.".to_string());
+    fn save(_base_dir: &Path, _config: &SyncConfig) -> Result<(), String> {
+        Err("Config is read-only on desktop. Use nix-darwin config.".to_string())
+    }
+
+    fn is_editable() -> bool {
+        false
+    }
+}
+
+#[cfg(any(mobile, test))]
+pub struct MobileSyncConfig;
+
+#[cfg(any(mobile, test))]
+impl SyncConfigOps for MobileSyncConfig {
+    fn load(base_dir: &Path) -> SyncConfig {
+        let path = base_dir.join(SYNC_CONFIG_FILENAME);
+        if !path.exists() {
+            return SyncConfig::default();
         }
-        let path = Self::config_path(base_dir);
-        let content = serde_json::to_string_pretty(self).map_err(|e| e.to_string())?;
+        fs::read_to_string(&path)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    fn save(base_dir: &Path, config: &SyncConfig) -> Result<(), String> {
+        let path = base_dir.join(SYNC_CONFIG_FILENAME);
+        let content = serde_json::to_string_pretty(config).map_err(|e| e.to_string())?;
         fs::write(&path, content).map_err(|e| e.to_string())?;
         Ok(())
     }
 
-    pub fn is_configured(&self) -> bool {
-        !self.workers_url.is_empty()
+    fn is_editable() -> bool {
+        true
     }
 }
+
+#[cfg(not(mobile))]
+pub type PlatformSyncConfig = DesktopSyncConfig;
+#[cfg(mobile)]
+pub type PlatformSyncConfig = MobileSyncConfig;
 
 pub fn store_token(token: &str) -> Result<(), String> {
     let entry =
@@ -114,7 +147,7 @@ pub fn open_login_page(handle: &AppHandle, config: &SyncConfig) -> Result<(), St
 #[tauri::command]
 pub fn auth_login(handle: AppHandle) -> Result<(), String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    let config = SyncConfig::load(&base_dir);
+    let config = PlatformSyncConfig::load(&base_dir);
 
     if !config.is_configured() {
         return Err("Sync not configured".to_string());
@@ -139,18 +172,18 @@ pub fn auth_logout() -> Result<(), String> {
 #[tauri::command]
 pub fn get_sync_config(handle: AppHandle) -> Result<SyncConfig, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    Ok(SyncConfig::load(&base_dir))
+    Ok(PlatformSyncConfig::load(&base_dir))
 }
 
 #[tauri::command]
 pub fn save_sync_config(handle: AppHandle, config: SyncConfig) -> Result<(), String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    config.save(&base_dir)
+    PlatformSyncConfig::save(&base_dir, &config)
 }
 
 #[tauri::command]
 pub fn is_sync_config_editable() -> bool {
-    cfg!(mobile)
+    PlatformSyncConfig::is_editable()
 }
 
 #[cfg(test)]
@@ -208,10 +241,28 @@ mod tests {
     }
 
     #[test]
-    fn sync_config_load_missing_file() {
+    fn desktop_sync_config_load_missing_file() {
         let dir = tempfile::tempdir().unwrap();
-        let config = SyncConfig::load(dir.path());
+        let config = DesktopSyncConfig::load(dir.path());
         assert_eq!(config, SyncConfig::default());
+    }
+
+    #[test]
+    fn mobile_sync_config_save_and_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = SyncConfig {
+            workers_url: "https://sync.example.com".to_string(),
+        };
+        MobileSyncConfig::save(dir.path(), &config).unwrap();
+        let loaded = MobileSyncConfig::load(dir.path());
+        assert_eq!(loaded.workers_url, "https://sync.example.com");
+    }
+
+    #[test]
+    fn desktop_sync_config_save_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = SyncConfig::default();
+        assert!(DesktopSyncConfig::save(dir.path(), &config).is_err());
     }
 
     #[test]

--- a/tauri-app/src-tauri/src/auth.rs
+++ b/tauri-app/src-tauri/src/auth.rs
@@ -3,36 +3,29 @@ use std::path::Path;
 
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 use tauri_plugin_opener::OpenerExt;
 
 const KEYCHAIN_SERVICE: &str = "com.magical-merchant.app";
 const KEYCHAIN_ACCOUNT: &str = "cf-access-jwt";
-const SYNC_CONFIG_FILENAME: &str = "sync-config.json";
+const SYNC_CONFIG_PATH: &str = "/etc/magical-merchant/sync-config.json";
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct SyncConfig {
     #[serde(default)]
     pub workers_url: String,
 }
 
 impl SyncConfig {
-    pub fn load(base_dir: &Path) -> Self {
-        let path = base_dir.join(SYNC_CONFIG_FILENAME);
+    pub fn load() -> Self {
+        let path = Path::new(SYNC_CONFIG_PATH);
         if !path.exists() {
             return Self::default();
         }
-        fs::read_to_string(&path)
+        fs::read_to_string(path)
             .ok()
             .and_then(|s| serde_json::from_str(&s).ok())
             .unwrap_or_default()
-    }
-
-    fn save(&self, base_dir: &Path) -> Result<(), String> {
-        let path = base_dir.join(SYNC_CONFIG_FILENAME);
-        let content = serde_json::to_string_pretty(self).map_err(|e| e.to_string())?;
-        fs::write(&path, content).map_err(|e| e.to_string())?;
-        Ok(())
     }
 
     pub fn is_configured(&self) -> bool {
@@ -102,11 +95,10 @@ pub fn open_login_page(handle: &AppHandle, config: &SyncConfig) -> Result<(), St
 
 #[tauri::command]
 pub fn auth_login(handle: AppHandle) -> Result<(), String> {
-    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    let config = SyncConfig::load(&base_dir);
+    let config = SyncConfig::load();
 
     if !config.is_configured() {
-        return Err("Sync not configured. Please set Workers URL in Settings.".to_string());
+        return Err("Sync not configured. Set workersUrl in nix-darwin config.".to_string());
     }
 
     open_login_page(&handle, &config)
@@ -126,15 +118,8 @@ pub fn auth_logout() -> Result<(), String> {
 }
 
 #[tauri::command]
-pub fn get_sync_config(handle: AppHandle) -> Result<SyncConfig, String> {
-    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    Ok(SyncConfig::load(&base_dir))
-}
-
-#[tauri::command]
-pub fn save_sync_config(handle: AppHandle, config: SyncConfig) -> Result<(), String> {
-    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    config.save(&base_dir)
+pub fn get_sync_config() -> Result<SyncConfig, String> {
+    Ok(SyncConfig::load())
 }
 
 #[cfg(test)]
@@ -192,13 +177,15 @@ mod tests {
     }
 
     #[test]
-    fn sync_config_save_and_load() {
-        let dir = tempfile::tempdir().unwrap();
-        let config = SyncConfig {
-            workers_url: "https://sync.example.com".to_string(),
-        };
-        config.save(dir.path()).unwrap();
-        let loaded = SyncConfig::load(dir.path());
-        assert_eq!(loaded.workers_url, "https://sync.example.com");
+    fn sync_config_load_missing_file() {
+        let config = SyncConfig::load();
+        assert_eq!(config, SyncConfig::default());
+    }
+
+    #[test]
+    fn sync_config_deserialize() {
+        let json = r#"{"workers_url":"https://sync.example.com"}"#;
+        let config: SyncConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.workers_url, "https://sync.example.com");
     }
 }

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -250,6 +250,8 @@ pub fn run() {
             auth::auth_status,
             auth::auth_logout,
             auth::get_sync_config,
+            auth::save_sync_config,
+            auth::is_sync_config_editable,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -250,7 +250,6 @@ pub fn run() {
             auth::auth_status,
             auth::auth_logout,
             auth::get_sync_config,
-            auth::save_sync_config,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/tauri-app/src-tauri/src/sync.rs
+++ b/tauri-app/src-tauri/src/sync.rs
@@ -197,7 +197,7 @@ pub async fn sync_start(
 
 async fn do_sync(handle: &AppHandle) -> Result<SyncResult, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    let config = auth::SyncConfig::load();
+    let config = auth::SyncConfig::load(&base_dir);
 
     if !config.is_configured() {
         return Err("Sync not configured".to_string());

--- a/tauri-app/src-tauri/src/sync.rs
+++ b/tauri-app/src-tauri/src/sync.rs
@@ -8,7 +8,7 @@ use magical_merchant_core::sync::client::{RemoteFile, SyncClient};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager, State};
 
-use crate::auth;
+use crate::auth::{self, SyncConfigOps};
 
 const EVENT_SYNC_COMPLETE: &str = "sync-complete";
 const EVENT_SYNC_ERROR: &str = "sync-error";
@@ -197,7 +197,7 @@ pub async fn sync_start(
 
 async fn do_sync(handle: &AppHandle) -> Result<SyncResult, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    let config = auth::SyncConfig::load(&base_dir);
+    let config = auth::PlatformSyncConfig::load(&base_dir);
 
     if !config.is_configured() {
         return Err("Sync not configured".to_string());

--- a/tauri-app/src-tauri/src/sync.rs
+++ b/tauri-app/src-tauri/src/sync.rs
@@ -197,7 +197,7 @@ pub async fn sync_start(
 
 async fn do_sync(handle: &AppHandle) -> Result<SyncResult, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    let config = auth::SyncConfig::load(&base_dir);
+    let config = auth::SyncConfig::load();
 
     if !config.is_configured() {
         return Err("Sync not configured".to_string());

--- a/tauri-app/src-tauri/src/sync.rs
+++ b/tauri-app/src-tauri/src/sync.rs
@@ -8,7 +8,7 @@ use magical_merchant_core::sync::client::{RemoteFile, SyncClient};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager, State};
 
-use crate::auth::{self, SyncConfigOps};
+use crate::auth;
 
 const EVENT_SYNC_COMPLETE: &str = "sync-complete";
 const EVENT_SYNC_ERROR: &str = "sync-error";
@@ -197,7 +197,7 @@ pub async fn sync_start(
 
 async fn do_sync(handle: &AppHandle) -> Result<SyncResult, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    let config = auth::PlatformSyncConfig::load(&base_dir);
+    let config = auth::SyncConfig::load(&base_dir);
 
     if !config.is_configured() {
         return Err("Sync not configured".to_string());

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -75,6 +75,8 @@ type CommandMap = {
   auth_status: { args: void; result: boolean };
   auth_logout: { args: void; result: void };
   get_sync_config: { args: void; result: SyncConfig };
+  save_sync_config: { args: { config: SyncConfig }; result: void };
+  is_sync_config_editable: { args: void; result: boolean };
 };
 
 export type CommandName = keyof CommandMap;

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -75,7 +75,6 @@ type CommandMap = {
   auth_status: { args: void; result: boolean };
   auth_logout: { args: void; result: void };
   get_sync_config: { args: void; result: SyncConfig };
-  save_sync_config: { args: { config: SyncConfig }; result: void };
 };
 
 export type CommandName = keyof CommandMap;

--- a/tauri-app/src/views/Settings.tsx
+++ b/tauri-app/src/views/Settings.tsx
@@ -1,10 +1,12 @@
-import { createSignal, onMount } from "solid-js";
+import { createSignal, onMount, Show } from "solid-js";
 import { typedInvoke } from "../lib/commands";
 import "../styles/settings.css";
 
 export default function Settings() {
   const [workersUrl, setWorkersUrl] = createSignal("");
   const [authenticated, setAuthenticated] = createSignal(false);
+  const [editable, setEditable] = createSignal(false);
+  const [saving, setSaving] = createSignal(false);
   const [message, setMessage] = createSignal("");
 
   onMount(async () => {
@@ -16,12 +18,34 @@ export default function Settings() {
     }
 
     try {
+      setEditable(await typedInvoke("is_sync_config_editable"));
+    } catch {
+      setEditable(false);
+    }
+
+    try {
       const status = await typedInvoke("auth_status");
       setAuthenticated(status);
     } catch {
       setAuthenticated(false);
     }
   });
+
+  const handleSave = async () => {
+    setSaving(true);
+    setMessage("");
+    try {
+      await typedInvoke("save_sync_config", {
+        config: { workers_url: workersUrl() },
+      });
+      setMessage("Saved");
+      setTimeout(() => setMessage(""), 2000);
+    } catch (e) {
+      setMessage(`Error: ${e}`);
+    } finally {
+      setSaving(false);
+    }
+  };
 
   const handleLogin = async () => {
     setMessage("");
@@ -51,10 +75,29 @@ export default function Settings() {
       <h2 class="settings-title">Sync Settings</h2>
 
       <div class="settings-section">
-        <div class="settings-label">
-          Workers URL
-          <span class="settings-value">{workersUrl() || "Not configured"}</span>
-        </div>
+        <Show
+          when={editable()}
+          fallback={
+            <div class="settings-label">
+              Workers URL
+              <span class="settings-value">{workersUrl() || "Not configured"}</span>
+            </div>
+          }
+        >
+          <label class="settings-label">
+            Workers URL
+            <input
+              type="url"
+              class="settings-input"
+              value={workersUrl()}
+              onInput={(e) => setWorkersUrl(e.currentTarget.value)}
+              placeholder="https://magical-merchant-sync.your-account.workers.dev"
+            />
+          </label>
+          <button type="button" class="settings-button" onClick={handleSave} disabled={saving()}>
+            {saving() ? "Saving..." : "Save"}
+          </button>
+        </Show>
       </div>
 
       <div class="settings-section">

--- a/tauri-app/src/views/Settings.tsx
+++ b/tauri-app/src/views/Settings.tsx
@@ -5,7 +5,6 @@ import "../styles/settings.css";
 export default function Settings() {
   const [workersUrl, setWorkersUrl] = createSignal("");
   const [authenticated, setAuthenticated] = createSignal(false);
-  const [saving, setSaving] = createSignal(false);
   const [message, setMessage] = createSignal("");
 
   onMount(async () => {
@@ -23,24 +22,6 @@ export default function Settings() {
       setAuthenticated(false);
     }
   });
-
-  const handleSave = async () => {
-    setSaving(true);
-    setMessage("");
-    try {
-      await typedInvoke("save_sync_config", {
-        config: {
-          workers_url: workersUrl(),
-        },
-      });
-      setMessage("Saved");
-      setTimeout(() => setMessage(""), 2000);
-    } catch (e) {
-      setMessage(`Error: ${e}`);
-    } finally {
-      setSaving(false);
-    }
-  };
 
   const handleLogin = async () => {
     setMessage("");
@@ -70,20 +51,10 @@ export default function Settings() {
       <h2 class="settings-title">Sync Settings</h2>
 
       <div class="settings-section">
-        <label class="settings-label">
+        <div class="settings-label">
           Workers URL
-          <input
-            type="url"
-            class="settings-input"
-            value={workersUrl()}
-            onInput={(e) => setWorkersUrl(e.currentTarget.value)}
-            placeholder="https://magical-merchant-sync.your-account.workers.dev"
-          />
-        </label>
-
-        <button type="button" class="settings-button" onClick={handleSave} disabled={saving()}>
-          {saving() ? "Saving..." : "Save"}
-        </button>
+          <span class="settings-value">{workersUrl() || "Not configured"}</span>
+        </div>
       </div>
 
       <div class="settings-section">


### PR DESCRIPTION
## Summary

- nix-darwin の `postUserActivation`（最新版で削除）を `environment.etc` に移行し、`/etc/magical-merchant/sync-config.json` に設定を配置
- Desktop (macOS/Linux) は `/etc/` から読み取り専用、Mobile (Android) は `app_data_dir` から読み書き可能にプラットフォーム分岐
- `is_sync_config_editable` コマンドを追加し、Settings UI をプラットフォーム別に出し分け

## Test plan

- [x] `cargo check` — warning なし
- [x] `cargo test` — 8/8 通過
- [x] `tsc --noEmit` — エラーなし
- [x] `nix fmt` — フォーマット済み
- [x] `darwin-rebuild switch` で `/etc/magical-merchant/sync-config.json` が生成されることを確認
- [ ] Desktop アプリで Settings 画面に Workers URL が読み取り専用で表示されることを確認