### PR TITLE
fix(ci): CI の timeout を解消し、ジョブ別 devShell で高速化する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,22 @@ permissions:
   contents: read
   pull-requests: read
 
+# 連続 push で古い run を走らせ続けない
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  rust:
+  # 変更検出を1ジョブに集約し、各ジョブをジョブ単位で gate する。
+  # ステップ単位の if だと、走らないジョブでも runner と checkout の時間を消費する
+  changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      # push / workflow_dispatch では filter を回さないので空になる → 全ジョブ実行
+      rust: ${{ steps.filter.outputs.rust || 'true' }}
+      frontend: ${{ steps.filter.outputs.frontend || 'true' }}
+      workers: ${{ steps.filter.outputs.workers || 'true' }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -30,37 +43,6 @@ jobs:
               - 'flake.lock'
               - 'justfile'
               - 'rust/justfile'
-      - name: Free disk space
-        if: steps.filter.outputs.rust == 'true' || github.event_name != 'pull_request'
-        run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
-      - uses: actions/cache@v4
-        if: steps.filter.outputs.rust == 'true' || github.event_name != 'pull_request'
-        with:
-          path: target
-          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'flake.lock') }}
-          restore-keys: |
-            cargo-${{ runner.os }}-
-      - if: steps.filter.outputs.rust == 'true' || github.event_name != 'pull_request'
-        uses: nixbuild/nix-quick-install-action@v34
-      - if: steps.filter.outputs.rust == 'true' || github.event_name != 'pull_request'
-        uses: DeterminateSystems/magic-nix-cache-action@v9
-      - name: check
-        if: steps.filter.outputs.rust == 'true' || github.event_name != 'pull_request'
-        run: nix develop --command just rust::check
-      - name: test
-        if: steps.filter.outputs.rust == 'true' || github.event_name != 'pull_request'
-        run: nix develop --command just rust::test
-    timeout-minutes: 15
-
-  frontend:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
-        if: github.event_name == 'pull_request'
-        id: filter
-        with:
-          filters: |
             frontend:
               - 'tauri-app/src/**'
               - 'tauri-app/package.json'
@@ -69,58 +51,102 @@ jobs:
               - 'tauri-app/vite.config.ts'
               - 'tauri-app/vitest.config.ts'
               - 'tauri-app/justfile'
