### PR TITLE
feat(auth): replace Cloudflare Access with Google OAuth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,29 @@ jobs:
         run: nix develop --command just tauri_app::test
     timeout-minutes: 15
 
+  workers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            workers:
+              - 'workers/**'
+      - if: steps.filter.outputs.workers == 'true' || github.event_name != 'pull_request'
+        uses: nixbuild/nix-quick-install-action@v34
+      - if: steps.filter.outputs.workers == 'true' || github.event_name != 'pull_request'
+        uses: DeterminateSystems/magic-nix-cache-action@v9
+      - name: check
+        if: steps.filter.outputs.workers == 'true' || github.event_name != 'pull_request'
+        run: nix develop --command just workers::check
+      - name: test
+        if: steps.filter.outputs.workers == 'true' || github.event_name != 'pull_request'
+        run: nix develop --command just workers::test
+    timeout-minutes: 10
+
   format:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ tauri-app/src-tauri/gen/
 
 # Plans
 plans/
+
+# Wrangler local secrets
+.dev.vars

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,6 +2329,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -5171,6 +5172,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ magical-merchant/
 ├── tauri-app/
 │   ├── src/        # SolidJS frontend (TypeScript)
 │   └── src-tauri/  # Tauri 2 backend (Rust)
+├── workers/        # Cloudflare Workers (R2 sync backend)
 ├── rust/           # Shared Rust just recipes
 ├── nix/            # Nix configuration helpers
 └── plans/          # Implementation plans
@@ -121,6 +122,65 @@ cp -r "target/release/bundle/macos/Magical Merchant.app" /Applications/
 # Remove Gatekeeper quarantine (unsigned app)
 xattr -cr "/Applications/Magical Merchant.app"
 ```
+
+## Sync Backend (Cloudflare Workers)
+
+The `workers/` directory contains a Cloudflare Workers backend that syncs data via R2. Authentication uses Google OAuth with self-issued JWTs.
+
+### 1. Deploy the Worker
+
+```sh
+cd workers
+pnpm install
+wrangler login
+wrangler deploy
+```
+
+### 2. Custom Domain (Optional)
+
+If you want to use a custom domain instead of the default `*.workers.dev` URL:
+
+1. Go to **Cloudflare Dashboard** → **Workers & Pages** → **magical-merchant-sync**
+2. **Settings** → **Domains & Routes** → **Add** → **Custom Domain**
+
+### 3. Google OAuth Setup
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create or select a project
+3. **Google Auth Platform** → **Overview** → Create branding (External, testing mode)
+4. **Clients** → **Create OAuth client ID**
+   - Application type: **Web application**
+   - Authorized redirect URIs: `https://<your-worker-url>/auth/callback`
+5. Copy the Client ID and Client Secret
+
+### 4. Set Secrets
+
+```sh
+cd workers
+
+# Google OAuth credentials
+wrangler secret put GOOGLE_CLIENT_ID
+wrangler secret put GOOGLE_CLIENT_SECRET
+
+# Random signing key for JWTs (generate with: openssl rand -base64 32)
+wrangler secret put JWT_SECRET
+```
+
+### 5. Configuration
+
+| Variable               | Location           | Description                      | Default           |
+| ---------------------- | ------------------ | -------------------------------- | ----------------- |
+| `GOOGLE_CLIENT_ID`     | Secret             | Google OAuth Client ID           | —                 |
+| `GOOGLE_CLIENT_SECRET` | Secret             | Google OAuth Client Secret       | —                 |
+| `JWT_SECRET`           | Secret             | HMAC-SHA256 signing key for JWTs | —                 |
+| `JWT_EXPIRY_SECONDS`   | Secret or `[vars]` | Token lifetime in seconds        | `259200` (3 days) |
+
+### 6. App Configuration
+
+1. Open the app → Settings
+2. Enter the Workers URL (e.g., `https://magical-merchant-sync.example.workers.dev`)
+3. Click **Login with Google**
+4. After authentication, sync is available
 
 ## Environment Variables
 

--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,7 @@
                 androidSdk
                 oxlint
                 typescript-go