-      - if: steps.filter.outputs.frontend == 'true' || github.event_name != 'pull_request'
-        uses: nixbuild/nix-quick-install-action@v34
-      - if: steps.filter.outputs.frontend == 'true' || github.event_name != 'pull_request'
-        uses: DeterminateSystems/magic-nix-cache-action@v9
-      - name: Get pnpm store directory
-        if: steps.filter.outputs.frontend == 'true' || github.event_name != 'pull_request'
-        id: pnpm-cache
-        shell: bash
-        run: echo "STORE_PATH=$(nix develop --command pnpm store path)" >> $GITHUB_OUTPUT
+              - 'flake.nix'
+              - 'flake.lock'
+            workers:
+              - 'workers/**'
+              - 'flake.nix'
+              - 'flake.lock'
+
+  rust:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - name: Free disk space
+        run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+      - uses: nixbuild/nix-quick-install-action@v35
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-rust-${{ hashFiles('flake.lock', 'flake.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-rust-
+          gc-max-store-size-linux: 3G
       - uses: actions/cache@v4
-        if: steps.filter.outputs.frontend == 'true' || github.event_name != 'pull_request'
+        with:
+          path: target
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'flake.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-
+      - name: check
+        run: nix develop .#rust --command just rust::check
+      - name: test
+        run: nix develop .#rust --command just rust::test
+
+  frontend:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: nixbuild/nix-quick-install-action@v35
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-frontend-${{ hashFiles('flake.lock', 'flake.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-frontend-
+          gc-max-store-size-linux: 3G
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(nix develop .#frontend --command pnpm store path)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: pnpm-${{ runner.os }}-${{ hashFiles('tauri-app/pnpm-lock.yaml') }}
           restore-keys: |
             pnpm-${{ runner.os }}-
       - name: check
-        if: steps.filter.outputs.frontend == 'true' || github.event_name != 'pull_request'
-        run: nix develop --command just tauri_app::check
+        run: nix develop .#frontend --command just tauri_app::check
       - name: test
-        if: steps.filter.outputs.frontend == 'true' || github.event_name != 'pull_request'
-        run: nix develop --command just tauri_app::test
-    timeout-minutes: 15
+        run: nix develop .#frontend --command just tauri_app::test
 
   workers:
+    needs: changes
+    if: needs.changes.outputs.workers == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
-        if: github.event_name == 'pull_request'
-        id: filter
+      - uses: nixbuild/nix-quick-install-action@v35
+      - uses: nix-community/cache-nix-action@v7
         with:
-          filters: |
-            workers:
-              - 'workers/**'
-      - if: steps.filter.outputs.workers == 'true' || github.event_name != 'pull_request'
-        uses: nixbuild/nix-quick-install-action@v34
-      - if: steps.filter.outputs.workers == 'true' || github.event_name != 'pull_request'
-        uses: DeterminateSystems/magic-nix-cache-action@v9
+          primary-key: nix-${{ runner.os }}-workers-${{ hashFiles('flake.lock', 'flake.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-workers-
+          gc-max-store-size-linux: 2G
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(nix develop .#workers --command pnpm store path)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: pnpm-workers-${{ runner.os }}-${{ hashFiles('workers/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-workers-${{ runner.os }}-
       - name: check
-        if: steps.filter.outputs.workers == 'true' || github.event_name != 'pull_request'
-        run: nix develop --command just workers::check
+        run: nix develop .#workers --command just workers::check
       - name: test
-        if: steps.filter.outputs.workers == 'true' || github.event_name != 'pull_request'
-        run: nix develop --command just workers::test
-    timeout-minutes: 10
+        run: nix develop .#workers --command just workers::test
 
   format:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: nixbuild/nix-quick-install-action@v34
-      - uses: DeterminateSystems/magic-nix-cache-action@v9
+      - uses: nixbuild/nix-quick-install-action@v35
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-format-${{ hashFiles('flake.lock', 'flake.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-format-
+          gc-max-store-size-linux: 2G
       - run: nix fmt -- --fail-on-change
-    timeout-minutes: 5

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,29 @@
         };
         androidSdk = androidComposition.androidsdk;
         playwrightBrowsers = pkgs.playwright-driver.browsers;
+
+        # CI 用の最小構成。Android クロスターゲットと rust-analyzer / rust-src は
+        # cache.nixos.org に無くソースビルドになるため、含めると CI が十数分伸びる
+        rustToolchainCI = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "clippy" ];
+        };
+        linuxTauriDeps = pkgs.lib.optionals pkgs.stdenv.isLinux (
+          with pkgs;
+          [
+            webkitgtk_4_1.dev
+            libappindicator-gtk3.dev
+            librsvg.dev
+            patchelf
+            pkg-config
+          ]
+        );
+        jsToolchain = with pkgs; [
+          nodejs_22
+          pnpm
+          oxlint
+          typescript-go
+          just
+        ];
       in
       {
         packages.default = pkgs.callPackage ./nix/package.nix { };
@@ -77,8 +100,7 @@
         devShells.default = pkgs.mkShell (
           {
             buildInputs =
-              with pkgs;
-              [
+              (with pkgs; [
                 rustToolchain
                 just
                 nodejs_22
@@ -89,14 +111,8 @@
                 oxlint
                 typescript-go
                 wrangler
-              ]
-              ++ lib.optionals stdenv.isLinux [
-                webkitgtk_4_1.dev
-                libappindicator-gtk3.dev
-                librsvg.dev
-                patchelf
-                pkg-config
-              ];
+              ])
+              ++ linuxTauriDeps;
             ANDROID_HOME = "${androidSdk}/libexec/android-sdk";
             NDK_HOME = "${androidSdk}/libexec/android-sdk/ndk/29.0.14206865";
             PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
@@ -120,6 +136,28 @@
             PLAYWRIGHT_BROWSERS_PATH = "${playwrightBrowsers}";
           }
         );
+
+        # CI 専用の shell。default は Android SDK/NDK と Rust クロスターゲットを含み、
+        # それらは毎回ソースビルドされるため CI で使うとジョブが timeout する
+        devShells.rust = pkgs.mkShell {
+          buildInputs = [
+            rustToolchainCI
+            pkgs.just
+          ]
+          ++ linuxTauriDeps;
+        };
+
+        devShells.frontend = pkgs.mkShell {
+          buildInputs = jsToolchain;
+          # vitest が browser mode (chromium) なのでブラウザ本体が要る
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+          PLAYWRIGHT_BROWSERS_PATH = "${playwrightBrowsers}";
+        };
+
+        # wrangler は workers/package.json の devDependency なので nix 版は不要
+        devShells.workers = pkgs.mkShell {
+          buildInputs = jsToolchain;
+        };
       }
     )
     // {


### PR DESCRIPTION
## 背景

PR #69 の CI で `rust` と `workers` が落ちていた。原因はテスト失敗ではなく **timeout** で、両ジョブとも制限時間の全部を `nix develop` の中で使い切っていた。

```
building 'androidsdk.drv'
building 'android-sdk-build-tools-35.0.0.drv' / '36.0.0.drv'
building 'rust-std-1.93.0-{aarch64,armv7,i686,x86_64}-linux-android.drv'
building 'rust-docs-...' / 'rust-analyzer-preview-...' / 'playwright-browsers.drv'
building 'rust-default-1.93.0.drv'   ← ここで 10 分に到達して kill
```

`workers` ジョブがやりたいのは TypeScript 5 ファイルへの oxlint + tsgo + vitest だけで、Android SDK も Rust のクロスターゲットも一切要らない。

さらに `DeterminateSystems/magic-nix-cache-action` が**機能停止していた**ため、キャッシュが一切効かず 4 ジョブが毎回同じ巨大 shell をソースからビルドしていた。

```
Magic Nix Cache has been deprecated ... will stop working on 1 February 2025
GitHub API error: TwirpErrorResponse { code: ResourceExhausted, msg: "rate limit exceeded" }
error: substituter 'http://127.0.0.1:37515' is disabled
Failed to restore: Cache service responded with 400
```

## 変更

### `flake.nix` — ジョブ別 devShell の追加

`devShells.default` はローカル開発用として**現状のまま**。CI 用に必要最小限の 3 つを追加した。

| shell | closure | 対 default |
| --- | --- | --- |
| default（従来 CI が使用） | **11.0 GiB** | — |
| workers | **1.6 GiB** | −85% |
| frontend | **2.6 GiB** | −76% |
| rust | **2.6 GiB** | −76% |

サイズ以上に効くのは中身で、削れた `androidsdk` / NDK / Android 向け `rust-std` 4 種 / `rust-docs` / `rust-analyzer` は**いずれも `cache.nixos.org` に無く毎回ソースビルドされていた**もの。

判断した点:

- **wrangler は workers shell に入れていない** — `workers/package.json` の devDependency にあり、`@cloudflare/vitest-pool-workers` は npm 側の workerd を使うため
- **playwright は frontend shell にのみ** — `tauri-app/vitest.config.ts` が browser mode (chromium) を使うため必須

### `.github/workflows/ci.yml`

- 各ジョブが `nix develop .#rust` / `.#frontend` / `.#workers` に入る
- `magic-nix-cache-action` → `nix-community/cache-nix-action@v7`
- `paths-filter` を `changes` ジョブに集約し、**ジョブ単位で gate**（スキップ時は runner を消費しない）
- `concurrency: cancel-in-progress` を追加
- `nix-quick-install-action` v34 → v35、workers にも pnpm store キャッシュを追加
- `flake.nix` / `flake.lock` を frontend と workers の paths-filter にも追加（devShell の定義元なので）

## 検証

各 shell で CI と同じコマンドをローカル実行した。

| コマンド | 結果 |
| --- | --- |
| `nix flake check` | all checks passed |
| `nix develop .#rust --command just rust::check` | clippy `-D warnings` clean |
| `nix develop .#rust --command just rust::test` | 127 passed |
| `nix develop .#workers --command just workers::check` / `::test` | clean / 21 passed |
| `nix develop .#frontend --command just tauri_app::check` / `::test` | clean / 54 passed |
| `actionlint .github/workflows/ci.yml` | exit 0 |
| `nix fmt` | 0 changed |

`workers::check` は shell 構築込みで**実測 4.5 秒**（従来は 10 分で timeout）。

## 注意点

ジョブ単位の gate によりスキップされたジョブは「skipped」として報告される。`main` の ruleset は `deletion` / `non_fast_forward` のみで**必須ステータスチェックは未設定**のため影響しない。

この PR 自体は `flake.nix` を触るので全ジョブが走る。初回は nix キャッシュが空だが、ソースビルドが消えている分だけ従来より短くなるはず。