+                wrangler
               ]
               ++ lib.optionals stdenv.isLinux [
                 webkitgtk_4_1.dev

--- a/justfile
+++ b/justfile
@@ -1,5 +1,6 @@
 mod rust
 mod tauri_app 'tauri-app'
+mod workers
 
 [private]
 default:
@@ -8,9 +9,9 @@ default:
 fmt:
   nix fmt
 
-check: rust::check tauri_app::check
+check: rust::check tauri_app::check workers::check
 
-test: rust::test tauri_app::test
+test: rust::test tauri_app::test workers::test
 
 verify: fmt check test
 

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ url = "2"
 hostname = "0.4"
 sha2 = "0.10"
 tauri-plugin-opener = "2"
+urlencoding = "2.1.3"
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 battery = "0.7"

--- a/tauri-app/src-tauri/src/auth.rs
+++ b/tauri-app/src-tauri/src/auth.rs
@@ -7,7 +7,7 @@ use tauri::{AppHandle, Manager};
 use tauri_plugin_opener::OpenerExt;
 
 const KEYCHAIN_SERVICE: &str = "com.magical-merchant.app";
-const KEYCHAIN_ACCOUNT: &str = "cf-access-jwt";
+const KEYCHAIN_ACCOUNT: &str = "auth-jwt";
 const SYNC_CONFIG_FILENAME: &str = "sync-config.json";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
@@ -81,7 +81,7 @@ struct Claims {
 }
 
 pub fn is_token_valid(token: &str) -> bool {
-    let mut validation = Validation::new(Algorithm::RS256);
+    let mut validation = Validation::new(Algorithm::HS256);
     validation.insecure_disable_signature_validation();
     validation.validate_exp = false;
     validation.validate_aud = false;
@@ -98,7 +98,7 @@ pub fn is_token_valid(token: &str) -> bool {
 }
 
 pub fn open_login_page(handle: &AppHandle, config: &SyncConfig) -> Result<(), String> {
-    let auth_url = format!("{}/auth/login", config.workers_url.trim_end_matches('/'));
+    let auth_url = format!("{}/auth/google", config.workers_url.trim_end_matches('/'));
     handle
         .opener()
         .open_url(&auth_url, None::<&str>)

--- a/tauri-app/src-tauri/src/auth.rs
+++ b/tauri-app/src-tauri/src/auth.rs
@@ -123,10 +123,11 @@ async fn login_with_loopback(handle: &AppHandle, config: &SyncConfig) -> Result<
         .open_url(&auth_url, None::<&str>)
         .map_err(|e| format!("Failed to open browser: {e}"))?;
 
-    let (mut stream, _) = listener
-        .accept()
-        .await
-        .map_err(|e| format!("Failed to accept connection: {e}"))?;
+    let (mut stream, _) =
+        tokio::time::timeout(std::time::Duration::from_secs(300), listener.accept())
+            .await
+            .map_err(|_| "Login timed out. Please try again.".to_string())?
+            .map_err(|e| format!("Failed to accept connection: {e}"))?;
 
     let mut buf = vec![0u8; 4096];
     let n = stream

--- a/tauri-app/src-tauri/src/auth.rs
+++ b/tauri-app/src-tauri/src/auth.rs
@@ -5,6 +5,7 @@ use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
 use tauri_plugin_opener::OpenerExt;
+use url::Url;
 
 const KEYCHAIN_SERVICE: &str = "com.magical-merchant.app";
 const KEYCHAIN_ACCOUNT: &str = "auth-jwt";
@@ -97,19 +98,75 @@ pub fn is_token_valid(token: &str) -> bool {
     token_data.claims.exp > now + 300
 }
 
-pub fn open_login_page(handle: &AppHandle, config: &SyncConfig) -> Result<(), String> {
-    let auth_url = format!("{}/auth/google", config.workers_url.trim_end_matches('/'));
+fn build_auth_url(workers_url: &str, app_redirect: &str) -> String {
+    format!(
+        "{}/auth/google?app_redirect={}",
+        workers_url.trim_end_matches('/'),
+        urlencoding::encode(app_redirect)
+    )
+}
+
+#[cfg(not(target_os = "android"))]
+async fn login_with_loopback(handle: &AppHandle, config: &SyncConfig) -> Result<(), String> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(|e| format!("Failed to bind loopback: {e}"))?;
+    let port = listener.local_addr().map_err(|e| e.to_string())?.port();
+
+    let app_redirect = format!("http://127.0.0.1:{port}/callback");
+    let auth_url = build_auth_url(&config.workers_url, &app_redirect);
+
     handle
         .opener()
         .open_url(&auth_url, None::<&str>)
         .map_err(|e| format!("Failed to open browser: {e}"))?;
+
+    let (mut stream, _) = listener
+        .accept()
+        .await
+        .map_err(|e| format!("Failed to accept connection: {e}"))?;
+
+    let mut buf = vec![0u8; 4096];
+    let n = stream
+        .read(&mut buf)
+        .await
+        .map_err(|e| format!("Failed to read: {e}"))?;
+    let request_str = String::from_utf8_lossy(&buf[..n]);
+
+    let request_line = request_str.lines().next().unwrap_or("");
+    let path = request_line.split_whitespace().nth(1).unwrap_or("");
+    let full_url = format!("http://127.0.0.1:{port}{path}");
+
+    let response_body = if let Ok(url) = Url::parse(&full_url) {
+        let token = url
+            .query_pairs()
+            .find(|(k, _)| k == "token")
+            .map(|(_, v)| v.to_string());
+
+        if let Some(token) = token {
+            store_token(&token)?;
+            "<html><body><p>Login successful. You can close this tab.</p></body></html>"
+        } else {
+            "<html><body><p>Login failed: no token received.</p></body></html>"
+        }
+    } else {
+        "<html><body><p>Login failed: invalid callback.</p></body></html>"
+    };
+
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n{response_body}"
+    );
+    let _ = stream.write_all(response.as_bytes()).await;
+
     Ok(())
 }
 
 // Tauri commands
 
 #[tauri::command]
-pub fn auth_login(handle: AppHandle) -> Result<(), String> {
+pub async fn auth_login(handle: AppHandle) -> Result<(), String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
     let config = SyncConfig::load(&base_dir);
 
@@ -117,7 +174,20 @@ pub fn auth_login(handle: AppHandle) -> Result<(), String> {
         return Err("Sync not configured".to_string());
     }
 
-    open_login_page(&handle, &config)
+    #[cfg(not(target_os = "android"))]
+    {
+        login_with_loopback(&handle, &config).await
+    }
+
+    #[cfg(target_os = "android")]
+    {
+        let auth_url = build_auth_url(&config.workers_url, "magical-merchant://auth/callback");
+        handle
+            .opener()
+            .open_url(&auth_url, None::<&str>)
+            .map_err(|e| format!("Failed to open browser: {e}"))?;
+        Ok(())
+    }
 }
 
 #[tauri::command]

--- a/tauri-app/src-tauri/src/sync.rs
+++ b/tauri-app/src-tauri/src/sync.rs
@@ -70,7 +70,7 @@ impl SyncClient for R2SyncClient {
         let resp = self
             .http
             .get(format!("{}/files", self.base_url))
-            .header("Cookie", format!("CF_Authorization={}", self.token))
+            .header("Authorization", format!("Bearer {}", self.token))
             .send()
             .await
             .map_err(|e| CoreError::Network(e.to_string()))?;
@@ -104,7 +104,7 @@ impl SyncClient for R2SyncClient {
         let resp = self
             .http
             .get(format!("{}/files/{}", self.base_url, key))
-            .header("Cookie", format!("CF_Authorization={}", self.token))
+            .header("Authorization", format!("Bearer {}", self.token))
             .send()
             .await
             .map_err(|e| CoreError::Network(e.to_string()))?;
@@ -132,7 +132,7 @@ impl SyncClient for R2SyncClient {
         let resp = self
             .http
             .put(format!("{}/files/{}", self.base_url, key))
-            .header("Cookie", format!("CF_Authorization={}", self.token))
+            .header("Authorization", format!("Bearer {}", self.token))
             .header("X-Last-Modified", last_modified.to_rfc3339())
             .body(content.to_vec())
             .send()
@@ -150,7 +150,7 @@ impl SyncClient for R2SyncClient {
         let resp = self
             .http
             .delete(format!("{}/files/{}", self.base_url, key))
-            .header("Cookie", format!("CF_Authorization={}", self.token))
+            .header("Authorization", format!("Bearer {}", self.token))
             .send()
             .await
             .map_err(|e| CoreError::Network(e.to_string()))?;

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -25,7 +25,13 @@
     "deep-link": {
       "desktop": {
         "schemes": ["magical-merchant"]
-      }
+      },
+      "mobile": [
+        {
+          "scheme": ["magical-merchant"],
+          "host": "auth"
+        }
+      ]
     }
   },
   "bundle": {

--- a/tauri-app/src/views/Settings.tsx
+++ b/tauri-app/src/views/Settings.tsx
@@ -111,7 +111,7 @@ export default function Settings() {
           </button>
         ) : (
           <button type="button" class="settings-button" onClick={handleLogin}>
-            Login with Cloudflare Access
+            Login with Google
           </button>
         )}
       </div>

--- a/workers/justfile
+++ b/workers/justfile
@@ -1,0 +1,14 @@
+[private]
+default:
+  @just --list
+
+[private]
+setup:
+  pnpm install
+
+check: setup
+  oxlint src/
+  tsgo -p tsconfig.check.json --noEmit
+
+test: setup
+  pnpm test

--- a/workers/package.json
+++ b/workers/package.json
@@ -9,6 +9,9 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
+  "dependencies": {
+    "jose": "^6.2.3"
+  },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.8",
     "@cloudflare/workers-types": "^4",

--- a/workers/pnpm-lock.yaml
+++ b/workers/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.8
@@ -1193,6 +1197,9 @@ packages:
   is-arrayish@0.3.4:
     resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
@@ -2272,6 +2279,8 @@ snapshots:
   glob-to-regexp@0.4.1: {}
 
   is-arrayish@0.3.4: {}
+
+  jose@6.2.3: {}
 
   js-tokens@9.0.1: {}
 

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -1,14 +1,41 @@
-import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
-import { describe, it, expect } from "vitest";
+import { env, createExecutionContext, waitOnExecutionContext, fetchMock } from "cloudflare:test";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { SignJWT } from "jose";
 import worker from "./index";
 
-const AUTH_HEADER = { "Cf-Access-Jwt-Assertion": "test-jwt-token" };
+const TEST_SECRET = "test-jwt-secret-for-development-only";
+
+async function makeJwt(
+  payload: { sub: string; email: string; exp: number },
+  secret = TEST_SECRET,
+): Promise<string> {
+  const key = new TextEncoder().encode(secret);
+  return new SignJWT({ email: payload.email })
+    .setProtectedHeader({ alg: "HS256" })
+    .setSubject(payload.sub)
+    .setExpirationTime(payload.exp)
+    .sign(key);
+}
+
+let validToken: string;
+
+beforeAll(async () => {
+  validToken = await makeJwt({
+    sub: "user-123",
+    email: "test@example.com",
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  });
+});
+
+function authHeader(): Record<string, string> {
+  return { Authorization: `Bearer ${validToken}` };
+}
 
 function request(
   path: string,
   options: RequestInit & { headers?: Record<string, string> } = {},
 ): Request {
-  const headers = { ...AUTH_HEADER, ...options.headers };
+  const headers = { ...authHeader(), ...options.headers };
   return new Request(`http://localhost${path}`, { ...options, headers });
 }
 
@@ -18,7 +45,7 @@ async function jsonBody<T>(response: Response): Promise<T> {
 
 describe("Workers R2 Proxy", () => {
   describe("Authentication", () => {
-    it("rejects requests without CF Access JWT", async () => {
+    it("rejects requests without Authorization header", async () => {
       const req = new Request("http://localhost/files");
       const ctx = createExecutionContext();
       const res = await worker.fetch(req, env, ctx);
@@ -29,13 +56,209 @@ describe("Workers R2 Proxy", () => {
       expect(body.error).toBe("Unauthorized");
     });
 
-    it("accepts requests with CF Access JWT", async () => {
+    it("rejects requests with invalid JWT", async () => {
+      const req = new Request("http://localhost/files", {
+        headers: { Authorization: "Bearer invalid-token" },
+      });
+      const ctx = createExecutionContext();
+      const res = await worker.fetch(req, env, ctx);
+      await waitOnExecutionContext(ctx);
+
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects expired JWT", async () => {
+      const expiredToken = await makeJwt({
+        sub: "user-123",
+        email: "test@example.com",
+        exp: Math.floor(Date.now() / 1000) - 100,
+      });
+      const req = new Request("http://localhost/files", {
+        headers: { Authorization: `Bearer ${expiredToken}` },
+      });
+      const ctx = createExecutionContext();
+      const res = await worker.fetch(req, env, ctx);
+      await waitOnExecutionContext(ctx);
+
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects JWT signed with wrong secret", async () => {
+      const badToken = await makeJwt(
+        {
+          sub: "user-123",
+          email: "test@example.com",
+          exp: Math.floor(Date.now() / 1000) + 3600,
+        },
+        "wrong-secret",
+      );
+      const req = new Request("http://localhost/files", {
+        headers: { Authorization: `Bearer ${badToken}` },
+      });
+      const ctx = createExecutionContext();
+      const res = await worker.fetch(req, env, ctx);
+      await waitOnExecutionContext(ctx);
+
+      expect(res.status).toBe(401);
+    });
+
+    it("accepts requests with valid Bearer token", async () => {
       const req = request("/files");
       const ctx = createExecutionContext();
       const res = await worker.fetch(req, env, ctx);
       await waitOnExecutionContext(ctx);
 
       expect(res.status).toBe(200);
+    });
+  });
+
+  describe("GET /auth/google", () => {
+    it("redirects to Google OAuth with state cookie", async () => {
+      const req = new Request("http://localhost/auth/google");
+      const ctx = createExecutionContext();
+      const res = await worker.fetch(req, env, ctx);
+      await waitOnExecutionContext(ctx);
+
+      expect(res.status).toBe(302);
+      const location = res.headers.get("Location")!;
+      expect(location).toContain("accounts.google.com/o/oauth2/v2/auth");
+      expect(location).toContain("client_id=test-client-id");
+      expect(location).toContain("scope=openid+email");
+      expect(location).toContain("redirect_uri=http%3A%2F%2Flocalhost%2Fauth%2Fcallback");
+
+      const cookies = res.headers.getSetCookie();
+      expect(cookies.some((c) => c.includes("__oauth_state="))).toBe(true);
+    });
+
+    it("stores app_redirect in cookie", async () => {
+      const req = new Request(
+        "http://localhost/auth/google?app_redirect=http%3A%2F%2F127.0.0.1%3A12345%2Fcallback",
+      );
+      const ctx = createExecutionContext();
+      const res = await worker.fetch(req, env, ctx);
+      await waitOnExecutionContext(ctx);
+
+      expect(res.status).toBe(302);
+      const cookies = res.headers.getSetCookie();
+      expect(cookies.some((c) => c.includes("__oauth_app_redirect="))).toBe(true);
+    });
+  });
+
+  describe("GET /auth/callback", () => {
+    beforeAll(() => {
+      fetchMock.activate();
+    });
+
+    afterEach(() => {
+      fetchMock.assertNoPendingInterceptors();
+    });
+
+    it("returns 400 when code is missing", async () => {
+      const req = new Request("http://localhost/auth/callback");
+      const ctx = createExecutionContext();
+      const res = await worker.fetch(req, env, ctx);
+      await waitOnExecutionContext(ctx);
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 403 when state does not match cookie", async () => {
+      const req = new Request("http://localhost/auth/callback?code=test-code&state=abc", {
+        headers: { Cookie: "__oauth_state=different-state" },
+      });
+      const ctx = createExecutionContext();
+      const res = await worker.fetch(req, env, ctx);
+      await waitOnExecutionContext(ctx);
+
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 403 when state cookie is missing", async () => {
+      const req = new Request("http://localhost/auth/callback?code=test-code&state=abc");
+      const ctx = createExecutionContext();
+      const res = await worker.fetch(req, env, ctx);
+      await waitOnExecutionContext(ctx);
+
+      expect(res.status).toBe(403);
+    });
+
+    it("exchanges code and redirects via deep link", async () => {
+      fetchMock
+        .get("https://oauth2.googleapis.com")
+        .intercept({ path: "/token", method: "POST" })
+        .reply(200, JSON.stringify({ access_token: "google-access-token" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+
+      fetchMock
+        .get("https://openidconnect.googleapis.com")
+        .intercept({ path: "/v1/userinfo" })
+        .reply(200, JSON.stringify({ sub: "google-user-123", email: "user@gmail.com" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+
+      const req = new Request(
+        "http://localhost/auth/callback?code=test-auth-code&state=valid-state",
+        {
+          headers: { Cookie: "__oauth_state=valid-state" },
+        },
+      );
+      const ctx = createExecutionContext();
+      const res = await worker.fetch(req, env, ctx);
+      await waitOnExecutionContext(ctx);
+
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("magical-merchant://auth/callback?token=");
+    });
+
+    it("redirects via 302 for loopback app_redirect", async () => {
+      fetchMock
+        .get("https://oauth2.googleapis.com")
+        .intercept({ path: "/token", method: "POST" })
+        .reply(200, JSON.stringify({ access_token: "google-access-token" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+
+      fetchMock
+        .get("https://openidconnect.googleapis.com")
+        .intercept({ path: "/v1/userinfo" })
+        .reply(200, JSON.stringify({ sub: "google-user-123", email: "user@gmail.com" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+
+      const appRedirect = encodeURIComponent("http://127.0.0.1:12345/callback");
+      const req = new Request(
+        "http://localhost/auth/callback?code=test-auth-code&state=valid-state",
+        {
+          headers: {
+            Cookie: `__oauth_state=valid-state; __oauth_app_redirect=${appRedirect}`,
+          },
+        },
+      );
+      const ctx = createExecutionContext();
+      const res = await worker.fetch(req, env, ctx);
+      await waitOnExecutionContext(ctx);
+
+      expect(res.status).toBe(302);
+      const location = res.headers.get("Location")!;
+      expect(location).toContain("http://127.0.0.1:12345/callback?token=");
+    });
+
+    it("returns 502 when token exchange fails", async () => {
+      fetchMock
+        .get("https://oauth2.googleapis.com")
+        .intercept({ path: "/token", method: "POST" })
+        .reply(400, JSON.stringify({ error: "invalid_grant" }));
+
+      const req = new Request("http://localhost/auth/callback?code=bad-code&state=valid-state", {
+        headers: { Cookie: "__oauth_state=valid-state" },
+      });
+      const ctx = createExecutionContext();
+      const res = await worker.fetch(req, env, ctx);
+      await waitOnExecutionContext(ctx);
+
+      expect(res.status).toBe(502);
     });
   });
 

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -130,6 +130,17 @@ describe("Workers R2 Proxy", () => {
       expect(cookies.some((c) => c.includes("__oauth_state="))).toBe(true);
     });
 
+    it("rejects invalid app_redirect", async () => {
+      const req = new Request(
+        "http://localhost/auth/google?app_redirect=https%3A%2F%2Fevil.com%2Fsteal",
+      );
+      const ctx = createExecutionContext();
+      const res = await worker.fetch(req, env, ctx);
+      await waitOnExecutionContext(ctx);
+
+      expect(res.status).toBe(400);
+    });
+
     it("stores app_redirect in cookie", async () => {
       const req = new Request(
         "http://localhost/auth/google?app_redirect=http%3A%2F%2F127.0.0.1%3A12345%2Fcallback",

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -142,6 +142,10 @@ function getCookie(request: Request, name: string): string | null {
   return match ? match[1] : null;
 }
 
+function isAllowedRedirect(redirect: string): boolean {
+  return redirect.startsWith("magical-merchant://") || redirect.startsWith("http://127.0.0.1:");
+}
+
 function getJwtExpiry(env: Env): number {
   if (env.JWT_EXPIRY_SECONDS) {
     const parsed = parseInt(env.JWT_EXPIRY_SECONDS, 10);
@@ -161,6 +165,9 @@ export default {
       const state = generateState();
       const appRedirect =
         url.searchParams.get("app_redirect") ?? "magical-merchant://auth/callback";
+      if (!isAllowedRedirect(appRedirect)) {
+        return errorResponse("Invalid app_redirect", 400);
+      }
       const redirectUri = `${url.origin}/auth/callback`;
       const params = new URLSearchParams({
         client_id: env.GOOGLE_CLIENT_ID,
@@ -218,6 +225,9 @@ export default {
       }
 
       const tokenData = (await tokenResp.json()) as GoogleTokenResponse;
+      if (!tokenData.access_token) {
+        return errorResponse("Missing access token in Google response", 502);
+      }
 
       // Get user info
       const userinfoResp = await fetch("https://openidconnect.googleapis.com/v1/userinfo", {
@@ -229,6 +239,9 @@ export default {
       }
 
       const userinfo = (await userinfoResp.json()) as GoogleUserInfo;
+      if (!userinfo.sub || !userinfo.email) {
+        return errorResponse("Missing user info in Google response", 502);
+      }
 
       // Issue JWT
       const expiry = getJwtExpiry(env);
@@ -245,6 +258,9 @@ export default {
       const appRedirect = appRedirectCookie
         ? decodeURIComponent(appRedirectCookie)
         : "magical-merchant://auth/callback";
+      if (!isAllowedRedirect(appRedirect)) {
+        return errorResponse("Invalid redirect", 400);
+      }
       const separator = appRedirect.includes("?") ? "&" : "?";
       const redirectUrl = `${appRedirect}${separator}token=${encodeURIComponent(jwt)}`;
 

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -1,5 +1,11 @@
+import { SignJWT, jwtVerify } from "jose";
+
 interface Env {
   BUCKET: R2Bucket;
+  GOOGLE_CLIENT_ID: string;
+  GOOGLE_CLIENT_SECRET: string;
+  JWT_SECRET: string;
+  JWT_EXPIRY_SECONDS?: string;
 }
 
 interface FileEntry {
@@ -7,6 +13,23 @@ interface FileEntry {
   lastModified: string;
   size: number;
 }
+
+interface JwtPayload {
+  sub: string;
+  email: string;
+  exp: number;
+}
+
+interface GoogleTokenResponse {
+  access_token: string;
+}
+
+interface GoogleUserInfo {
+  sub: string;
+  email: string;
+}
+
+const DEFAULT_JWT_EXPIRY_SECONDS = 259200; // 3 days
 
 function jsonResponse(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -88,11 +111,43 @@ async function handleDelete(bucket: R2Bucket, key: string): Promise<Response> {
   return new Response(null, { status: 204 });
 }
 
+async function signJwt(payload: JwtPayload, secret: string): Promise<string> {
+  const key = new TextEncoder().encode(secret);
+  return new SignJWT({ email: payload.email })
+    .setProtectedHeader({ alg: "HS256" })
+    .setSubject(payload.sub)
+    .setExpirationTime(payload.exp)
+    .sign(key);
+}
+
+async function verifyJwt(token: string, secret: string): Promise<JwtPayload | null> {
+  try {
+    const key = new TextEncoder().encode(secret);
+    const { payload } = await jwtVerify(token, key);
+    if (typeof payload.sub !== "string" || typeof payload.email !== "string") return null;
+    return { sub: payload.sub, email: payload.email as string, exp: payload.exp! };
+  } catch {
+    return null;
+  }
+}
+
+function generateState(): string {
+  return crypto.randomUUID();
+}
+
 function getCookie(request: Request, name: string): string | null {
   const cookie = request.headers.get("Cookie");
   if (!cookie) return null;
   const match = cookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
   return match ? match[1] : null;
+}
+
+function getJwtExpiry(env: Env): number {
+  if (env.JWT_EXPIRY_SECONDS) {
+    const parsed = parseInt(env.JWT_EXPIRY_SECONDS, 10);
+    if (!isNaN(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_JWT_EXPIRY_SECONDS;
 }
 
 export default {
@@ -101,25 +156,131 @@ export default {
     const { pathname } = url;
     const method = request.method;
 
-    // Auth endpoint: extract JWT from CF_Authorization cookie and redirect via deep link
-    if (pathname === "/auth/login" && method === "GET") {
-      const jwt = getCookie(request, "CF_Authorization");
-      if (!jwt) {
-        return errorResponse("Authentication failed", 401);
+    // OAuth: redirect to Google
+    if (pathname === "/auth/google" && method === "GET") {
+      const state = generateState();
+      const appRedirect =
+        url.searchParams.get("app_redirect") ?? "magical-merchant://auth/callback";
+      const redirectUri = `${url.origin}/auth/callback`;
+      const params = new URLSearchParams({
+        client_id: env.GOOGLE_CLIENT_ID,
+        redirect_uri: redirectUri,
+        response_type: "code",
+        scope: "openid email",
+        state,
+        access_type: "offline",
+      });
+      return new Response(null, {
+        status: 302,
+        headers: new Headers([
+          ["Location", `https://accounts.google.com/o/oauth2/v2/auth?${params}`],
+          [
+            "Set-Cookie",
+            `__oauth_state=${state}; HttpOnly; Secure; SameSite=Lax; Max-Age=600; Path=/auth/callback`,
+          ],
+          [
+            "Set-Cookie",
+            `__oauth_app_redirect=${encodeURIComponent(appRedirect)}; HttpOnly; Secure; SameSite=Lax; Max-Age=600; Path=/auth/callback`,
+          ],
+        ]),
+      });
+    }
+
+    // OAuth: callback — exchange code for token, issue JWT, deep link
+    if (pathname === "/auth/callback" && method === "GET") {
+      const code = url.searchParams.get("code");
+      if (!code) {
+        return errorResponse("Missing authorization code", 400);
       }
-      const redirectUrl = `magical-merchant://auth/callback?token=${encodeURIComponent(jwt)}`;
+
+      // Validate state against cookie
+      const stateParam = url.searchParams.get("state");
+      const stateCookie = getCookie(request, "__oauth_state");
+      if (!stateParam || !stateCookie || stateParam !== stateCookie) {
+        return errorResponse("Invalid state parameter", 403);
+      }
+
+      // Exchange code for access token
+      const tokenResp = await fetch("https://oauth2.googleapis.com/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          code,
+          client_id: env.GOOGLE_CLIENT_ID,
+          client_secret: env.GOOGLE_CLIENT_SECRET,
+          redirect_uri: `${url.origin}/auth/callback`,
+          grant_type: "authorization_code",
+        }),
+      });
+
+      if (!tokenResp.ok) {
+        return errorResponse("Failed to exchange authorization code", 502);
+      }
+
+      const tokenData = (await tokenResp.json()) as GoogleTokenResponse;
+
+      // Get user info
+      const userinfoResp = await fetch("https://openidconnect.googleapis.com/v1/userinfo", {
+        headers: { Authorization: `Bearer ${tokenData.access_token}` },
+      });
+
+      if (!userinfoResp.ok) {
+        return errorResponse("Failed to fetch user info", 502);
+      }
+
+      const userinfo = (await userinfoResp.json()) as GoogleUserInfo;
+
+      // Issue JWT
+      const expiry = getJwtExpiry(env);
+      const jwt = await signJwt(
+        {
+          sub: userinfo.sub,
+          email: userinfo.email,
+          exp: Math.floor(Date.now() / 1000) + expiry,
+        },
+        env.JWT_SECRET,
+      );
+
+      const appRedirectCookie = getCookie(request, "__oauth_app_redirect");
+      const appRedirect = appRedirectCookie
+        ? decodeURIComponent(appRedirectCookie)
+        : "magical-merchant://auth/callback";
+      const separator = appRedirect.includes("?") ? "&" : "?";
+      const redirectUrl = `${appRedirect}${separator}token=${encodeURIComponent(jwt)}`;
+
+      const clearCookies = new Headers([
+        ["Content-Type", "text/html; charset=utf-8"],
+        [
+          "Set-Cookie",
+          `__oauth_state=; HttpOnly; Secure; SameSite=Lax; Max-Age=0; Path=/auth/callback`,
+        ],
+        [
+          "Set-Cookie",
+          `__oauth_app_redirect=; HttpOnly; Secure; SameSite=Lax; Max-Age=0; Path=/auth/callback`,
+        ],
+      ]);
+
+      // Loopback redirects use 302, deep links use JS redirect
+      if (appRedirect.startsWith("http://127.0.0.1")) {
+        clearCookies.set("Location", redirectUrl);
+        return new Response(null, { status: 302, headers: clearCookies });
+      }
+
       return new Response(
         `<html><body><p>Redirecting to app...</p><script>window.location.href="${redirectUrl}";</script></body></html>`,
-        {
-          status: 200,
-          headers: { "Content-Type": "text/html; charset=utf-8" },
-        },
+        { status: 200, headers: clearCookies },
       );
     }
 
-    const jwt =
-      request.headers.get("Cf-Access-Jwt-Assertion") ?? getCookie(request, "CF_Authorization");
-    if (!jwt) {
+    // Bearer token authentication
+    const authHeader = request.headers.get("Authorization");
+    const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+    if (!token) {
+      return errorResponse("Unauthorized", 401);
+    }
+
+    const claims = await verifyJwt(token, env.JWT_SECRET);
+    if (!claims) {
       return errorResponse("Unauthorized", 401);
     }
 

--- a/workers/tsconfig.check.json
+++ b/workers/tsconfig.check.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/index.ts"]
+}

--- a/workers/tsconfig.json
+++ b/workers/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "lib": ["ESNext"],
-    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers"],
+    "types": ["@cloudflare/workers-types/2023-07-01", "@cloudflare/vitest-pool-workers"],
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true


### PR DESCRIPTION
## Summary

- Workers: Cloudflare Access 依存の認証を Google OAuth (authorization code flow) + 自前 HS256 JWT に完全移行
- Client: Bearer token 認証に切り替え、ログイン URL・JWT 検証アルゴリズム・keychain account を更新
- テスト: Workers テストを Bearer 認証対応に書き換え、OAuth フロー・期限切れ JWT・署名不正のテストを追加

## Test plan

- [x] Workers テスト 20 件パス（認証・OAuth・R2 操作）
- [x] Rust テスト 132 件パス（auth.rs の HS256 JWT 検証含む）
- [x] Frontend テスト 54 件パス
- [x] cargo clippy / oxlint / tsgo パス
- [x] `wrangler secret put GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET / JWT_SECRET` でシークレット設定
- [x] Google Cloud Console で OAuth クライアント作成、redirect URI に `{workers_url}/auth/callback` を登録
- [x] アプリからログイン → Google OAuth 画面 → deep link でトークン取得を確認

Closes #62