### PR TITLE
chore: enforce the strictest lint configuration across the workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
               - 'rust/justfile'
             frontend:
               - 'tauri-app/src/**'
+              - '.oxlintrc.json'
+              - 'tauri-app/.oxlintrc.json'
               - 'tauri-app/package.json'
               - 'tauri-app/pnpm-lock.yaml'
               - 'tauri-app/tsconfig.json'
@@ -55,6 +57,7 @@ jobs:
               - 'flake.lock'
             workers:
               - 'workers/**'
+              - '.oxlintrc.json'
               - 'flake.nix'
               - 'flake.lock'
 

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,128 @@
+{
+  // Shared oxlint baseline. `tauri-app` and `workers` extend this file.
+  //
+  // Every category oxlint ships is enabled at "error", including `nursery`.
+  // `restriction` is the one category left out as a group: its lints exist to
+  // ban language features and contradict each other by design (e.g.
+  // `no-default-export` vs `prefer-default-export`). The valuable ones are
+  // opted into individually under "rules".
+  //
+  // Every rule turned off below states why. Nothing is disabled for being noisy.
+  //
+  // `vitest` is missing from "plugins" on purpose: its rules (require-hook,
+  // require-top-level-describe, …) treat every file as a test file, so it is
+  // enabled per-glob in "overrides" instead.
+  "plugins": ["typescript", "unicorn", "oxc", "import", "promise", "node", "jsx-a11y"],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "error",
+    "pedantic": "error",
+    "perf": "error",
+    "style": "error",
+    "nursery": "error"
+  },
+  "rules": {
+    // --- opted in from `restriction` ---
+    "typescript/no-explicit-any": "error",
+    "typescript/no-non-null-assertion": "error",
+    "typescript/no-import-type-side-effects": "error",
+    "typescript/explicit-module-boundary-types": "error",
+    "no-eq-null": "error",
+    "no-use-before-define": "error",
+
+    // --- configured, not weakened ---
+    // `void promise` as a statement is the explicit "I am intentionally not
+    // awaiting this" marker; `void` inside an expression stays banned.
+    "no-void": ["error", { "allowAsStatement": true }],
+    // A bare `import "./styles.css"` has no binding to assign by definition.
+    "import/no-unassigned-import": ["error", { "allow": ["**/*.css"] }],
+
+    // --- off: contradicts another enabled rule ---
+    // `import/no-default-export` is the convention here; these three demand the
+    // opposite module shape.
+    "import/prefer-default-export": "off",
+    "import/no-named-export": "off",
+    "import/group-exports": "off",
+    // Wants every export at the bottom of the file, which fights colocating an
+    // export with its definition.
+    "import/exports-last": "off",
+    // A value import and a fully-erased `import type` from the same module is
+    // the shape `import/consistent-type-specifier-style` and
+    // `typescript/no-import-type-side-effects` both require; this rule cannot
+    // tell the two statements apart and calls it a duplicate.
+    "no-duplicate-imports": "off",
+
+    // --- off: wrong target environment ---
+    // These ban ES2015+ syntax for old-browser support. The Tauri webview and
+    // workerd both ship modern V8.
+    "oxc/no-async-await": "off",
+    "oxc/no-optional-chaining": "off",
+    "oxc/no-rest-spread-properties": "off",
+    // TypeScript already resolves every identifier; this rule only has value in
+    // untyped JS and misreports type-only and platform globals.
+    "no-undef": "off",
+
+    // --- off: conflicts with project conventions ---
+    // CLAUDE.md assigns "why not" to comments; JSDoc-on-everything is a
+    // different documentation model.
+    "jsdoc/require-param": "off",
+    "jsdoc/require-returns": "off",
+    "no-inline-comments": "off",
+    // Comments here are written in Japanese, which has no letter case.
+    "capitalized-comments": "off",
+
+    // --- off: arbitrary thresholds, not defects ---
+    "max-lines": "off",
+    "max-lines-per-function": "off",
+    "max-statements": "off",
+    "max-params": "off",
+    "max-depth": "off",
+    "max-nested-callbacks": "off",
+    "import/max-dependencies": "off",
+    "no-magic-numbers": "off",
+
+    // --- off: style opinions a formatter or reviewer owns ---
+    // Ordering rules that fight each other and the grouping used here.
+    "sort-imports": "off",
+    "sort-keys": "off",
+    // Bans `i`, `e`, `id` and other idiomatic short names.
+    "id-length": "off",
+    // Ternaries are how JSX expresses a branch.
+    "no-ternary": "off",
+    // Forcing one of declaration/expression everywhere has no defect behind it.
+    "func-style": "off",
+    // `let x; if (…) x = …` is a legitimate shape.
+    "init-declarations": "off",
+    "no-plusplus": "off",
+    // DOM and JSON interop hands us `null`; pretending otherwise adds casts.
+    "unicorn/no-null": "off"
+  },
+  "overrides": [
+    {
+      "files": ["**/*.test.ts", "**/*.test.tsx", "**/__mocks__/**"],
+      "plugins": ["vitest"],
+      "rules": {
+        // A top-level `describe` names the component or module under test, so
+        // it keeps that identifier's casing; nested titles stay lowercase.
+        "jest/prefer-lowercase-title": ["error", { "ignoreTopLevelDescribe": true }],
+        // Test names describe behaviour, not the function under test.
+        "vitest/prefer-describe-function-title": "off",
+        // Importing `describe`/`it` explicitly is deliberate: no magic globals.
+        "vitest/no-importing-vitest-globals": "off",
+        // A missing timeout means "use the configured default", not a bug.
+        "vitest/require-test-timeout": "off",
+        // Fixture setup in a hook is the pattern this suite uses.
+        "jest/no-hooks": "off",
+        // An arbitrary threshold, like the other max-* rules above.
+        "jest/max-expects": "off",
+        // Exact opposites of `vitest/prefer-strict-boolean-matchers`, which
+        // stays on: asserting `toBe(true)` is stricter than truthiness.
+        "vitest/prefer-to-be-truthy": "off",
+        "vitest/prefer-to-be-falsy": "off",
+        // Exact opposite of `vitest/prefer-called-times`, which stays on:
+        // `toHaveBeenCalledTimes(n)` is one spelling for every n.
+        "vitest/prefer-called-once": "off"
+      }
+    }
+  ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,50 @@ members = ["core", "mcp-cli", "tauri-app/src-tauri"]
 
 [workspace.package]
 license = "MIT"
+repository = "https://github.com/Xantibody/magical-merchant"
+readme = "README.md"
+keywords = ["notes", "markdown", "tauri"]
+categories = ["text-editors"]
 
 [workspace.lints.rust]
-unsafe_op_in_unsafe_fn = "warn"
+# Lint groups. priority = -1 so individual lints below can override them.
+future_incompatible = { level = "deny", priority = -1 }
+nonstandard_style = { level = "deny", priority = -1 }
+rust_2018_idioms = { level = "deny", priority = -1 }
+unused = { level = "deny", priority = -1 }
+
+missing_debug_implementations = "deny"
+trivial_casts = "deny"
+trivial_numeric_casts = "deny"
+unreachable_pub = "deny"
+unsafe_op_in_unsafe_fn = "deny"
+unused_qualifications = "deny"
 invalid_reference_casting = "deny"
 
 [workspace.lints.clippy]
-mod_module_files = "warn"
-excessive_precision = "warn"
-impl_trait_in_params = "warn"
-float_cmp = "warn"
-redundant_field_names = "warn"
+all = { level = "deny", priority = -1 }
+pedantic = { level = "deny", priority = -1 }
+nursery = { level = "deny", priority = -1 }
+cargo = { level = "deny", priority = -1 }
+
+# Hand-picked from `restriction`, which is not enabled as a group because its
+# lints contradict each other by design.
+mod_module_files = "deny"
+impl_trait_in_params = "deny"
+undocumented_unsafe_blocks = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+
+# Versions of transitive dependencies are not ours to unify.
+multiple_crate_versions = "allow"
+
+# Doc-comment mandates are off by project policy: CLAUDE.md assigns "how" to the
+# code and "why not" to comments, so a doc comment on every item is noise.
+# `missing_docs` (rustc) is omitted above for the same reason.
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+
+# Contradicts rustc's `unreachable_pub`: one wants `pub(crate)` narrowed to
+# `pub` inside private modules, the other wants the opposite. `unreachable_pub`
+# wins because it describes the crate's real API surface.
+redundant_pub_crate = "allow"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,7 +2,12 @@
 name = "magical-merchant-core"
 version = "0.1.0"
 edition = "2021"
+description = "Framework-independent core logic for the Magical Merchant note-taking app"
 license.workspace = true
+repository.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -37,10 +37,10 @@ pub enum CoreError {
 impl From<NoteError> for CoreError {
     fn from(err: NoteError) -> Self {
         match err {
-            NoteError::Io(e) => CoreError::Io(e),
-            NoteError::NotFound(s) => CoreError::NotFound(s),
-            NoteError::PathTraversal(s) => CoreError::PathTraversal(s),
-            NoteError::Parse(s) => CoreError::Parse(s),
+            NoteError::Io(e) => Self::Io(e),
+            NoteError::NotFound(s) => Self::NotFound(s),
+            NoteError::PathTraversal(s) => Self::PathTraversal(s),
+            NoteError::Parse(s) => Self::Parse(s),
         }
     }
 }
@@ -48,8 +48,8 @@ impl From<NoteError> for CoreError {
 impl From<TimelineError> for CoreError {
     fn from(err: TimelineError) -> Self {
         match err {
-            TimelineError::Io(e) => CoreError::Io(e),
-            TimelineError::Parse(s) => CoreError::Parse(s),
+            TimelineError::Io(e) => Self::Io(e),
+            TimelineError::Parse(s) => Self::Parse(s),
         }
     }
 }
@@ -57,11 +57,11 @@ impl From<TimelineError> for CoreError {
 impl From<ProjectError> for CoreError {
     fn from(err: ProjectError) -> Self {
         match err {
-            ProjectError::Io(e) => CoreError::Io(e),
-            ProjectError::NotFound(s) => CoreError::NotFound(s),
-            ProjectError::AlreadyExists(s) => CoreError::AlreadyExists(s),
-            ProjectError::InvalidSlug(s) => CoreError::InvalidSlug(s),
-            ProjectError::Parse(s) => CoreError::Parse(s),
+            ProjectError::Io(e) => Self::Io(e),
+            ProjectError::NotFound(s) => Self::NotFound(s),
+            ProjectError::AlreadyExists(s) => Self::AlreadyExists(s),
+            ProjectError::InvalidSlug(s) => Self::InvalidSlug(s),
+            ProjectError::Parse(s) => Self::Parse(s),
         }
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,7 @@
+// A panicking assertion is the point of a test; only production code has to
+// prove it handles the error case.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 mod note;
 mod project;
 pub mod sync;

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -1,8 +1,8 @@
-pub mod error;
-pub mod repository;
+pub(crate) mod error;
+pub(crate) mod repository;
 mod summary;
 
-pub use repository::Notes;
+pub(crate) use repository::Notes;
 pub use summary::Summary as NoteSummary;
 
 use std::path::{Path, PathBuf};
@@ -26,7 +26,7 @@ pub fn update_note(
     tags: &[String],
     context: &Context,
 ) -> Result<(), CoreError> {
-    Notes::new(PathBuf::new()).update(file_path, body, tags, context)
+    Notes::update(file_path, body, tags, context)
 }
 
 pub fn list_notes(base_dir: &Path) -> Result<Vec<NoteSummary>, CoreError> {

--- a/core/src/note/repository.rs
+++ b/core/src/note/repository.rs
@@ -12,12 +12,12 @@ use crate::utils::validated::NoteFilename;
 
 use super::summary::Summary as NoteSummary;
 
-pub struct Notes {
+pub(crate) struct Notes {
     base_dir: PathBuf,
 }
 
 impl Notes {
-    pub fn new(base_dir: PathBuf) -> Self {
+    pub(crate) const fn new(base_dir: PathBuf) -> Self {
         Self { base_dir }
     }
 
@@ -25,7 +25,7 @@ impl Notes {
         notes_dir(&self.base_dir)
     }
 
-    pub fn create(
+    pub(crate) fn create(
         &self,
         body: &str,
         tags: &[String],
@@ -35,12 +35,12 @@ impl Notes {
         let file_path = note_file_path(&self.base_dir, now);
         ensure_dir(&file_path)?;
 
-        let content = format_note_markdown(body, tags, now, context)?;
-        fs::write(&file_path, content)?;
+        let markdown = format_note_markdown(body, tags, now, context)?;
+        fs::write(&file_path, markdown)?;
         Ok(file_path)
     }
 
-    pub fn list(&self) -> Result<Vec<NoteSummary>, CoreError> {
+    pub(crate) fn list(&self) -> Result<Vec<NoteSummary>, CoreError> {
         let notes_dir = self.notes_dir();
         let entries = list_md_files(&notes_dir)?;
 
@@ -57,7 +57,7 @@ impl Notes {
         Ok(summaries)
     }
 
-    pub fn read(&self, filename: &NoteFilename) -> Result<String, CoreError> {
+    pub(crate) fn read(&self, filename: &NoteFilename) -> Result<String, CoreError> {
         let fname = filename.as_str();
         let notes_dir = self.notes_dir();
         let file_path = notes_dir.join(fname);
@@ -75,20 +75,19 @@ impl Notes {
         Ok(fs::read_to_string(canonical_file_path)?)
     }
 
-    pub fn update(
-        &self,
+    pub(crate) fn update(
         path: &Path,
         body: &str,
         tags: &[String],
         context: &Context,
     ) -> Result<(), CoreError> {
         let now = Local::now();
-        let content = format_note_markdown(body, tags, now, context)?;
-        fs::write(path, content)?;
+        let markdown = format_note_markdown(body, tags, now, context)?;
+        fs::write(path, markdown)?;
         Ok(())
     }
 
-    pub fn delete(&self, filename: &NoteFilename) -> Result<(), CoreError> {
+    pub(crate) fn delete(&self, filename: &NoteFilename) -> Result<(), CoreError> {
         let fname = filename.as_str();
         let notes_dir = self.notes_dir();
         let file_path = notes_dir.join(fname);

--- a/core/src/note/summary.rs
+++ b/core/src/note/summary.rs
@@ -15,17 +15,16 @@ pub struct Summary {
 }
 
 impl Summary {
+    #[must_use]
     pub fn from_file(path: PathBuf, filename: String, content: &str) -> Self {
-        let (time, tags, preview) = match frontmatter::parse::<NoteFrontmatter>(content) {
-            Ok((fm, body)) => {
+        let (time, tags, preview) =
+            if let Ok((fm, body)) = frontmatter::parse::<NoteFrontmatter>(content) {
                 let preview: String = body.chars().take(100).collect();
                 (Some(fm.time), fm.tags, preview)
-            }
-            Err(_) => {
+            } else {
                 let preview: String = content.chars().take(100).collect();
                 (None, Vec::new(), preview)
-            }
-        };
+            };
 
         Self {
             path,

--- a/core/src/project.rs
+++ b/core/src/project.rs
@@ -1,9 +1,9 @@
-pub mod error;
-pub mod repository;
+pub(crate) mod error;
+pub(crate) mod repository;
 mod summary;
-pub mod task;
+pub(crate) mod task;
 
-pub use repository::Projects;
+pub(crate) use repository::Projects;
 pub use summary::{ActivitySummary as ProjectActivitySummary, Summary as ProjectSummary};
 pub use task::{
     Summary as TaskSummary, complete_task, create_task, delete_task, list_active_tasks,
@@ -43,17 +43,15 @@ pub fn get_project_activity_summary(
     let mut result = Vec::new();
 
     for project in projects {
-        let slug = Slug::parse(&project.slug).expect("already validated by list_projects");
+        let slug = Slug::parse(&project.slug)?;
         let done_tasks = list_done_tasks(base_dir, &slug)?;
         let filtered: Vec<TaskSummary> = done_tasks
             .into_iter()
             .filter(|task| {
-                task.completed
-                    .map(|dt| {
-                        let date = dt.date_naive();
-                        date >= start && date <= end
-                    })
-                    .unwrap_or(false)
+                task.completed.is_some_and(|dt| {
+                    let date = dt.date_naive();
+                    date >= start && date <= end
+                })
             })
             .collect();
 

--- a/core/src/project/repository.rs
+++ b/core/src/project/repository.rs
@@ -11,16 +11,21 @@ use crate::utils::validated::Slug;
 
 use super::summary::Summary as ProjectSummary;
 
-pub struct Projects {
+pub(crate) struct Projects {
     base_dir: PathBuf,
 }
 
 impl Projects {
-    pub fn new(base_dir: PathBuf) -> Self {
+    pub(crate) const fn new(base_dir: PathBuf) -> Self {
         Self { base_dir }
     }
 
-    pub fn create(&self, slug: &Slug, name: &str, description: &str) -> Result<PathBuf, CoreError> {
+    pub(crate) fn create(
+        &self,
+        slug: &Slug,
+        name: &str,
+        description: &str,
+    ) -> Result<PathBuf, CoreError> {
         let file_path = paths::project_file_path(&self.base_dir, slug.as_str());
         if file_path.exists() {
             return Err(CoreError::AlreadyExists(format!("project: {slug}")));
@@ -44,7 +49,7 @@ impl Projects {
         Ok(proj_dir)
     }
 
-    pub fn list(&self) -> Result<Vec<ProjectSummary>, CoreError> {
+    pub(crate) fn list(&self) -> Result<Vec<ProjectSummary>, CoreError> {
         let dir = paths::projects_dir(&self.base_dir);
         if !dir.exists() {
             return Ok(Vec::new());
@@ -52,10 +57,10 @@ impl Projects {
 
         let mut projects = Vec::new();
         let mut entries: Vec<_> = fs::read_dir(&dir)?
-            .filter_map(|e| e.ok())
+            .filter_map(Result::ok)
             .filter(|e| e.path().is_dir())
             .collect();
-        entries.sort_by_key(|e| e.file_name());
+        entries.sort_by_key(fs::DirEntry::file_name);
 
         for entry in entries {
             let slug_str = entry.file_name().to_string_lossy().to_string();
@@ -69,7 +74,7 @@ impl Projects {
         Ok(projects)
     }
 
-    pub fn read(&self, slug: &Slug) -> Result<ProjectSummary, CoreError> {
+    pub(crate) fn read(&self, slug: &Slug) -> Result<ProjectSummary, CoreError> {
         let slug_str = slug.as_str();
         let file_path = paths::project_file_path(&self.base_dir, slug_str);
         if !file_path.exists() {

--- a/core/src/project/summary.rs
+++ b/core/src/project/summary.rs
@@ -15,6 +15,7 @@ pub struct Summary {
 }
 
 impl Summary {
+    #[must_use]
     pub fn from_frontmatter(
         slug: String,
         fm: ProjectFrontmatter,

--- a/core/src/project/task.rs
+++ b/core/src/project/task.rs
@@ -1,7 +1,7 @@
-pub mod repository;
+pub(crate) mod repository;
 mod summary;
 
-pub use repository::Tasks;
+pub(crate) use repository::Tasks;
 pub use summary::Summary;
 
 use std::path::{Path, PathBuf};

--- a/core/src/project/task/repository.rs
+++ b/core/src/project/task/repository.rs
@@ -11,16 +11,16 @@ use crate::utils::validated::{Filename, Slug};
 use super::list_tasks_in_dir;
 use super::summary::Summary;
 
-pub struct Tasks {
+pub(crate) struct Tasks {
     base_dir: PathBuf,
 }
 
 impl Tasks {
-    pub fn new(base_dir: PathBuf) -> Self {
+    pub(crate) const fn new(base_dir: PathBuf) -> Self {
         Self { base_dir }
     }
 
-    pub fn create(
+    pub(crate) fn create(
         &self,
         project_slug: &Slug,
         title: &str,
@@ -47,7 +47,7 @@ impl Tasks {
         Ok(file_path)
     }
 
-    pub fn list_active(&self, project_slug: &Slug) -> Result<Vec<Summary>, CoreError> {
+    pub(crate) fn list_active(&self, project_slug: &Slug) -> Result<Vec<Summary>, CoreError> {
         let slug_str = project_slug.as_str();
         let project_file = paths::project_file_path(&self.base_dir, slug_str);
         if !project_file.exists() {
@@ -56,7 +56,7 @@ impl Tasks {
         list_tasks_in_dir(&paths::active_tasks_dir(&self.base_dir, slug_str))
     }
 
-    pub fn list_done(&self, project_slug: &Slug) -> Result<Vec<Summary>, CoreError> {
+    pub(crate) fn list_done(&self, project_slug: &Slug) -> Result<Vec<Summary>, CoreError> {
         let slug_str = project_slug.as_str();
         let project_file = paths::project_file_path(&self.base_dir, slug_str);
         if !project_file.exists() {
@@ -65,7 +65,11 @@ impl Tasks {
         list_tasks_in_dir(&paths::done_tasks_dir(&self.base_dir, slug_str))
     }
 
-    pub fn complete(&self, project_slug: &Slug, filename: &Filename) -> Result<(), CoreError> {
+    pub(crate) fn complete(
+        &self,
+        project_slug: &Slug,
+        filename: &Filename,
+    ) -> Result<(), CoreError> {
         let slug_str = project_slug.as_str();
         let fname = filename.as_str();
         let active_path = paths::active_tasks_dir(&self.base_dir, slug_str).join(fname);
@@ -90,7 +94,7 @@ impl Tasks {
         Ok(())
     }
 
-    pub fn update(
+    pub(crate) fn update(
         &self,
         project_slug: &Slug,
         filename: &Filename,
@@ -120,7 +124,7 @@ impl Tasks {
         Ok(())
     }
 
-    pub fn delete(&self, project_slug: &Slug, filename: &Filename) -> Result<(), CoreError> {
+    pub(crate) fn delete(&self, project_slug: &Slug, filename: &Filename) -> Result<(), CoreError> {
         let slug_str = project_slug.as_str();
         let fname = filename.as_str();
         let active_path = paths::active_tasks_dir(&self.base_dir, slug_str).join(fname);

--- a/core/src/project/task/summary.rs
+++ b/core/src/project/task/summary.rs
@@ -27,6 +27,7 @@ impl Summary {
         })
     }
 
+    #[must_use]
     pub fn to_frontmatter(&self) -> TaskFrontmatter {
         TaskFrontmatter {
             title: self.title.clone(),

--- a/core/src/sync/conflict.rs
+++ b/core/src/sync/conflict.rs
@@ -8,6 +8,7 @@ pub enum ConflictResolution {
     KeepRemote,
 }
 
+#[must_use]
 pub fn resolve(
     local_modified: DateTime<Utc>,
     remote_modified: DateTime<Utc>,
@@ -19,6 +20,7 @@ pub fn resolve(
     }
 }
 
+#[must_use]
 pub fn conflict_filename(key: &str, timestamp: DateTime<Utc>) -> String {
     let path = Path::new(key);
     let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("file");

--- a/core/src/sync/diff.rs
+++ b/core/src/sync/diff.rs
@@ -23,6 +23,7 @@ pub enum SyncAction {
     Conflict { key: String },
 }
 
+#[must_use]
 pub fn compute(
     local_files: &[LocalFile],
     remote_files: &[RemoteFile],
@@ -93,12 +94,12 @@ pub fn compute(
             // Local exists, remote gone, was synced → remote deleted it
             // ただしローカルに未同期の変更があれば、削除より変更を優先して復活させる
             (Some(local), None, Some(record)) => {
-                if local.content_hash != record.content_hash {
-                    actions.push(SyncAction::UploadModified {
+                if local.content_hash == record.content_hash {
+                    actions.push(SyncAction::DeleteLocal {
                         key: key.to_string(),
                     });
                 } else {
-                    actions.push(SyncAction::DeleteLocal {
+                    actions.push(SyncAction::UploadModified {
                         key: key.to_string(),
                     });
                 }
@@ -107,12 +108,12 @@ pub fn compute(
             // Remote exists, local gone, was synced → local deleted it
             // ただしリモートに未取得の変更があれば、削除より変更を優先して復活させる
             (None, Some(remote), Some(record)) => {
-                if remote.last_modified != record.last_synced_modified {
-                    actions.push(SyncAction::DownloadModified {
+                if remote.last_modified == record.last_synced_modified {
+                    actions.push(SyncAction::DeleteRemote {
                         key: key.to_string(),
                     });
                 } else {
-                    actions.push(SyncAction::DeleteRemote {
+                    actions.push(SyncAction::DownloadModified {
                         key: key.to_string(),
                     });
                 }

--- a/core/src/sync/state.rs
+++ b/core/src/sync/state.rs
@@ -55,8 +55,10 @@ mod tests {
     #[test]
     fn save_and_load_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
-        let mut state = SyncState::default();
-        state.last_sync = Some(Utc::now());
+        let mut state = SyncState {
+            last_sync: Some(Utc::now()),
+            ..SyncState::default()
+        };
         state.files.insert(
             "notes/test.md".to_string(),
             FileSyncRecord {

--- a/core/src/timeline.rs
+++ b/core/src/timeline.rs
@@ -1,7 +1,7 @@
-pub mod error;
-pub mod repository;
+pub(crate) mod error;
+pub(crate) mod repository;
 
-pub use repository::Timeline;
+pub(crate) use repository::Timeline;
 
 use std::path::Path;
 

--- a/core/src/timeline/repository.rs
+++ b/core/src/timeline/repository.rs
@@ -9,46 +9,46 @@ use crate::utils::fs::ensure_dir;
 use crate::utils::markdown::format_timeline_line;
 use crate::utils::paths::{self, timeline_file_path};
 
-pub struct Timeline {
+pub(crate) struct Timeline {
     base_dir: PathBuf,
 }
 
 impl Timeline {
-    pub fn new(base_dir: PathBuf) -> Self {
+    pub(crate) const fn new(base_dir: PathBuf) -> Self {
         Self { base_dir }
     }
 
-    pub fn save_entry(&self, text: &str, context: &Context) -> Result<(), CoreError> {
+    pub(crate) fn save_entry(&self, text: &str, context: &Context) -> Result<(), CoreError> {
         let now = Local::now();
         let file_path = timeline_file_path(&self.base_dir, now.date_naive());
         ensure_dir(&file_path)?;
 
         let line = format_timeline_line(text, now, context);
 
-        let mut content = if file_path.exists() {
+        let mut day_log = if file_path.exists() {
             fs::read_to_string(&file_path)?
         } else {
             String::new()
         };
 
-        if !content.is_empty() && !content.ends_with('\n') {
-            content.push('\n');
+        if !day_log.is_empty() && !day_log.ends_with('\n') {
+            day_log.push('\n');
         }
-        content.push_str(&line);
-        content.push('\n');
+        day_log.push_str(&line);
+        day_log.push('\n');
 
-        fs::write(&file_path, content)?;
+        fs::write(&file_path, day_log)?;
         Ok(())
     }
 
-    pub fn list_dates(&self) -> Result<Vec<NaiveDate>, CoreError> {
+    pub(crate) fn list_dates(&self) -> Result<Vec<NaiveDate>, CoreError> {
         let timeline_dir = paths::data_dir(&self.base_dir).join(paths::TIMELINE_DIR);
         if !timeline_dir.exists() {
             return Ok(Vec::new());
         }
 
         let mut dates: Vec<NaiveDate> = fs::read_dir(&timeline_dir)?
-            .filter_map(|e| e.ok())
+            .filter_map(Result::ok)
             .filter_map(|e| {
                 let name = e.file_name().to_string_lossy().to_string();
                 let stem = name.strip_suffix(".md")?;
@@ -60,7 +60,7 @@ impl Timeline {
         Ok(dates)
     }
 
-    pub fn read(&self, date: NaiveDate) -> Result<Vec<String>, CoreError> {
+    pub(crate) fn read(&self, date: NaiveDate) -> Result<Vec<String>, CoreError> {
         let file_path = timeline_file_path(&self.base_dir, date);
         if !file_path.exists() {
             return Ok(Vec::new());

--- a/core/src/utils/device.rs
+++ b/core/src/utils/device.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum NetworkType {
     WiFi,
     Mobile,

--- a/core/src/utils/frontmatter.rs
+++ b/core/src/utils/frontmatter.rs
@@ -13,14 +13,14 @@ pub struct NoteFrontmatter {
     pub context: Option<Context>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProjectFrontmatter {
     pub name: String,
     pub created: DateTime<FixedOffset>,
     pub description: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TaskFrontmatter {
     pub title: String,
     pub created: DateTime<FixedOffset>,

--- a/core/src/utils/fs.rs
+++ b/core/src/utils/fs.rs
@@ -16,7 +16,7 @@ pub fn list_md_files(dir: &Path) -> Result<Vec<DirEntry>, CoreError> {
     }
 
     let mut entries: Vec<_> = fs::read_dir(dir)?
-        .filter_map(|e| e.ok())
+        .filter_map(Result::ok)
         .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
         .collect();
 
@@ -30,7 +30,7 @@ pub fn count_md_files(dir: &Path) -> Result<usize, CoreError> {
     }
 
     Ok(fs::read_dir(dir)?
-        .filter_map(|e| e.ok())
+        .filter_map(Result::ok)
         .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
         .count())
 }

--- a/core/src/utils/markdown.rs
+++ b/core/src/utils/markdown.rs
@@ -4,6 +4,7 @@ use crate::error::CoreError;
 use crate::utils::device::Context;
 use crate::utils::frontmatter::{self, NoteFrontmatter};
 
+#[must_use]
 pub fn format_timeline_line(text: &str, timestamp: DateTime<Local>, context: &Context) -> String {
     let time = timestamp.format("%H:%M:%S");
     match serde_json::to_string(context) {

--- a/core/src/utils/paths.rs
+++ b/core/src/utils/paths.rs
@@ -9,42 +9,51 @@ pub const ACTIVE_DIR: &str = "active";
 pub const DONE_DIR: &str = "done";
 pub const PROJECT_FILE: &str = "project.md";
 
+#[must_use]
 pub fn data_dir(base_dir: &Path) -> PathBuf {
     base_dir.join(DATA_DIR)
 }
 
+#[must_use]
 pub fn timeline_file_path(base_dir: &Path, date: NaiveDate) -> PathBuf {
     data_dir(base_dir)
         .join(TIMELINE_DIR)
         .join(format!("{}.md", date.format("%Y-%m-%d")))
 }
 
+#[must_use]
 pub fn note_file_path(base_dir: &Path, timestamp: DateTime<Local>) -> PathBuf {
     data_dir(base_dir)
         .join(NOTES_DIR)
         .join(format!("{}.md", timestamp.format("%Y%m%d_%H%M%S")))
 }
 
+#[must_use]
 pub fn notes_dir(base_dir: &Path) -> PathBuf {
     data_dir(base_dir).join(NOTES_DIR)
 }
 
+#[must_use]
 pub fn projects_dir(base_dir: &Path) -> PathBuf {
     data_dir(base_dir).join(PROJECTS_DIR)
 }
 
+#[must_use]
 pub fn project_dir(base_dir: &Path, slug: &str) -> PathBuf {
     projects_dir(base_dir).join(slug)
 }
 
+#[must_use]
 pub fn project_file_path(base_dir: &Path, slug: &str) -> PathBuf {
     project_dir(base_dir, slug).join(PROJECT_FILE)
 }
 
+#[must_use]
 pub fn active_tasks_dir(base_dir: &Path, slug: &str) -> PathBuf {
     project_dir(base_dir, slug).join(ACTIVE_DIR)
 }
 
+#[must_use]
 pub fn done_tasks_dir(base_dir: &Path, slug: &str) -> PathBuf {
     project_dir(base_dir, slug).join(DONE_DIR)
 }

--- a/core/src/utils/validated.rs
+++ b/core/src/utils/validated.rs
@@ -19,6 +19,7 @@ impl Slug {
         Ok(Self(s.to_string()))
     }
 
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -46,6 +47,7 @@ impl Filename {
         Ok(Self(s.to_string()))
     }
 
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -76,6 +78,7 @@ impl NoteFilename {
         Ok(Self(s.to_string()))
     }
 
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Rust development environment";
+  description = "Magical Merchant: Rust core, Tauri app, and Cloudflare Workers sync";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
@@ -34,26 +34,37 @@
         };
         # Workaround: see nix/android-repo-fix.nix and #26
         fixedRepoFile = import ./nix/android-repo-fix.nix { inherit pkgs; };
-        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+
+        # Rust の入手経路はここ一箇所。shell ごとに override を書き分けると
+        # バージョンが静かにずれる
+        mkRustToolchain =
+          {
+            extensions ? [ ],
+            targets ? [ ],
+          }:
+          pkgs.rust-bin.stable.latest.default.override { inherit extensions targets; };
+
+        androidRustTargets = [
+          "aarch64-linux-android"
+          "armv7-linux-androideabi"
+          "i686-linux-android"
+          "x86_64-linux-android"
+        ];
+
+        rustToolchain = mkRustToolchain {
           extensions = [
             "rust-src"
             "clippy"
             "rust-analyzer"
           ];
-          targets = [
-            "aarch64-linux-android"
-            "armv7-linux-androideabi"
-            "i686-linux-android"
-            "x86_64-linux-android"
-          ];
+          targets = androidRustTargets;
         };
-        treefmtEval = treefmt-nix.lib.evalModule pkgs {
-          projectRootFile = "flake.nix";
-          programs.nixfmt.enable = true;
-          programs.rustfmt.enable = true;
-          programs.taplo.enable = true;
-          programs.oxfmt.enable = true;
-        };
+
+        # CI 用の最小構成。Android クロスターゲットと rust-analyzer / rust-src は
+        # cache.nixos.org に無くソースビルドになるため、含めると CI が十数分伸びる
+        rustToolchainCI = mkRustToolchain { extensions = [ "clippy" ]; };
+
+        androidNdkVersion = "29.0.14206865";
         androidComposition = pkgs.androidenv.composeAndroidPackages {
           repoJson = fixedRepoFile;
           platformVersions = [ "36" ];
@@ -62,19 +73,21 @@
             "36.0.0"
           ];
           includeNDK = true;
-          ndkVersions = [ "29.0.14206865" ];
+          ndkVersions = [ androidNdkVersion ];
           includeSources = false;
           includeSystemImages = false;
           includeEmulator = false;
         };
         androidSdk = androidComposition.androidsdk;
-        playwrightBrowsers = pkgs.playwright-driver.browsers;
+        androidSdkRoot = "${androidSdk}/libexec/android-sdk";
 
-        # CI 用の最小構成。Android クロスターゲットと rust-analyzer / rust-src は
-        # cache.nixos.org に無くソースビルドになるため、含めると CI が十数分伸びる
-        rustToolchainCI = pkgs.rust-bin.stable.latest.default.override {
-          extensions = [ "clippy" ];
+        # vitest が browser mode (chromium) なのでブラウザ本体が要る
+        playwrightBrowsers = pkgs.playwright-driver.browsers;
+        playwrightEnv = {
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+          PLAYWRIGHT_BROWSERS_PATH = "${playwrightBrowsers}";
         };
+
         linuxTauriDeps = pkgs.lib.optionals pkgs.stdenv.isLinux (
           with pkgs;
           [
@@ -92,30 +105,34 @@
           typescript-go
           just
         ];
+
+        treefmtEval = treefmt-nix.lib.evalModule pkgs {
+          projectRootFile = "flake.nix";
+          programs.nixfmt.enable = true;
+          programs.rustfmt.enable = true;
+          programs.taplo.enable = true;
+          programs.oxfmt.enable = true;
+        };
       in
       {
         packages.default = pkgs.callPackage ./nix/package.nix { };
         formatter = treefmtEval.config.build.wrapper;
         checks.formatting = treefmtEval.config.build.check self;
         devShells.default = pkgs.mkShell (
-          {
-            buildInputs =
-              (with pkgs; [
-                rustToolchain
-                just
-                nodejs_22
-                pnpm
-                cargo-tauri
-                jdk17
-                androidSdk
-                oxlint
-                typescript-go
-                wrangler
-              ])
-              ++ linuxTauriDeps;
-            ANDROID_HOME = "${androidSdk}/libexec/android-sdk";
-            NDK_HOME = "${androidSdk}/libexec/android-sdk/ndk/29.0.14206865";
-            PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+          playwrightEnv
+          // {
+            buildInputs = [
+              rustToolchain
+              androidSdk
+              pkgs.cargo-tauri
+              pkgs.jdk17
+              pkgs.wrangler
+              pkgs.agent-browser
+            ]
+            ++ jsToolchain
+            ++ linuxTauriDeps;
+            ANDROID_HOME = androidSdkRoot;
+            NDK_HOME = "${androidSdkRoot}/ndk/${androidNdkVersion}";
             shellHook = ''
               # Create a rustup shim that no-ops for tauri android init
               mkdir -p "$PWD/.nix-shims"
@@ -132,9 +149,6 @@
               export PATH="$PWD/.nix-shims:$PATH"
             '';
           }
-          // {
-            PLAYWRIGHT_BROWSERS_PATH = "${playwrightBrowsers}";
-          }
         );
 
         # CI 専用の shell。default は Android SDK/NDK と Rust クロスターゲットを含み、
@@ -147,12 +161,7 @@
           ++ linuxTauriDeps;
         };
 
-        devShells.frontend = pkgs.mkShell {
-          buildInputs = jsToolchain;
-          # vitest が browser mode (chromium) なのでブラウザ本体が要る
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
-          PLAYWRIGHT_BROWSERS_PATH = "${playwrightBrowsers}";
-        };
+        devShells.frontend = pkgs.mkShell (playwrightEnv // { buildInputs = jsToolchain; });
 
         # wrangler は workers/package.json の devDependency なので nix 版は不要
         devShells.workers = pkgs.mkShell {

--- a/mcp-cli/Cargo.toml
+++ b/mcp-cli/Cargo.toml
@@ -2,7 +2,12 @@
 name = "magical-merchant-mcp-cli"
 version = "0.1.0"
 edition = "2021"
+description = "MCP server exposing Magical Merchant notes to AI agents"
 license.workspace = true
+repository.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 magical-merchant-core = { path = "../core" }

--- a/mcp-cli/src/main.rs
+++ b/mcp-cli/src/main.rs
@@ -1,3 +1,7 @@
+// A panicking assertion is the point of a test; only production code has to
+// prove it handles the error case.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
 use std::path::PathBuf;
 
 use chrono::NaiveDate;
@@ -229,7 +233,7 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let server = McpServer::new(cli.data_dir);
     let transport = rmcp::transport::io::stdio();
-    let _server = server.serve(transport).await?;
-    _server.waiting().await?;
+    let running = server.serve(transport).await?;
+    running.waiting().await?;
     Ok(())
 }

--- a/rust/justfile
+++ b/rust/justfile
@@ -5,7 +5,7 @@ default:
   @just --list
 
 check:
-  cargo clippy --workspace -- -D warnings
+  cargo clippy --workspace --all-targets -- -D warnings
 
 test:
   cargo test --workspace
@@ -13,13 +13,13 @@ test:
 # --- Per-crate recipes ---
 
 check-app:
-  cargo clippy -p magical-merchant-core -p magical-merchant-app -- -D warnings
+  cargo clippy -p magical-merchant-core -p magical-merchant-app --all-targets -- -D warnings
 
 test-app:
   cargo test -p magical-merchant-core -p magical-merchant-app
 
 check-cli:
-  cargo clippy -p magical-merchant-mcp-cli -- -D warnings
+  cargo clippy -p magical-merchant-mcp-cli --all-targets -- -D warnings
 
 test-cli:
   cargo test -p magical-merchant-mcp-cli

--- a/tauri-app/.oxlintrc.json
+++ b/tauri-app/.oxlintrc.json
@@ -1,5 +1,16 @@
 {
+  "extends": ["../.oxlintrc.json"],
   "rules": {
+    // The frontend is SolidJS. oxlint's `react` plugin is not enabled at all:
+    // its rules assume the React runtime (`react-in-jsx-scope`), React's DOM
+    // prop names (`no-unknown-property` rejects Solid's `class`/`classList`)
+    // and React's reconciler.
+
+    // Solid components are PascalCase files next to kebab-case modules.
+    "unicorn/filename-case": ["error", { "cases": { "kebabCase": true, "pascalCase": true } }],
+
+    // Solid assigns `ref` bindings out of band, so the declaration really does
+    // stay unassigned in the source the linter can see.
     "no-unassigned-vars": "off"
   }
 }

--- a/tauri-app/justfile
+++ b/tauri-app/justfile
@@ -12,6 +12,7 @@ assets: setup
 check: setup
   oxlint src/
   tsgo -b --noEmit
+  pnpm knip
 
 test: setup
   pnpm test

--- a/tauri-app/knip.jsonc
+++ b/tauri-app/knip.jsonc
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  // tsgo comes from the nix devShell (typescript-go), not from node_modules.
+  "ignoreBinaries": ["tsgo"],
+  // open-props is consumed by `@import` in src/styles/base.css, which knip
+  // does not parse.
+  "ignoreDependencies": ["open-props"],
+}

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -30,6 +30,7 @@
     "@types/markdown-it": "^14.1.2",
     "@vitest/browser-playwright": "^4.1.4",
     "jsdom": "^29.0.2",
+    "knip": "^6.31.0",
     "playwright": "1.58.2",
     "typescript": "^5.6.0",
     "vite": "^6.0.0",

--- a/tauri-app/pnpm-lock.yaml
+++ b/tauri-app/pnpm-lock.yaml
@@ -50,10 +50,13 @@ importers:
         version: 14.1.2
       '@vitest/browser-playwright':
         specifier: ^4.1.4
-        version: 4.1.4(playwright@1.58.2)(vite@6.4.1(jiti@1.21.7))(vitest@4.1.4)
+        version: 4.1.4(playwright@1.58.2)(vite@6.4.1(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.4)
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2
+      knip:
+        specifier: ^6.31.0
+        version: 6.31.0
       playwright:
         specifier: 1.58.2
         version: 1.58.2
@@ -62,13 +65,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.1(jiti@1.21.7)
+        version: 6.4.1(jiti@2.7.0)(yaml@2.9.0)
       vite-plugin-solid:
         specifier: ^2.11.12
-        version: 2.11.12(solid-js@1.9.12)(vite@6.4.1(jiti@1.21.7))
+        version: 2.11.12(solid-js@1.9.12)(vite@6.4.1(jiti@2.7.0)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@vitest/browser-playwright@4.1.4)(jsdom@29.0.2)(vite@6.4.1(jiti@1.21.7))
+        version: 4.1.4(@vitest/browser-playwright@4.1.4)(jsdom@29.0.2)(vite@6.4.1(jiti@2.7.0)(yaml@2.9.0))
 
 packages:
 
@@ -223,6 +226,15 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -493,8 +505,248 @@ packages:
   '@milkdown/utils@7.20.0':
     resolution: {integrity: sha512-ciEhtLKhIW/Kaz/NRE5DUXVoMCdenn7S4mClrO7sZ/nXtmObnk3okJzSDnamQoDOcLOIbpOu1V3E1Btkvc5x9w==}
 
+  '@napi-rs/wasm-runtime@1.2.2':
+    resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
+
   '@ocavue/utils@1.6.0':
     resolution: {integrity: sha512-8W3q1hxx9qFdrYgPtbElllG/tqYkO/dMhlRUiqasO0SuDFTj78azSQjhIrBTFWxlBPPsSZN6zXYHmb3RwN2Jtg==}
+
+  '@oxc-parser/binding-android-arm-eabi@0.142.0':
+    resolution: {integrity: sha512-ZiRGDutGsv1G6bL/ozy/koC0Sv39T1DqyoC4KD1DOy9ZoACm1O5UWhEK2c02Qdk+4lfLVkvFa/mQ0fm/4h1BtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.142.0':
+    resolution: {integrity: sha512-WZkvGRLNQTz8lR9zP5nLjUdlroRCopBu3g9zF1p/laE6DzT1UbQo8Rdz5MWhaJUPYg/6gp+jo7HUgsyKaN1FtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.142.0':
+    resolution: {integrity: sha512-l4khS8LQOOVYsGRVARo1gSaCT/aBSceUVXgtovWc2+drnxVuDr082WA3OCHVdVzIz5JIrP/y9CWsSKxBDNmYGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.142.0':
+    resolution: {integrity: sha512-QBsNF3nqlXmcH2B1YOPqQYmCJoy4HuIjUxGbBO/k5JAJUl68ghU2psRY2zPk+RyBaWqKP/qfL4oaFgEMCdwskA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.142.0':
+    resolution: {integrity: sha512-b7Q7m4Cqc6XqNhri3R+QhU+GVy646Pn+bkdhrDdWym/Fdi0ZUa+d73H9dm5H91JtbtAQ/z1d8XKMW3oOV8a4tQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.142.0':
+    resolution: {integrity: sha512-3riVS5IhdH3uCZj1Y9ftDQlR0dvLsIlw/edrRqk8JhgNd5K0XSs+UBtgh50N13CAlW9/TXj6sVGXaKNBocd0Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.142.0':
+    resolution: {integrity: sha512-NmXUOpgpTSkhl795TiXmWppTwmSJ92RC1qvD6e4XOF+slgmo3e6Ah+kEu+6AN8s7NAOEwqGmir58MgSQSWmBSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.142.0':
+    resolution: {integrity: sha512-gc0EXsKtXgerujmU2Bql3u1L1HsSQ2774R83idq/FoNMPVV/RY/1ErFsvnit7KoiP/sLvzQixeUo4Ut0ic0wmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.142.0':
+    resolution: {integrity: sha512-F2XvmWSE0uWpie+jHKKIFgdVOe9ypGhkEZxKx5DuW215K6cbAC274yYaPkcM7EqY4Df3Weyhpcz3lsURyH2LVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.142.0':
+    resolution: {integrity: sha512-wLMbT21U/QxknQsk+VvNF0b9D2/aGWhcaQQQ+VYlE8FwD5+GoWZIPPXNzyHmkYyhm0KB3itL+TBavjMatqNnYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.142.0':
+    resolution: {integrity: sha512-+G8F/4ckwT7FCJV4H2bt09xEzJbjNCfuL4Sp1AYNaFtFMVtgIGMuJlteT82U+K0UIZ/DzAR/LDlMFnEuajG7Kw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.142.0':
+    resolution: {integrity: sha512-hTsHtTLxMAfCo+rpF5K3qZJKW2NpPN/CHd4mYB3y7XlSdspHkd2gehDIofP64AacA9nWQw2tY3O7wR6UY8IVOA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.142.0':
+    resolution: {integrity: sha512-6y7qYY3TCUDYjqswImdTGl92y+KA/80twALegQPN27kfY+bG7Ib1+L3jbmrCZQx6wrVnai9IPsEZp07I0hx7JQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.142.0':
+    resolution: {integrity: sha512-i69kAWU+2LgoH5bR+zWiiu+UzAw7Oxkwv7COeJTeY19pn4e70nKQcr9Pm6cL2Z0Z54d+gl9qADlK/0yyuCPiBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.142.0':
+    resolution: {integrity: sha512-4SQs678MmjYVrmhAgCWD4o0vpaFszXw9xLX5p2Z9MMFcltxiLkA88wQjh80YHjPrXtpyZ2CWI5m+1yNKM0m2Pw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.142.0':
+    resolution: {integrity: sha512-YHpx9N7Ln3a++Tc8rv+H7mrK1zyJQOAwCFg8LZ3lTs1T5afGWeZrLPhPT9HLnIwSjCyJqPWVMIrMxbjcmBr2oQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.142.0':
+    resolution: {integrity: sha512-3pLDyY3+oogW73RM5uehNgAiR/Xfb7fvO2Q1Z1gIqZ2+50XDVQmBVlRkHXZTU4gKnQHpwETNsYQVsJ3joVB2iA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.142.0':
+    resolution: {integrity: sha512-Had/VeVY28Oyb0K+Q4FV8KCzoBycIh93oDK6pCbya9lkzdq+ikMHMgBubsdqqlybjJmQRawCQRrnBRHyQwYvcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.142.0':
+    resolution: {integrity: sha512-GGi3+YphVHavvgs6gum2UXoNCqzHAmPt/nXkn8ZQZstV2Q1qZD1Mn8fz/nWrDkefHQtrG/+1/XrbMxsBTo6Svw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.142.0':
+    resolution: {integrity: sha512-Ny/Wv4Us1LGC/ljwNTp+Hx3r/pH15EFfeDF0p+n898gt+TtRd6C9SccHcuUhDiNTb8s5tt7jdeAMDRQZ4Vq6hg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.142.0':
+    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
+    resolution: {integrity: sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-resolver/binding-android-arm64@11.24.2':
+    resolution: {integrity: sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
+    resolution: {integrity: sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
+    resolution: {integrity: sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
+    resolution: {integrity: sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
+    resolution: {integrity: sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
+    resolution: {integrity: sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
+    resolution: {integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
+    resolution: {integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
+    resolution: {integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
+    resolution: {integrity: sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
+    resolution: {integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
+    resolution: {integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
+    resolution: {integrity: sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
+    resolution: {integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
+    resolution: {integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
+    resolution: {integrity: sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
+    resolution: {integrity: sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    resolution: {integrity: sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==}
+    cpu: [x64]
+    os: [win32]
 
   '@phosphor-icons/core@2.1.1':
     resolution: {integrity: sha512-v4ARvrip4qBCImOE5rmPUylOEK4iiED9ZyKjcvzuezqMaiRASCHKcRIuvvxL/twvLpkfnEODCOJp5dM4eZilxQ==}
@@ -774,6 +1026,9 @@ packages:
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -1067,6 +1322,9 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fd-package-json@2.0.0:
+    resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1075,6 +1333,11 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  formatly@0.3.0:
+    resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
+    engines: {node: '>=18.3.0'}
+    hasBin: true
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -1089,6 +1352,9 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
@@ -1117,8 +1383,8 @@ packages:
     resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
     engines: {node: '>=12.13'}
 
-  jiti@1.21.7:
-    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
   js-tokens@4.0.0:
@@ -1141,6 +1407,11 @@ packages:
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
+    hasBin: true
+
+  knip@6.31.0:
+    resolution: {integrity: sha512-NbeIEmUS2VUMjAkbiSNOKPJeV9wpCsr0660sUyKyMQbk4Iom0++nTLInVp4MJ+LfR4kORnw67bDi5tvO7YLnzA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   linkify-it@5.0.0:
@@ -1341,6 +1612,13 @@ packages:
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
 
+  oxc-parser@0.142.0:
+    resolution: {integrity: sha512-kKR+jPiRJYJDexVoziIg/FVGvr1fT1FZSSJOk6tVoMKKSlsf1Cso+cgGCJkOEDWOP174vRntCPFKg+AS7InWvw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-resolver@11.24.2:
+    resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
@@ -1355,6 +1633,10 @@ packages:
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   playwright-core@1.58.2:
@@ -1507,6 +1789,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1544,6 +1829,10 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
+  smol-toml@1.7.1:
+    resolution: {integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==}
+    engines: {node: '>= 18'}
+
   solid-js@1.9.12:
     resolution: {integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==}
 
@@ -1568,6 +1857,10 @@ packages:
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
+
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
@@ -1583,6 +1876,10 @@ packages:
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.1.0:
@@ -1614,6 +1911,9 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1621,6 +1921,10 @@ packages:
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  unbash@4.0.6:
+    resolution: {integrity: sha512-YGBMSVG/WrA2vgaZbXVvxrGgoMcWZecyyS4foGt8clbtY7s1nIKNmt7Z9LR74XE6FkYTSqDmKk2lIOhOjIvmrw==}
+    engines: {node: '>=14'}
 
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
@@ -1770,6 +2074,10 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  walk-up-path@4.0.0:
+    resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
+    engines: {node: 20 || >=22}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -1808,6 +2116,14 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -1996,6 +2312,22 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@emnapi/core@1.11.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -2373,7 +2705,141 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@ocavue/utils@1.6.0': {}
+
+  '@oxc-parser/binding-android-arm-eabi@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.142.0':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.142.0':
+    optional: true
+
+  '@oxc-project/types@0.142.0': {}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-android-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    optional: true
 
   '@phosphor-icons/core@2.1.1': {}
 
@@ -2571,6 +3037,11 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -2639,29 +3110,29 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitest/browser-playwright@4.1.4(playwright@1.58.2)(vite@6.4.1(jiti@1.21.7))(vitest@4.1.4)':
+  '@vitest/browser-playwright@4.1.4(playwright@1.58.2)(vite@6.4.1(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.4)':
     dependencies:
-      '@vitest/browser': 4.1.4(vite@6.4.1(jiti@1.21.7))(vitest@4.1.4)
-      '@vitest/mocker': 4.1.4(vite@6.4.1(jiti@1.21.7))
+      '@vitest/browser': 4.1.4(vite@6.4.1(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.4)
+      '@vitest/mocker': 4.1.4(vite@6.4.1(jiti@2.7.0)(yaml@2.9.0))
       playwright: 1.58.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@vitest/browser-playwright@4.1.4)(jsdom@29.0.2)(vite@6.4.1(jiti@1.21.7))
+      vitest: 4.1.4(@vitest/browser-playwright@4.1.4)(jsdom@29.0.2)(vite@6.4.1(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.4(vite@6.4.1(jiti@1.21.7))(vitest@4.1.4)':
+  '@vitest/browser@4.1.4(vite@6.4.1(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.4)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.4(vite@6.4.1(jiti@1.21.7))
+      '@vitest/mocker': 4.1.4(vite@6.4.1(jiti@2.7.0)(yaml@2.9.0))
       '@vitest/utils': 4.1.4
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@vitest/browser-playwright@4.1.4)(jsdom@29.0.2)(vite@6.4.1(jiti@1.21.7))
+      vitest: 4.1.4(@vitest/browser-playwright@4.1.4)(jsdom@29.0.2)(vite@6.4.1(jiti@2.7.0)(yaml@2.9.0))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -2678,13 +3149,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@6.4.1(jiti@1.21.7))':
+  '@vitest/mocker@4.1.4(vite@6.4.1(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(jiti@1.21.7)
+      vite: 6.4.1(jiti@2.7.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -2917,9 +3388,21 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fd-package-json@2.0.0:
+    dependencies:
+      walk-up-path: 4.0.0
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  formatly@0.3.0:
+    dependencies:
+      fd-package-json: 2.0.0
 
   fsevents@2.3.2:
     optional: true
@@ -2928,6 +3411,10 @@ snapshots:
     optional: true
 
   gensync@1.0.0-beta.2: {}
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   hast-util-to-html@9.0.5:
     dependencies:
@@ -2963,8 +3450,7 @@ snapshots:
 
   is-what@4.1.16: {}
 
-  jiti@1.21.7:
-    optional: true
+  jiti@2.7.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -2997,6 +3483,22 @@ snapshots:
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
+
+  knip@6.31.0:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      formatly: 0.3.0
+      get-tsconfig: 4.14.0
+      jiti: 2.7.0
+      oxc-parser: 0.142.0
+      oxc-resolver: 11.24.2
+      picomatch: 4.0.5
+      smol-toml: 1.7.1
+      strip-json-comments: 5.0.3
+      tinyglobby: 0.2.17
+      unbash: 4.0.6
+      yaml: 2.9.0
+      zod: 4.4.3
 
   linkify-it@5.0.0:
     dependencies:
@@ -3372,6 +3874,53 @@ snapshots:
 
   orderedmap@2.1.1: {}
 
+  oxc-parser@0.142.0:
+    dependencies:
+      '@oxc-project/types': 0.142.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.142.0
+      '@oxc-parser/binding-android-arm64': 0.142.0
+      '@oxc-parser/binding-darwin-arm64': 0.142.0
+      '@oxc-parser/binding-darwin-x64': 0.142.0
+      '@oxc-parser/binding-freebsd-x64': 0.142.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.142.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.142.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.142.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.142.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.142.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-x64-musl': 0.142.0
+      '@oxc-parser/binding-openharmony-arm64': 0.142.0
+      '@oxc-parser/binding-wasm32-wasi': 0.142.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.142.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.142.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.142.0
+
+  oxc-resolver@11.24.2:
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.24.2
+      '@oxc-resolver/binding-android-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-x64': 11.24.2
+      '@oxc-resolver/binding-freebsd-x64': 11.24.2
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-musl': 11.24.2
+      '@oxc-resolver/binding-openharmony-arm64': 11.24.2
+      '@oxc-resolver/binding-wasm32-wasi': 11.24.2
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
+      '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
@@ -3385,6 +3934,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  picomatch@4.0.5: {}
 
   playwright-core@1.58.2: {}
 
@@ -3566,6 +4117,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   rollup@4.59.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -3630,6 +4183,8 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  smol-toml@1.7.1: {}
+
   solid-js@1.9.12:
     dependencies:
       csstype: 3.2.3
@@ -3658,6 +4213,8 @@ snapshots:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
 
+  strip-json-comments@5.0.3: {}
+
   style-mod@4.1.3: {}
 
   symbol-tree@3.2.4: {}
@@ -3670,6 +4227,11 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyrainbow@3.1.0: {}
 
@@ -3693,9 +4255,14 @@ snapshots:
 
   trough@2.2.0: {}
 
+  tslib@2.8.1:
+    optional: true
+
   typescript@5.9.3: {}
 
   uc.micro@2.1.0: {}
+
+  unbash@4.0.6: {}
 
   undici@7.25.0: {}
 
@@ -3748,7 +4315,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@6.4.1(jiti@1.21.7)):
+  vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@6.4.1(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
@@ -3756,12 +4323,12 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.12
       solid-refresh: 0.6.3(solid-js@1.9.12)
-      vite: 6.4.1(jiti@1.21.7)
-      vitefu: 1.1.3(vite@6.4.1(jiti@1.21.7))
+      vite: 6.4.1(jiti@2.7.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@6.4.1(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
-  vite@6.4.1(jiti@1.21.7):
+  vite@6.4.1(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -3771,16 +4338,17 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       fsevents: 2.3.3
-      jiti: 1.21.7
+      jiti: 2.7.0
+      yaml: 2.9.0
 
-  vitefu@1.1.3(vite@6.4.1(jiti@1.21.7)):
+  vitefu@1.1.3(vite@6.4.1(jiti@2.7.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 6.4.1(jiti@1.21.7)
+      vite: 6.4.1(jiti@2.7.0)(yaml@2.9.0)
 
-  vitest@4.1.4(@vitest/browser-playwright@4.1.4)(jsdom@29.0.2)(vite@6.4.1(jiti@1.21.7)):
+  vitest@4.1.4(@vitest/browser-playwright@4.1.4)(jsdom@29.0.2)(vite@6.4.1(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@6.4.1(jiti@1.21.7))
+      '@vitest/mocker': 4.1.4(vite@6.4.1(jiti@2.7.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -3797,10 +4365,10 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 6.4.1(jiti@1.21.7)
+      vite: 6.4.1(jiti@2.7.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@vitest/browser-playwright': 4.1.4(playwright@1.58.2)(vite@6.4.1(jiti@1.21.7))(vitest@4.1.4)
+      '@vitest/browser-playwright': 4.1.4(playwright@1.58.2)(vite@6.4.1(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.4)
       jsdom: 29.0.2
     transitivePeerDependencies:
       - msw
@@ -3820,6 +4388,8 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+
+  walk-up-path@4.0.0: {}
 
   webidl-conversions@8.0.1: {}
 
@@ -3845,5 +4415,9 @@ snapshots:
   xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.9.0: {}
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -2,7 +2,12 @@
 name = "magical-merchant-app"
 version = "0.1.0"
 edition = "2021"
+description = "Tauri desktop and mobile shell for the Magical Merchant note-taking app"
 license.workspace = true
+repository.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [lib]
 name = "magical_merchant_app_lib"

--- a/tauri-app/src-tauri/build.rs
+++ b/tauri-app/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    tauri_build::build()
+    tauri_build::build();
 }

--- a/tauri-app/src-tauri/src/auth.rs
+++ b/tauri-app/src-tauri/src/auth.rs
@@ -11,14 +11,14 @@ const KEYCHAIN_SERVICE: &str = "com.magical-merchant.app";
 const KEYCHAIN_ACCOUNT: &str = "auth-jwt";
 const SYNC_CONFIG_FILENAME: &str = "sync-config.json";
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
-pub struct SyncConfig {
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub(crate) struct SyncConfig {
     #[serde(default)]
     pub workers_url: String,
 }
 
 impl SyncConfig {
-    pub fn load(base_dir: &Path) -> Self {
+    pub(crate) fn load(base_dir: &Path) -> Self {
         let path = base_dir.join(SYNC_CONFIG_FILENAME);
         if !path.exists() {
             return Self::default();
@@ -29,7 +29,7 @@ impl SyncConfig {
             .unwrap_or_default()
     }
 
-    pub fn save(&self, base_dir: &Path) -> Result<(), String> {
+    pub(crate) fn save(&self, base_dir: &Path) -> Result<(), String> {
         // 初回起動時は app_data_dir がまだ存在しないことがある
         fs::create_dir_all(base_dir).map_err(|e| e.to_string())?;
         let path = base_dir.join(SYNC_CONFIG_FILENAME);
@@ -38,7 +38,7 @@ impl SyncConfig {
         Ok(())
     }
 
-    pub fn is_editable(base_dir: &Path) -> bool {
+    pub(crate) fn is_editable(base_dir: &Path) -> bool {
         let path = base_dir.join(SYNC_CONFIG_FILENAME);
         if !path.exists() {
             return true;
@@ -46,7 +46,7 @@ impl SyncConfig {
         !path.metadata().is_ok_and(|m| m.permissions().readonly())
     }
 
-    pub fn is_configured(&self) -> bool {
+    pub(crate) const fn is_configured(&self) -> bool {
         !self.workers_url.is_empty()
     }
 }
@@ -58,7 +58,7 @@ fn normalize_workers_url(input: &str) -> Result<String, String> {
     if trimmed.is_empty() {
         return Ok(String::new());
     }
-    let parsed = url::Url::parse(trimmed)
+    let parsed = Url::parse(trimmed)
         .map_err(|_| "Invalid URL. Expected e.g. https://example.workers.dev".to_string())?;
     if parsed.scheme() != "https" && parsed.scheme() != "http" {
         return Err("URL must start with https:// or http://".to_string());
@@ -66,14 +66,14 @@ fn normalize_workers_url(input: &str) -> Result<String, String> {
     Ok(trimmed.to_string())
 }
 
-pub fn store_token(token: &str) -> Result<(), String> {
+pub(crate) fn store_token(token: &str) -> Result<(), String> {
     let entry =
         keyring::Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT).map_err(|e| e.to_string())?;
     entry.set_password(token).map_err(|e| e.to_string())?;
     Ok(())
 }
 
-pub fn get_token() -> Result<Option<String>, String> {
+pub(crate) fn get_token() -> Result<Option<String>, String> {
     let entry =
         keyring::Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT).map_err(|e| e.to_string())?;
     match entry.get_password() {
@@ -83,12 +83,12 @@ pub fn get_token() -> Result<Option<String>, String> {
     }
 }
 
-pub fn clear_token() -> Result<(), String> {
+pub(crate) fn clear_token() -> Result<(), String> {
     let entry =
         keyring::Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT).map_err(|e| e.to_string())?;
     match entry.delete_credential() {
-        Ok(()) => Ok(()),
-        Err(keyring::Error::NoEntry) => Ok(()),
+        // Deleting a credential that was never stored leaves the desired state.
+        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
         Err(e) => Err(e.to_string()),
     }
 }
@@ -98,16 +98,16 @@ struct Claims {
     exp: i64,
 }
 
-pub fn is_token_valid(token: &str) -> bool {
+pub(crate) fn is_token_valid(token: &str) -> bool {
     let mut validation = Validation::new(Algorithm::HS256);
     validation.insecure_disable_signature_validation();
     validation.validate_exp = false;
     validation.validate_aud = false;
     validation.required_spec_claims.clear();
 
-    let token_data = match decode::<Claims>(token, &DecodingKey::from_secret(&[]), &validation) {
-        Ok(data) => data,
-        Err(_) => return false,
+    let Ok(token_data) = decode::<Claims>(token, &DecodingKey::from_secret(&[]), &validation)
+    else {
+        return false;
     };
 
     let now = chrono::Utc::now().timestamp();
@@ -186,7 +186,7 @@ async fn login_with_loopback(handle: &AppHandle, config: &SyncConfig) -> Result<
 // Tauri commands
 
 #[tauri::command]
-pub async fn auth_login(handle: AppHandle) -> Result<(), String> {
+pub(crate) async fn auth_login(handle: AppHandle) -> Result<(), String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
     let config = SyncConfig::load(&base_dir);
 
@@ -211,26 +211,23 @@ pub async fn auth_login(handle: AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub fn auth_status() -> Result<bool, String> {
-    match get_token()? {
-        Some(token) => Ok(is_token_valid(&token)),
-        None => Ok(false),
-    }
+pub(crate) fn auth_status() -> Result<bool, String> {
+    Ok(get_token()?.is_some_and(|token| is_token_valid(&token)))
 }
 
 #[tauri::command]
-pub fn auth_logout() -> Result<(), String> {
+pub(crate) fn auth_logout() -> Result<(), String> {
     clear_token()
 }
 
 #[tauri::command]
-pub fn get_sync_config(handle: AppHandle) -> Result<SyncConfig, String> {
+pub(crate) fn get_sync_config(handle: AppHandle) -> Result<SyncConfig, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
     Ok(SyncConfig::load(&base_dir))
 }
 
 #[tauri::command]
-pub fn save_sync_config(handle: AppHandle, config: SyncConfig) -> Result<(), String> {
+pub(crate) fn save_sync_config(handle: AppHandle, config: SyncConfig) -> Result<(), String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
     let config = SyncConfig {
         workers_url: normalize_workers_url(&config.workers_url)?,
@@ -239,7 +236,7 @@ pub fn save_sync_config(handle: AppHandle, config: SyncConfig) -> Result<(), Str
 }
 
 #[tauri::command]
-pub fn is_sync_config_editable(handle: AppHandle) -> Result<bool, String> {
+pub(crate) fn is_sync_config_editable(handle: AppHandle) -> Result<bool, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
     Ok(SyncConfig::is_editable(&base_dir))
 }

--- a/tauri-app/src-tauri/src/device.rs
+++ b/tauri-app/src-tauri/src/device.rs
@@ -1,7 +1,7 @@
 use magical_merchant_core::DeviceContext;
 use magical_merchant_core::utils::device::{Location, NetworkType};
 
-pub fn get_context(location: Option<Location>) -> DeviceContext {
+pub(crate) fn get_context(location: Option<Location>) -> DeviceContext {
     let (battery, is_charging) = get_battery();
     let (network_type, wifi_ssid) = get_network();
 
@@ -52,18 +52,19 @@ fn get_locale() -> Option<String> {
 fn get_battery() -> (Option<u8>, Option<bool>) {
     use battery::State;
 
-    let manager = match battery::Manager::new() {
-        Ok(m) => m,
-        Err(_) => return (None, None),
+    let Ok(manager) = battery::Manager::new() else {
+        return (None, None);
     };
 
-    let mut batteries = match manager.batteries() {
-        Ok(b) => b,
-        Err(_) => return (None, None),
+    let Ok(mut batteries) = manager.batteries() else {
+        return (None, None);
     };
 
     match batteries.next() {
         Some(Ok(bat)) => {
+            // clamp() keeps the value inside u8 range, so the cast cannot
+            // truncate or lose a sign.
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             let percentage = (bat.state_of_charge().value * 100.0)
                 .round()
                 .clamp(0.0, 100.0) as u8;
@@ -81,12 +82,11 @@ fn get_battery() -> (Option<u8>, Option<bool>) {
 
 #[cfg(target_os = "macos")]
 fn get_network() -> (Option<NetworkType>, Option<String>) {
-    let output = match std::process::Command::new("ipconfig")
+    let Ok(output) = std::process::Command::new("ipconfig")
         .args(["getsummary", "en0"])
         .output()
-    {
-        Ok(o) => o,
-        Err(_) => return (None, None),
+    else {
+        return (None, None);
     };
 
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/tauri-app/src-tauri/src/device.rs
+++ b/tauri-app/src-tauri/src/device.rs
@@ -37,7 +37,7 @@ fn get_os_version() -> Option<String> {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn get_os_version() -> Option<String> {
+const fn get_os_version() -> Option<String> {
     None
 }
 
@@ -76,7 +76,7 @@ fn get_battery() -> (Option<u8>, Option<bool>) {
 }
 
 #[cfg(target_os = "android")]
-fn get_battery() -> (Option<u8>, Option<bool>) {
+const fn get_battery() -> (Option<u8>, Option<bool>) {
     (None, None)
 }
 
@@ -107,11 +107,11 @@ fn get_network() -> (Option<NetworkType>, Option<String>) {
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "android")))]
-fn get_network() -> (Option<NetworkType>, Option<String>) {
+const fn get_network() -> (Option<NetworkType>, Option<String>) {
     (None, None)
 }
 
 #[cfg(target_os = "android")]
-fn get_network() -> (Option<NetworkType>, Option<String>) {
+const fn get_network() -> (Option<NetworkType>, Option<String>) {
     (None, None)
 }

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -1,3 +1,11 @@
+// A panicking assertion is the point of a test; only production code has to
+// prove it handles the error case.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+// `#[tauri::command]` arguments arrive by value: serde deserializes them out of
+// the IPC payload, and `AppHandle` / `State` are injected owned. Borrowing them
+// is not an option this crate has.
+#![allow(clippy::needless_pass_by_value)]
+
 mod auth;
 mod device;
 mod sync;
@@ -8,7 +16,7 @@ use magical_merchant_core::{
 };
 use tauri::{AppHandle, Emitter, Listener, Manager};
 
-fn make_location(latitude: Option<f64>, longitude: Option<f64>) -> Option<Location> {
+const fn make_location(latitude: Option<f64>, longitude: Option<f64>) -> Option<Location> {
     match (latitude, longitude) {
         (Some(lat), Some(lng)) => Some(Location {
             latitude: lat,
@@ -201,6 +209,9 @@ fn update_task(
         .map_err(|e| e.to_string())
 }
 
+// `mobile_entry_point` fixes the signature to `fn run()`, so a failed startup
+// has nowhere to be returned to — panicking is the only way to report it.
+#[allow(clippy::expect_used)]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()

--- a/tauri-app/src-tauri/src/main.rs
+++ b/tauri-app/src-tauri/src/main.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    magical_merchant_app_lib::run()
+    magical_merchant_app_lib::run();
 }

--- a/tauri-app/src-tauri/src/sync.rs
+++ b/tauri-app/src-tauri/src/sync.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::Path;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, PoisonError};
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as B64;
@@ -19,14 +19,14 @@ const EVENT_SYNC_COMPLETE: &str = "sync-complete";
 const EVENT_SYNC_ERROR: &str = "sync-error";
 
 #[derive(Debug, Clone, Serialize)]
-pub struct SyncStatusInfo {
+pub(crate) struct SyncStatusInfo {
     pub is_syncing: bool,
     pub last_synced_at: Option<DateTime<Utc>>,
     pub last_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
-pub struct SyncResult {
+pub(crate) struct SyncResult {
     pub uploaded: usize,
     pub downloaded: usize,
     pub deleted_remote: usize,
@@ -38,7 +38,7 @@ pub struct SyncResult {
 /// フロントが「設定へ誘導」「再試行」などを出し分けられるよう、
 /// エラーを kind 付きで返す
 #[derive(Debug, Clone, Serialize)]
-pub struct SyncErrorInfo {
+pub(crate) struct SyncErrorInfo {
     pub kind: &'static str,
     pub message: String,
 }
@@ -57,7 +57,7 @@ impl SyncErrorInfo {
     }
 }
 
-pub struct AppSyncState {
+pub(crate) struct AppSyncState {
     pub is_syncing: AtomicBool,
     pub last_synced_at: Mutex<Option<DateTime<Utc>>>,
     pub last_error: Mutex<Option<String>>,
@@ -225,7 +225,7 @@ async fn check_status(
 
 // ──────────── Tauri commands ────────────
 
-/// panic やキャンセルでも is_syncing を確実に false へ戻すガード
+/// panic やキャンセルでも `is_syncing` を確実に false へ戻すガード
 struct SyncingGuard<'a>(&'a AtomicBool);
 
 impl Drop for SyncingGuard<'_> {
@@ -235,7 +235,7 @@ impl Drop for SyncingGuard<'_> {
 }
 
 #[tauri::command]
-pub async fn sync_start(
+pub(crate) async fn sync_start(
     handle: AppHandle,
     state: State<'_, AppSyncState>,
 ) -> Result<SyncResult, SyncErrorInfo> {
@@ -252,12 +252,21 @@ pub async fn sync_start(
 
     match &result {
         Ok(sync_result) => {
-            *state.last_synced_at.lock().unwrap() = Some(Utc::now());
-            *state.last_error.lock().unwrap() = None;
+            *state
+                .last_synced_at
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner) = Some(Utc::now());
+            *state
+                .last_error
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner) = None;
             let _ = handle.emit(EVENT_SYNC_COMPLETE, sync_result);
         }
         Err(err) => {
-            *state.last_error.lock().unwrap() = Some(err.message.clone());
+            *state
+                .last_error
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner) = Some(err.message.clone());
             let _ = handle.emit(EVENT_SYNC_ERROR, err);
         }
     }
@@ -266,12 +275,19 @@ pub async fn sync_start(
 }
 
 #[tauri::command]
-pub fn sync_status(state: State<'_, AppSyncState>) -> Result<SyncStatusInfo, String> {
-    Ok(SyncStatusInfo {
+pub(crate) fn sync_status(state: State<'_, AppSyncState>) -> SyncStatusInfo {
+    SyncStatusInfo {
         is_syncing: state.is_syncing.load(Ordering::SeqCst),
-        last_synced_at: *state.last_synced_at.lock().unwrap(),
-        last_error: state.last_error.lock().unwrap().clone(),
-    })
+        last_synced_at: *state
+            .last_synced_at
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner),
+        last_error: state
+            .last_error
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone(),
+    }
 }
 
 // ──────────── Sync orchestration ────────────

--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -3,13 +3,14 @@ import { Router, Route } from "@solidjs/router";
 import AppLayout from "./layouts/AppLayout";
 import Timeline from "./views/Timeline";
 import { ROUTES } from "./lib/routes";
+import type { JSX } from "solid-js";
 
 // 起動時に表示しない view は遅延読み込みして初期バンドルを軽くする
 const Notes = lazy(() => import("./views/Notes"));
 const Tasks = lazy(() => import("./views/Tasks"));
 const Settings = lazy(() => import("./views/Settings"));
 
-export default function App() {
+export default function App(): JSX.Element {
   return (
     <Router root={AppLayout}>
       <Route path={ROUTES.TIMELINE} component={Timeline} />

--- a/tauri-app/src/__mocks__/@tauri-apps/api/core.ts
+++ b/tauri-app/src/__mocks__/@tauri-apps/api/core.ts
@@ -1,3 +1,3 @@
 import { vi } from "vitest";
 
-export const invoke = vi.fn();
+export const invoke = vi.fn<(command: string, args?: unknown) => Promise<unknown>>();

--- a/tauri-app/src/components/ActionBar.test.tsx
+++ b/tauri-app/src/components/ActionBar.test.tsx
@@ -5,6 +5,14 @@ import ActionBar from "./ActionBar";
 
 afterEach(() => cleanup());
 
+function requireElement(root: ParentNode, selector: string): Element {
+  const element = root.querySelector(selector);
+  if (!element) {
+    throw new Error(`expected an element matching ${selector}`);
+  }
+  return element;
+}
+
 function makeTouch(target: Element, clientY: number): Touch {
   return new Touch({ identifier: 0, target, clientY, clientX: 0 });
 }
@@ -51,7 +59,7 @@ describe("ActionBar", () => {
     await expect.element(screen.getByText("Test Action")).toBeInTheDocument();
   });
 
-  it("has action-bar-zone and action-bar classes", async () => {
+  it("has action-bar-zone and action-bar classes", () => {
     const { baseElement } = render(() => (
       <ActionBar>
         <span>content</span>
@@ -69,8 +77,8 @@ describe("ActionBar", () => {
           <button>Action</button>
         </ActionBar>
       ));
-      const zone = baseElement.querySelector(".action-bar-zone")!;
-      const bar = baseElement.querySelector(".action-bar")!;
+      const zone = requireElement(baseElement, ".action-bar-zone");
+      const bar = requireElement(baseElement, ".action-bar");
 
       flick(zone, 300, 250); // upward: deltaY = -50
 
@@ -83,8 +91,8 @@ describe("ActionBar", () => {
           <button>Action</button>
         </ActionBar>
       ));
-      const zone = baseElement.querySelector(".action-bar-zone")!;
-      const bar = baseElement.querySelector(".action-bar")!;
+      const zone = requireElement(baseElement, ".action-bar-zone");
+      const bar = requireElement(baseElement, ".action-bar");
 
       // First show it
       flick(zone, 300, 250);
@@ -102,8 +110,8 @@ describe("ActionBar", () => {
           <button>Action</button>
         </ActionBar>
       ));
-      const zone = baseElement.querySelector(".action-bar-zone")!;
-      const bar = baseElement.querySelector(".action-bar")!;
+      const zone = requireElement(baseElement, ".action-bar-zone");
+      const bar = requireElement(baseElement, ".action-bar");
 
       flick(zone, 300, 290); // deltaY = -10, below 30px threshold
 
@@ -116,8 +124,8 @@ describe("ActionBar", () => {
           <button>Action</button>
         </ActionBar>
       ));
-      const zone = baseElement.querySelector(".action-bar-zone")!;
-      const bar = baseElement.querySelector(".action-bar")!;
+      const zone = requireElement(baseElement, ".action-bar-zone");
+      const bar = requireElement(baseElement, ".action-bar");
 
       // Show it first
       flick(zone, 300, 250);
@@ -135,15 +143,15 @@ describe("ActionBar", () => {
           <button>Action</button>
         </ActionBar>
       ));
-      const zone = baseElement.querySelector(".action-bar-zone")!;
-      const bar = baseElement.querySelector(".action-bar")!;
+      const zone = requireElement(baseElement, ".action-bar-zone");
+      const bar = requireElement(baseElement, ".action-bar");
 
       // Show it first
       flick(zone, 300, 250);
       expect(bar.classList.contains("action-bar--visible")).toBe(true);
 
       // Tap inside the bar
-      const button = bar.querySelector("button")!;
+      const button = requireElement(bar, "button");
       tap(button);
 
       expect(bar.classList.contains("action-bar--visible")).toBe(true);

--- a/tauri-app/src/components/ActionBar.tsx
+++ b/tauri-app/src/components/ActionBar.tsx
@@ -1,4 +1,5 @@
-import { type JSX, createSignal, onMount, onCleanup } from "solid-js";
+import { createSignal, onMount, onCleanup } from "solid-js";
+import type { JSX } from "solid-js";
 
 interface ActionBarProps {
   children: JSX.Element;
@@ -7,7 +8,7 @@ interface ActionBarProps {
 const FLICK_DISTANCE = 30;
 const FLICK_MAX_DURATION = 300;
 
-export default function ActionBar(props: ActionBarProps) {
+export default function ActionBar(props: ActionBarProps): JSX.Element {
   const [visible, setVisible] = createSignal(false);
   let barRef!: HTMLDivElement;
 

--- a/tauri-app/src/components/ConfirmDialog.test.tsx
+++ b/tauri-app/src/components/ConfirmDialog.test.tsx
@@ -37,7 +37,7 @@ describe("ConfirmDialog", () => {
   });
 
   it("calls onConfirm when delete button is clicked", async () => {
-    const onConfirm = vi.fn();
+    const onConfirm = vi.fn<() => void>();
     const { baseElement } = render(() => (
       <ConfirmDialog
         open={true}
@@ -50,11 +50,11 @@ describe("ConfirmDialog", () => {
     const screen = page.elementLocator(baseElement);
 
     await userEvent.click(screen.getByRole("button", { name: "削除" }));
-    expect(onConfirm).toHaveBeenCalledOnce();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
   it("calls onCancel when cancel button is clicked", async () => {
-    const onCancel = vi.fn();
+    const onCancel = vi.fn<() => void>();
     const { baseElement } = render(() => (
       <ConfirmDialog
         open={true}
@@ -67,6 +67,6 @@ describe("ConfirmDialog", () => {
     const screen = page.elementLocator(baseElement);
 
     await userEvent.click(screen.getByRole("button", { name: "キャンセル" }));
-    expect(onCancel).toHaveBeenCalledOnce();
+    expect(onCancel).toHaveBeenCalledTimes(1);
   });
 });

--- a/tauri-app/src/components/ConfirmDialog.tsx
+++ b/tauri-app/src/components/ConfirmDialog.tsx
@@ -1,4 +1,5 @@
 import { createEffect, onCleanup } from "solid-js";
+import type { JSX } from "solid-js";
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -8,11 +9,13 @@ interface ConfirmDialogProps {
   onCancel: () => void;
 }
 
-export default function ConfirmDialog(props: ConfirmDialogProps) {
+export default function ConfirmDialog(props: ConfirmDialogProps): JSX.Element {
   let dialogRef!: HTMLDialogElement;
 
   createEffect(() => {
-    if (!dialogRef) return;
+    if (!dialogRef) {
+      return;
+    }
 
     if (props.open) {
       if (!dialogRef.open) {

--- a/tauri-app/src/components/Icon.test.tsx
+++ b/tauri-app/src/components/Icon.test.tsx
@@ -18,7 +18,10 @@ describe("Icon", () => {
     const screen = page.elementLocator(baseElement);
 
     await expect.element(screen.locator(".icon svg")).toBeInTheDocument();
-    const svg = baseElement.querySelector(".icon svg")!;
+    const svg = baseElement.querySelector(".icon svg");
+    if (!svg) {
+      throw new Error("expected the icon to render an svg");
+    }
     expect(svg.getAttribute("width")).toBe("16px");
     expect(svg.getAttribute("height")).toBe("16px");
   });

--- a/tauri-app/src/components/Icon.tsx
+++ b/tauri-app/src/components/Icon.tsx
@@ -50,12 +50,25 @@ interface IconProps extends JSX.HTMLAttributes<HTMLSpanElement> {
 
 const cache = new Map<IconName, string>();
 
-export default function Icon(props: IconProps) {
+function applyIcon(el: HTMLSpanElement | undefined, svg: string, size: number) {
+  if (!el) {
+    return;
+  }
+  el.innerHTML = svg;
+  const svgEl = el.querySelector("svg");
+  if (svgEl) {
+    const s = `${size}px`;
+    svgEl.setAttribute("width", s);
+    svgEl.setAttribute("height", s);
+  }
+}
+
+export default function Icon(props: IconProps): JSX.Element {
   const [local, rest] = splitProps(props, ["name", "size"]);
   let ref: HTMLSpanElement | undefined;
 
   createEffect(() => {
-    const name = local.name;
+    const { name } = local;
     const size = local.size ?? 24;
 
     const cached = cache.get(name);
@@ -65,28 +78,17 @@ export default function Icon(props: IconProps) {
     }
 
     const currentName = name;
-    void ICONS[name]().then((mod) => {
+    void (async () => {
+      const mod = await ICONS[currentName]();
       const svg = mod.default as string;
       cache.set(currentName, svg);
       if (local.name === currentName && ref) {
-        const currentSize = local.size ?? 24;
-        applyIcon(ref, svg, currentSize);
+        applyIcon(ref, svg, local.size ?? 24);
       }
-    });
+    })();
   });
 
   return (
     <span ref={ref} class="icon" style={{ display: "inline-flex", "line-height": 0 }} {...rest} />
   );
-}
-
-function applyIcon(el: HTMLSpanElement | undefined, svg: string, size: number) {
-  if (!el) return;
-  el.innerHTML = svg;
-  const svgEl = el.querySelector("svg");
-  if (svgEl) {
-    const s = `${size}px`;
-    svgEl.setAttribute("width", s);
-    svgEl.setAttribute("height", s);
-  }
 }

--- a/tauri-app/src/components/MarkdownPreview.tsx
+++ b/tauri-app/src/components/MarkdownPreview.tsx
@@ -1,11 +1,12 @@
 import { createSignal, createEffect, on } from "solid-js";
 import { renderMarkdown } from "../lib/markdown";
+import type { JSX } from "solid-js";
 
 interface MarkdownPreviewProps {
   source: string;
 }
 
-export default function MarkdownPreview(props: MarkdownPreviewProps) {
+export default function MarkdownPreview(props: MarkdownPreviewProps): JSX.Element {
   const [html, setHtml] = createSignal("");
 
   let renderVersion = 0;

--- a/tauri-app/src/components/MarkdownToolbar.test.tsx
+++ b/tauri-app/src/components/MarkdownToolbar.test.tsx
@@ -6,7 +6,7 @@ import MarkdownToolbar from "./MarkdownToolbar";
 
 function createMockEditor(): Editor {
   return {
-    action: vi.fn(),
+    action: vi.fn<(callback: unknown) => unknown>(),
   } as unknown as Editor;
 }
 
@@ -43,7 +43,7 @@ describe("MarkdownToolbar", () => {
 
     fireEvent.click(screen.getByLabelText("Outdent"));
 
-    expect(editor.action).toHaveBeenCalled();
+    expect(editor.action).toHaveBeenCalledWith(expect.any(Function));
   });
 
   it("hides toolbar when editor becomes undefined", () => {

--- a/tauri-app/src/components/MarkdownToolbar.tsx
+++ b/tauri-app/src/components/MarkdownToolbar.tsx
@@ -9,17 +9,20 @@ import {
   insertHrCommand,
 } from "@milkdown/kit/preset/commonmark";
 import Icon from "./Icon";
+import type { JSX } from "solid-js";
 
 interface MarkdownToolbarProps {
   editor: Editor | undefined;
 }
 
-export default function MarkdownToolbar(props: MarkdownToolbarProps) {
+export default function MarkdownToolbar(props: MarkdownToolbarProps): JSX.Element {
   const [toolbarTop, setToolbarTop] = createSignal<number | undefined>();
 
   onMount(() => {
     const vv = window.visualViewport;
-    if (!vv) return;
+    if (!vv) {
+      return;
+    }
 
     const update = () => {
       setToolbarTop(vv.offsetTop + vv.height);
@@ -34,8 +37,10 @@ export default function MarkdownToolbar(props: MarkdownToolbarProps) {
   });
 
   const exec = (run: (editor: Editor) => void) => {
-    const editor = props.editor;
-    if (!editor) return;
+    const { editor } = props;
+    if (!editor) {
+      return;
+    }
     run(editor);
     editor.action((ctx) => {
       const root = ctx.get(rootCtx) as HTMLElement;
@@ -54,9 +59,9 @@ export default function MarkdownToolbar(props: MarkdownToolbarProps) {
           role="toolbar"
           aria-label="Markdown formatting"
           style={
-            top() != null
-              ? { top: `${top()}px`, bottom: "auto", transform: "translateY(-100%)" }
-              : undefined
+            top() === undefined
+              ? undefined
+              : { top: `${top()}px`, bottom: "auto", transform: "translateY(-100%)" }
           }
         >
           <button

--- a/tauri-app/src/components/MilkdownEditor.tsx
+++ b/tauri-app/src/components/MilkdownEditor.tsx
@@ -13,36 +13,43 @@ import { getHighlighter } from "../lib/highlighter";
 import { exitCodeBlockPlugin } from "../lib/exit-code-block-plugin";
 import { createPlaceholderPlugin } from "../lib/placeholder-plugin";
 import { getShikiTheme } from "../lib/theme";
+import type { JSX } from "solid-js";
 
 interface MilkdownEditorProps {
   defaultValue?: string;
   onChange?: (markdown: string) => void;
   placeholder?: string;
-  onEditorReady?: (editor: Editor | undefined) => void;
+  onEditorReady?: (editor?: Editor) => void;
 }
 
-export default function MilkdownEditor(props: MilkdownEditorProps) {
+export default function MilkdownEditor(props: MilkdownEditorProps): JSX.Element {
   let ref: HTMLDivElement | undefined;
   let editor: Editor | undefined;
 
   onMount(async () => {
-    if (!ref) return;
+    const root = ref;
+    if (!root) {
+      return;
+    }
 
     const highlighter = await getHighlighter();
 
-    const parser = createParser(highlighter as any, {
+    // Shiki's Highlighter type is structurally compatible but comes from a
+    // different copy of the package than the one @milkdown/plugin-highlight
+    // resolves, so the nominal types do not line up.
+    const parser = createParser(highlighter as Parameters<typeof createParser>[0], {
       theme: getShikiTheme(),
     });
 
     editor = await Editor.make()
       .config((ctx) => {
-        ctx.set(rootCtx, ref!);
+        ctx.set(rootCtx, root);
         if (props.defaultValue) {
           ctx.set(defaultValueCtx, props.defaultValue);
         }
         ctx.set(highlightPluginConfig.key, { parser });
         if (props.onChange) {
-          const onChange = props.onChange;
+          const { onChange } = props;
           ctx.get(listenerCtx).markdownUpdated((_ctx, markdown) => {
             onChange(markdown);
           });
@@ -65,18 +72,20 @@ export default function MilkdownEditor(props: MilkdownEditorProps) {
 
   onCleanup(() => {
     editor?.destroy();
-    props.onEditorReady?.(undefined);
+    props.onEditorReady?.();
   });
 
   const handleClick = (e: MouseEvent) => {
-    if (!ref) return;
+    if (!ref) {
+      return;
+    }
     const prosemirror = ref.querySelector(".ProseMirror") as HTMLElement | null;
     if (prosemirror && e.target === ref) {
       prosemirror.focus();
     }
   };
 
-  return <div ref={ref} class="milkdown-editor" onClick={handleClick} />;
+  return <div ref={ref} class="milkdown-editor" role="presentation" onClick={handleClick} />;
 }
 
 export { type MilkdownEditorProps };

--- a/tauri-app/src/components/SyncButton.tsx
+++ b/tauri-app/src/components/SyncButton.tsx
@@ -3,13 +3,17 @@ import { useNavigate } from "@solidjs/router";
 import { typedInvoke } from "../lib/commands";
 import { EVENTS } from "../lib/events";
 import { ROUTES } from "../lib/routes";
-import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import Icon, { type IconName } from "./Icon";
-import { describeSyncError, describeSyncResult, type SyncResultPayload } from "../lib/sync-status";
+import { listen } from "@tauri-apps/api/event";
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import Icon from "./Icon";
+import type { IconName } from "./Icon";
+import { describeSyncError, describeSyncResult } from "../lib/sync-status";
+import type { SyncResultPayload } from "../lib/sync-status";
+import type { JSX } from "solid-js";
 
 type SyncStatus = "idle" | "syncing" | "success" | "error" | "needs-setup";
 
-export default function SyncButton() {
+export default function SyncButton(): JSX.Element {
   const [status, setStatus] = createSignal<SyncStatus>("idle");
   const [message, setMessage] = createSignal("");
   const navigate = useNavigate();
@@ -17,7 +21,9 @@ export default function SyncButton() {
   const unlisteners: UnlistenFn[] = [];
 
   const clearResetTimer = () => {
-    if (resetTimer) clearTimeout(resetTimer);
+    if (resetTimer) {
+      clearTimeout(resetTimer);
+    }
     resetTimer = undefined;
   };
 
@@ -62,7 +68,9 @@ export default function SyncButton() {
 
   const applyError = (err: unknown) => {
     const ui = describeSyncError(err);
-    if (!ui) return;
+    if (!ui) {
+      return;
+    }
     showPersistent(ui.status, ui.message);
   };
 
@@ -92,12 +100,16 @@ export default function SyncButton() {
 
   onCleanup(() => {
     clearResetTimer();
-    for (const unlisten of unlisteners) unlisten();
+    for (const unlisten of unlisteners) {
+      unlisten();
+    }
   });
 
   const handleClick = async () => {
     const s = status();
-    if (s === "syncing") return;
+    if (s === "syncing") {
+      return;
+    }
     if (s === "needs-setup") {
       navigate(ROUTES.SETTINGS);
       return;
@@ -107,32 +119,45 @@ export default function SyncButton() {
     try {
       await typedInvoke("sync_start");
       // 結果表示は sync-complete / sync-error イベント側で行う
-    } catch (e) {
-      applyError(e);
+    } catch (error) {
+      applyError(error);
     }
   };
 
   const iconName = (): IconName => {
     switch (status()) {
-      case "syncing":
+      case "syncing": {
         return "cloud-arrow-up";
-      case "error":
+      }
+      case "error": {
         return "cloud-warning";
-      case "needs-setup":
+      }
+      case "needs-setup": {
         return "cloud-slash";
-      default:
+      }
+      default: {
         return "cloud-check";
+      }
     }
   };
 
   const tooltip = () => {
     switch (status()) {
-      case "error":
+      case "error": {
         return `${message()} — click to retry`;
-      case "syncing":
+      }
+      case "syncing": {
         return "Syncing...";
-      default:
+      }
+      default: {
         return message() || "Sync now";
+      }
+    }
+  };
+
+  const dismissToast = (): void => {
+    if (status() !== "syncing") {
+      setMessage("");
     }
   };
 
@@ -154,16 +179,15 @@ export default function SyncButton() {
         <Icon name={iconName()} size={18} />
       </button>
       <Show when={message()}>
-        <div
+        <button
+          type="button"
           class="sync-toast"
           data-status={status()}
-          role="status"
-          onClick={() => {
-            if (status() !== "syncing") setMessage("");
-          }}
+          aria-live="polite"
+          onClick={dismissToast}
         >
           {message()}
-        </div>
+        </button>
       </Show>
     </>
   );

--- a/tauri-app/src/components/TimelineEntry.tsx
+++ b/tauri-app/src/components/TimelineEntry.tsx
@@ -1,4 +1,5 @@
 import { Show, createMemo } from "solid-js";
+import type { JSX } from "solid-js";
 import Icon from "./Icon";
 import MarkdownPreview from "./MarkdownPreview";
 import {
@@ -14,7 +15,7 @@ interface TimelineEntryProps {
   markdown?: boolean;
 }
 
-export default function TimelineEntry(props: TimelineEntryProps) {
+export default function TimelineEntry(props: TimelineEntryProps): JSX.Element {
   const parsed = createMemo(() => parseTimelineEntry(props.raw));
 
   return (

--- a/tauri-app/src/components/ToggleMenu.test.tsx
+++ b/tauri-app/src/components/ToggleMenu.test.tsx
@@ -33,7 +33,7 @@ describe("ToggleMenu", () => {
 
     await expect.element(screen.getByText("Timeline")).toBeInTheDocument();
     const links = baseElement.querySelectorAll("a.toggle-menu-item");
-    const hrefs = Array.from(links).map((a) => a.getAttribute("href"));
-    expect(hrefs).toEqual(["/", "/notes", "/tasks", "/settings"]);
+    const hrefs = [...links].map((a) => a.getAttribute("href"));
+    expect(hrefs).toStrictEqual(["/", "/notes", "/tasks", "/settings"]);
   });
 });

--- a/tauri-app/src/components/ToggleMenu.tsx
+++ b/tauri-app/src/components/ToggleMenu.tsx
@@ -1,4 +1,4 @@
-import { type Accessor } from "solid-js";
+import type { Accessor, JSX } from "solid-js";
 import { A } from "@solidjs/router";
 import Icon from "./Icon";
 import { ROUTES, MODE_ICONS, MODE_LABELS } from "../lib/routes";
@@ -8,7 +8,7 @@ interface ToggleMenuProps {
   onClose: () => void;
 }
 
-export default function ToggleMenu(props: ToggleMenuProps) {
+export default function ToggleMenu(props: ToggleMenuProps): JSX.Element {
   return (
     <nav class="toggle-menu" classList={{ open: props.isOpen() }}>
       <A

--- a/tauri-app/src/layouts/AppLayout.tsx
+++ b/tauri-app/src/layouts/AppLayout.tsx
@@ -1,43 +1,48 @@
 import { createSignal, createEffect, onCleanup } from "solid-js";
 import { useLocation } from "@solidjs/router";
-import Icon, { type IconName } from "../components/Icon";
+import Icon from "../components/Icon";
+import type { IconName } from "../components/Icon";
 import SyncButton from "../components/SyncButton";
 import ToggleMenu from "../components/ToggleMenu";
-import { MODE_ICONS, MODE_LABELS, type RoutePath } from "../lib/routes";
+import { MODE_ICONS, MODE_LABELS } from "../lib/routes";
+import type { RoutePath } from "../lib/routes";
+import type { JSX } from "solid-js";
 
 interface AppLayoutProps {
-  children?: any;
+  children?: JSX.Element;
 }
 
 type Theme = "light" | "dark" | "system";
 
 function getInitialTheme(): Theme {
   const saved = localStorage.getItem("theme") as Theme | null;
-  if (saved === "light" || saved === "dark" || saved === "system") return saved;
+  if (saved === "light" || saved === "dark" || saved === "system") {
+    return saved;
+  }
   return "system";
 }
 
 function getResolvedTheme(theme: Theme): "light" | "dark" {
   if (theme === "system") {
-    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    return globalThis.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
   }
   return theme;
 }
 
 function applyTheme(theme: Theme) {
   const resolved = getResolvedTheme(theme);
-  document.documentElement.setAttribute("data-theme", resolved);
+  document.documentElement.dataset.theme = resolved;
   localStorage.setItem("theme", theme);
 }
 
-export default function AppLayout(props: AppLayoutProps) {
+export default function AppLayout(props: AppLayoutProps): JSX.Element {
   const [menuOpen, setMenuOpen] = createSignal(false);
   const [theme, setTheme] = createSignal<Theme>(getInitialTheme());
   const location = useLocation();
 
   applyTheme(theme());
 
-  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+  const mediaQuery = globalThis.matchMedia("(prefers-color-scheme: dark)");
   const handleMediaChange = () => {
     if (theme() === "system") {
       applyTheme("system");
@@ -63,7 +68,9 @@ export default function AppLayout(props: AppLayoutProps) {
   // 現在のテーマを表すアイコンを表示する
   const themeIcon = (): IconName => {
     const t = theme();
-    if (t === "system") return "circle-half";
+    if (t === "system") {
+      return "circle-half";
+    }
     return t === "dark" ? "moon" : "sun";
   };
 

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -32,7 +32,7 @@ interface LocationArgs {
   longitude: number | null;
 }
 
-type CommandMap = {
+interface CommandMap {
   save_quick_capture: { args: { text: string } & LocationArgs; result: void };
   read_timeline: { args: void; result: string[] };
   list_timeline_dates: { args: void; result: string[] };
@@ -77,11 +77,11 @@ type CommandMap = {
   get_sync_config: { args: void; result: SyncConfig };
   save_sync_config: { args: { config: SyncConfig }; result: void };
   is_sync_config_editable: { args: void; result: boolean };
-};
+}
 
 export type CommandName = keyof CommandMap;
 
-export async function typedInvoke<K extends CommandName>(
+export function typedInvoke<K extends CommandName>(
   cmd: K,
   ...args: CommandMap[K]["args"] extends void ? [] : [CommandMap[K]["args"]]
 ): Promise<CommandMap[K]["result"]> {

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -23,7 +23,7 @@ export interface Task {
   body: string;
 }
 
-export interface SyncConfig {
+interface SyncConfig {
   workers_url: string;
 }
 

--- a/tauri-app/src/lib/exit-code-block-plugin.ts
+++ b/tauri-app/src/lib/exit-code-block-plugin.ts
@@ -6,21 +6,25 @@ import { keymap } from "@milkdown/kit/prose/keymap";
  * Exit a code block by pressing Mod+Enter (Cmd+Enter on Mac).
  * Inserts a new paragraph after the code block and moves the cursor there.
  */
-export const exitCodeBlockPlugin = $prose(() => {
-  return keymap({
+export const exitCodeBlockPlugin = $prose(() =>
+  keymap({
     "Mod-Enter": (state, dispatch) => {
       const { $from } = state.selection;
       const node = $from.node($from.depth);
-      if (node.type.name !== "code_block") return false;
+      if (node.type.name !== "code_block") {
+        return false;
+      }
 
-      if (!dispatch) return true;
+      if (!dispatch) {
+        return true;
+      }
       const endOfBlock = $from.after($from.depth);
-      const tr = state.tr;
+      const { tr } = state;
       const paragraphType = state.schema.nodes.paragraph;
       tr.insert(endOfBlock, paragraphType.create());
       tr.setSelection(TextSelection.near(tr.doc.resolve(endOfBlock + 1)));
       dispatch(tr);
       return true;
     },
-  });
-});
+  }),
+);

--- a/tauri-app/src/lib/highlighter.ts
+++ b/tauri-app/src/lib/highlighter.ts
@@ -1,4 +1,5 @@
-import { createHighlighterCore, type HighlighterCore } from "shiki/core";
+import { createHighlighterCore } from "shiki/core";
+import type { HighlighterCore } from "shiki/core";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 
 let highlighterPromise: Promise<HighlighterCore> | undefined;

--- a/tauri-app/src/lib/markdown.ts
+++ b/tauri-app/src/lib/markdown.ts
@@ -1,7 +1,7 @@
 import MarkdownIt from "markdown-it";
 import { getHighlighter } from "./highlighter";
 
-const md = MarkdownIt({
+const md = new MarkdownIt({
   html: false,
   linkify: true,
   typographer: true,
@@ -21,7 +21,7 @@ interface RenderEnv {
   __shikiBlocks?: ShikiBlock[];
 }
 
-const fenceMd = MarkdownIt({
+const fenceMd = new MarkdownIt({
   html: false,
   linkify: true,
   typographer: true,

--- a/tauri-app/src/lib/parse-timeline.test.ts
+++ b/tauri-app/src/lib/parse-timeline.test.ts
@@ -13,7 +13,7 @@ describe("parseTimelineEntry", () => {
     const result = parseTimelineEntry(raw);
     expect(result.time).toBe("14:30:45");
     expect(result.text).toBe("hello world");
-    expect(result.context).toEqual({ battery: 82, is_charging: false });
+    expect(result.context).toStrictEqual({ battery: 82, is_charging: false });
   });
 
   it("parses entry without context (old format)", () => {
@@ -29,7 +29,7 @@ describe("parseTimelineEntry", () => {
     const result = parseTimelineEntry(raw);
     expect(result.time).toBe("14:30:45");
     expect(result.text).toBe("code {foo}");
-    expect(result.context).toEqual({ battery: 50 });
+    expect(result.context).toStrictEqual({ battery: 50 });
   });
 
   it("normalizes empty object {} to null", () => {
@@ -57,10 +57,11 @@ describe("parseTimelineEntry", () => {
   });
 });
 
-describe("getBatteryIcon", () => {
-  const ctx = (battery: number, charging = false) =>
-    ({ battery, is_charging: charging, os: "", arch: "" }) as const;
+function ctx(battery: number, charging = false) {
+  return { battery, is_charging: charging, os: "", arch: "" } as const;
+}
 
+describe("getBatteryIcon", () => {
   it("returns battery-charging when charging", () => {
     expect(getBatteryIcon(ctx(50, true))).toBe("battery-charging");
   });

--- a/tauri-app/src/lib/parse-timeline.ts
+++ b/tauri-app/src/lib/parse-timeline.ts
@@ -26,12 +26,12 @@ export function parseTimelineEntry(raw: string): ParsedEntry {
     return { time: "", text: raw, context: null };
   }
 
-  const time = timeMatch[1];
+  const [, time] = timeMatch;
   const rest = raw.slice(timeMatch[0].length);
 
   // Try to extract context JSON from the last " {" in the line
   const lastBrace = rest.lastIndexOf(" {");
-  if (lastBrace >= 0) {
+  if (lastBrace !== -1) {
     const jsonCandidate = rest.slice(lastBrace + 1);
     try {
       const parsed = JSON.parse(jsonCandidate);
@@ -48,37 +48,61 @@ export function parseTimelineEntry(raw: string): ParsedEntry {
 }
 
 export function getBatteryIcon(ctx: DeviceContext): IconName | null {
-  if (ctx.battery == null) return null;
-  if (ctx.is_charging) return "battery-charging";
-  if (ctx.battery >= 75) return "battery-full";
-  if (ctx.battery >= 50) return "battery-high";
-  if (ctx.battery >= 25) return "battery-medium";
-  if (ctx.battery >= 5) return "battery-low";
+  if (ctx.battery === undefined) {
+    return null;
+  }
+  if (ctx.is_charging) {
+    return "battery-charging";
+  }
+  if (ctx.battery >= 75) {
+    return "battery-full";
+  }
+  if (ctx.battery >= 50) {
+    return "battery-high";
+  }
+  if (ctx.battery >= 25) {
+    return "battery-medium";
+  }
+  if (ctx.battery >= 5) {
+    return "battery-low";
+  }
   return "battery-empty";
 }
 
 export function getNetworkIcon(ctx: DeviceContext): IconName | null {
-  if (!ctx.network_type) return null;
+  if (!ctx.network_type) {
+    return null;
+  }
   switch (ctx.network_type) {
-    case "WiFi":
+    case "WiFi": {
       return "wifi-high";
-    case "Mobile":
+    }
+    case "Mobile": {
       return "cell-signal-full";
-    case "Offline":
+    }
+    case "Offline": {
       return "wifi-slash";
-    default:
+    }
+    default: {
       return null;
+    }
   }
 }
 
 export function hasLocation(ctx: DeviceContext): boolean {
-  return ctx.location != null;
+  return ctx.location !== undefined;
 }
 
 export function getOsLabel(ctx: DeviceContext): string | null {
-  if (!ctx.os) return null;
+  if (!ctx.os) {
+    return null;
+  }
   const parts: string[] = [ctx.os];
-  if (ctx.os_version) parts.push(ctx.os_version);
-  if (ctx.arch) parts.push(ctx.arch);
+  if (ctx.os_version) {
+    parts.push(ctx.os_version);
+  }
+  if (ctx.arch) {
+    parts.push(ctx.arch);
+  }
   return parts.join(" ");
 }

--- a/tauri-app/src/lib/placeholder-plugin.ts
+++ b/tauri-app/src/lib/placeholder-plugin.ts
@@ -4,27 +4,28 @@ import { DecorationSet, Decoration } from "@milkdown/kit/prose/view";
 
 const placeholderPluginKey = new PluginKey("placeholder");
 
-export function createPlaceholderPlugin(text: string) {
-  return $prose(() => {
-    return new Plugin({
-      key: placeholderPluginKey,
-      props: {
-        decorations(state) {
-          const { doc } = state;
-          if (
-            doc.childCount === 1 &&
-            doc.firstChild?.isTextblock &&
-            doc.firstChild.content.size === 0
-          ) {
-            const placeholder = Decoration.node(0, doc.firstChild.nodeSize, {
-              class: "empty-node",
-              "data-placeholder": text,
-            });
-            return DecorationSet.create(doc, [placeholder]);
-          }
-          return DecorationSet.empty;
+export function createPlaceholderPlugin(text: string): ReturnType<typeof $prose> {
+  return $prose(
+    () =>
+      new Plugin({
+        key: placeholderPluginKey,
+        props: {
+          decorations(state) {
+            const { doc } = state;
+            if (
+              doc.childCount === 1 &&
+              doc.firstChild?.isTextblock &&
+              doc.firstChild.content.size === 0
+            ) {
+              const placeholder = Decoration.node(0, doc.firstChild.nodeSize, {
+                class: "empty-node",
+                "data-placeholder": text,
+              });
+              return DecorationSet.create(doc, [placeholder]);
+            }
+            return DecorationSet.empty;
+          },
         },
-      },
-    });
-  });
+      }),
+  );
 }

--- a/tauri-app/src/lib/sync-status.ts
+++ b/tauri-app/src/lib/sync-status.ts
@@ -32,8 +32,12 @@ export function describeSyncResult(result: SyncResultPayload): SyncUiState {
   }
 
   const parts: string[] = [];
-  if (result.uploaded) parts.push(`↑${result.uploaded}`);
-  if (result.downloaded) parts.push(`↓${result.downloaded}`);
+  if (result.uploaded) {
+    parts.push(`↑${result.uploaded}`);
+  }
+  if (result.downloaded) {
+    parts.push(`↓${result.downloaded}`);
+  }
   if (result.deleted_remote + result.deleted_local) {
     parts.push(`−${result.deleted_remote + result.deleted_local}`);
   }
@@ -51,7 +55,9 @@ export function describeSyncError(err: unknown): SyncUiState | null {
       ? (err as SyncErrorInfo)
       : { kind: "other", message: String(err) };
 
-  if (info.kind === "busy") return null;
+  if (info.kind === "busy") {
+    return null;
+  }
   if (info.kind === "notConfigured" || info.kind === "notAuthenticated") {
     return { status: "needs-setup", message: info.message };
   }

--- a/tauri-app/src/lib/sync-status.ts
+++ b/tauri-app/src/lib/sync-status.ts
@@ -7,7 +7,7 @@ export interface SyncResultPayload {
   errors: string[];
 }
 
-export interface SyncErrorInfo {
+interface SyncErrorInfo {
   kind: string;
   message: string;
 }

--- a/tauri-app/src/lib/theme.test.ts
+++ b/tauri-app/src/lib/theme.test.ts
@@ -3,16 +3,16 @@ import { getShikiTheme } from "./theme";
 
 describe("getShikiTheme", () => {
   afterEach(() => {
-    document.documentElement.removeAttribute("data-theme");
+    delete document.documentElement.dataset.theme;
   });
 
   it("returns github-dark-default when data-theme is dark", () => {
-    document.documentElement.setAttribute("data-theme", "dark");
+    document.documentElement.dataset.theme = "dark";
     expect(getShikiTheme()).toBe("github-dark-default");
   });
 
   it("returns github-light-default when data-theme is light", () => {
-    document.documentElement.setAttribute("data-theme", "light");
+    document.documentElement.dataset.theme = "light";
     expect(getShikiTheme()).toBe("github-light-default");
   });
 

--- a/tauri-app/src/lib/theme.ts
+++ b/tauri-app/src/lib/theme.ts
@@ -1,6 +1,6 @@
 export type ShikiTheme = "github-dark-default" | "github-light-default";
 
 export function getShikiTheme(): ShikiTheme {
-  const resolved = document.documentElement.getAttribute("data-theme");
+  const resolved = document.documentElement.dataset.theme;
   return resolved === "light" ? "github-light-default" : "github-dark-default";
 }

--- a/tauri-app/src/main.tsx
+++ b/tauri-app/src/main.tsx
@@ -2,4 +2,9 @@ import { render } from "solid-js/web";
 import App from "./App";
 import "./index.css";
 
-render(() => <App />, document.getElementById("root")!);
+const root = document.querySelector("#root");
+if (!root) {
+  throw new Error("missing #root element");
+}
+
+render(() => <App />, root);

--- a/tauri-app/src/styles/layout.css
+++ b/tauri-app/src/styles/layout.css
@@ -65,6 +65,9 @@
 
 /* 同期状態のトースト: ヘッダー直下に表示し、クリックで閉じる */
 .sync-toast {
+  appearance: none;
+  font-family: inherit;
+  text-align: start;
   position: absolute;
   top: calc(var(--size-8) + var(--size-2));
   right: var(--size-3);

--- a/tauri-app/src/views/Notes.tsx
+++ b/tauri-app/src/views/Notes.tsx
@@ -10,7 +10,8 @@ import {
   Match,
 } from "solid-js";
 import type { Editor } from "@milkdown/kit/core";
-import { typedInvoke, type Note } from "../lib/commands";
+import { typedInvoke } from "../lib/commands";
+import type { Note } from "../lib/commands";
 import MilkdownEditor from "../components/MilkdownEditor";
 import MarkdownPreview from "../components/MarkdownPreview";
 import MarkdownToolbar from "../components/MarkdownToolbar";
@@ -18,14 +19,33 @@ import { getLocation } from "../lib/location";
 import ConfirmDialog from "../components/ConfirmDialog";
 import ActionBar from "../components/ActionBar";
 import Icon from "../components/Icon";
+import type { JSX } from "solid-js";
 
 type ViewMode = "editor" | "list" | "preview";
 
-async function fetchNotes(): Promise<Note[]> {
+function fetchNotes(): Promise<Note[]> {
   return typedInvoke("list_notes");
 }
 
-export default function Notes() {
+function extractBody(content: string): string {
+  const match = content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
+  return match ? match[1].trim() : content;
+}
+
+function formatTime(time?: string): string {
+  if (!time) {
+    return "";
+  }
+  const d = new Date(time);
+  return d.toLocaleString("ja-JP", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function Notes(): JSX.Element {
   const [body, setBody] = createSignal("");
   const [tagsInput, setTagsInput] = createSignal("");
   const [draftPath, setDraftPath] = createSignal<string | null>(null);
@@ -34,7 +54,7 @@ export default function Notes() {
   const [selectedNote, setSelectedNote] = createSignal<Note | null>(null);
   const [noteContent, setNoteContent] = createSignal("");
   const [confirmOpen, setConfirmOpen] = createSignal(false);
-  const [error, setError] = createSignal("");
+  const [errorMessage, setErrorMessage] = createSignal("");
   const [editorInstance, setEditorInstance] = createSignal<Editor | undefined>();
   const [notes, { refetch: refetchNotes }] = createResource(fetchNotes);
 
@@ -51,7 +71,9 @@ export default function Notes() {
 
   const doSave = async () => {
     const currentBody = body();
-    if (!currentBody.trim()) return;
+    if (!currentBody.trim()) {
+      return;
+    }
 
     const tags = parseTags();
     setStatus("saving");
@@ -82,42 +104,46 @@ export default function Notes() {
     }
   };
 
-  const save = () => {
-    saveChain = saveChain.then(doSave);
+  const save = (): Promise<void> => {
+    const previous = saveChain;
+    saveChain = (async () => {
+      await previous;
+      await doSave();
+    })();
     return saveChain;
   };
 
   const scheduleSave = () => {
-    if (debounceTimer) clearTimeout(debounceTimer);
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
     debounceTimer = setTimeout(save, 1000);
   };
 
   createEffect(
     on(body, () => {
-      if (body().trim() && !isHydrating) scheduleSave();
+      if (body().trim() && !isHydrating) {
+        scheduleSave();
+      }
     }),
   );
 
   createEffect(
     on(tagsInput, () => {
-      if (draftPath() && !isHydrating) scheduleSave();
+      if (draftPath() && !isHydrating) {
+        scheduleSave();
+      }
     }),
   );
 
   onCleanup(() => {
     if (debounceTimer) {
       clearTimeout(debounceTimer);
-      if (body().trim()) void save();
+      if (body().trim()) {
+        void save();
+      }
     }
   });
-
-  const handleDone = async () => {
-    if (debounceTimer) clearTimeout(debounceTimer);
-    if (body().trim()) {
-      await save();
-    }
-    resetEditor();
-  };
 
   const resetEditor = () => {
     setBody("");
@@ -127,6 +153,16 @@ export default function Notes() {
     setEditorInstance(undefined);
   };
 
+  const handleDone = async () => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
+    if (body().trim()) {
+      await save();
+    }
+    resetEditor();
+  };
+
   const openList = () => {
     refetchNotes();
     setViewMode("list");
@@ -134,13 +170,13 @@ export default function Notes() {
 
   const openPreview = async (note: Note) => {
     try {
-      setError("");
+      setErrorMessage("");
       const content = await typedInvoke("read_note", { filename: note.filename });
       setSelectedNote(note);
       setNoteContent(content);
       setViewMode("preview");
-    } catch (e) {
-      setError(String(e));
+    } catch (error) {
+      setErrorMessage(String(error));
     }
   };
 
@@ -151,7 +187,9 @@ export default function Notes() {
 
   const editNote = () => {
     const note = selectedNote();
-    if (!note) return;
+    if (!note) {
+      return;
+    }
     const content = noteContent();
     const bodyText = extractBody(content);
     setEditorInstance(undefined);
@@ -170,7 +208,9 @@ export default function Notes() {
 
   const handleDelete = async () => {
     const note = selectedNote();
-    if (!note) return;
+    if (!note) {
+      return;
+    }
     setConfirmOpen(false);
     try {
       await typedInvoke("delete_note", { filename: note.filename });
@@ -178,8 +218,8 @@ export default function Notes() {
       setNoteContent("");
       refetchNotes();
       setViewMode("list");
-    } catch (e) {
-      setError(String(e));
+    } catch (error) {
+      setErrorMessage(String(error));
     }
   };
 
@@ -191,17 +231,6 @@ export default function Notes() {
     } else {
       setViewMode("editor");
     }
-  };
-
-  const formatTime = (time?: string) => {
-    if (!time) return "";
-    const d = new Date(time);
-    return d.toLocaleString("ja-JP", {
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
   };
 
   return (
@@ -245,8 +274,8 @@ export default function Notes() {
 
         <Match when={viewMode() === "list"}>
           <div class="notes-list-container">
-            <Show when={error()}>
-              <p class="error-text">{error()}</p>
+            <Show when={errorMessage()}>
+              <p class="error-text">{errorMessage()}</p>
             </Show>
             <div class="browse-list">
               <Show when={notes()?.length} fallback={<p class="empty-state">ノートなし</p>}>
@@ -281,8 +310,8 @@ export default function Notes() {
 
         <Match when={viewMode() === "preview"}>
           <div class="note-preview-container">
-            <Show when={error()}>
-              <p class="error-text">{error()}</p>
+            <Show when={errorMessage()}>
+              <p class="error-text">{errorMessage()}</p>
             </Show>
             <MarkdownPreview source={noteContent()} />
           </div>
@@ -310,9 +339,4 @@ export default function Notes() {
       </Switch>
     </div>
   );
-}
-
-function extractBody(content: string): string {
-  const match = content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
-  return match ? match[1].trim() : content;
 }

--- a/tauri-app/src/views/Settings.tsx
+++ b/tauri-app/src/views/Settings.tsx
@@ -1,10 +1,12 @@
 import { createSignal, onMount, onCleanup, Show } from "solid-js";
 import { typedInvoke } from "../lib/commands";
 import { EVENTS } from "../lib/events";
-import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { listen } from "@tauri-apps/api/event";
+import type { UnlistenFn } from "@tauri-apps/api/event";
 import "../styles/settings.css";
+import type { JSX } from "solid-js";
 
-export default function Settings() {
+export default function Settings(): JSX.Element {
   const [workersUrl, setWorkersUrl] = createSignal("");
   const [authenticated, setAuthenticated] = createSignal(false);
   const [editable, setEditable] = createSignal(false);
@@ -51,7 +53,9 @@ export default function Settings() {
   });
 
   onCleanup(() => {
-    for (const unlisten of unlisteners) unlisten();
+    for (const unlisten of unlisteners) {
+      unlisten();
+    }
   });
 
   const handleSave = async () => {
@@ -63,8 +67,8 @@ export default function Settings() {
       });
       setMessage("Saved");
       setTimeout(() => setMessage(""), 2000);
-    } catch (e) {
-      setMessage(`Error: ${e}`);
+    } catch (error) {
+      setMessage(`Error: ${error}`);
     } finally {
       setSaving(false);
     }
@@ -82,8 +86,8 @@ export default function Settings() {
         setMessage("Authenticated");
         setTimeout(() => setMessage(""), 2000);
       }
-    } catch (e) {
-      setMessage(`Auth error: ${e}`);
+    } catch (error) {
+      setMessage(`Auth error: ${error}`);
     }
   };
 
@@ -93,8 +97,8 @@ export default function Settings() {
       setAuthenticated(false);
       setMessage("Logged out");
       setTimeout(() => setMessage(""), 2000);
-    } catch (e) {
-      setMessage(`Error: ${e}`);
+    } catch (error) {
+      setMessage(`Error: ${error}`);
     }
   };
 

--- a/tauri-app/src/views/Tasks.tsx
+++ b/tauri-app/src/views/Tasks.tsx
@@ -9,12 +9,14 @@ import {
   Switch,
   Match,
 } from "solid-js";
-import { typedInvoke, type Project, type Task } from "../lib/commands";
+import { typedInvoke } from "../lib/commands";
+import type { Project, Task } from "../lib/commands";
 import Icon from "../components/Icon";
 import ActionBar from "../components/ActionBar";
 import MilkdownEditor from "../components/MilkdownEditor";
 import MarkdownPreview from "../components/MarkdownPreview";
 import ConfirmDialog from "../components/ConfirmDialog";
+import type { JSX } from "solid-js";
 
 type ViewMode = "list" | "edit" | "preview";
 
@@ -22,23 +24,44 @@ function toSlug(name: string): string {
   return name
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "");
+    .replaceAll(/[^a-z0-9]+/g, "-")
+    .replaceAll(/^-|-$/g, "");
 }
 
-async function fetchProjects(): Promise<Project[]> {
+function fetchProjects(): Promise<Project[]> {
   return typedInvoke("list_projects");
 }
 
-export default function Tasks() {
+function isActiveTask(task: Task): boolean {
+  return !task.completed;
+}
+
+function formatTime(time?: string): string {
+  if (!time) {
+    return "";
+  }
+  const d = new Date(time);
+  return d.toLocaleString("ja-JP", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function Tasks(): JSX.Element {
   const [selectedProject, setSelectedProject] = createSignal<string>("");
   const [projects, { refetch: refetchProjects }] = createResource(fetchProjects);
   const [tasks, { refetch: refetchTasks }] = createResource(selectedProject, (slug) => {
-    if (!slug) return Promise.resolve([]);
+    if (!slug) {
+      return Promise.resolve([]);
+    }
     return typedInvoke("list_active_tasks", { projectSlug: slug });
   });
   const [doneTasks, { refetch: refetchDoneTasks }] = createResource(selectedProject, (slug) => {
-    if (!slug) return Promise.resolve([]);
+    if (!slug) {
+      return Promise.resolve([]);
+    }
     return typedInvoke("list_done_tasks", { projectSlug: slug });
   });
 
@@ -46,7 +69,7 @@ export default function Tasks() {
   const [showNewProject, setShowNewProject] = createSignal(false);
   const [newProjectName, setNewProjectName] = createSignal("");
   const [newTaskTitle, setNewTaskTitle] = createSignal("");
-  const [error, setError] = createSignal("");
+  const [errorMessage, setErrorMessage] = createSignal("");
   const [viewMode, setViewMode] = createSignal<ViewMode>("list");
   const [selectedTask, setSelectedTask] = createSignal<Task | null>(null);
   const [confirmOpen, setConfirmOpen] = createSignal(false);
@@ -69,7 +92,9 @@ export default function Tasks() {
   const doSaveTask = async () => {
     const task = selectedTask();
     const slug = selectedProject();
-    if (!task || !slug) return;
+    if (!task || !slug) {
+      return;
+    }
 
     setSaveStatus("saving");
     try {
@@ -86,29 +111,41 @@ export default function Tasks() {
     }
   };
 
-  const saveTask = () => {
-    saveChain = saveChain.then(doSaveTask);
+  const saveTask = (): Promise<void> => {
+    const previous = saveChain;
+    saveChain = (async () => {
+      await previous;
+      await doSaveTask();
+    })();
     return saveChain;
   };
 
   const scheduleSaveTask = () => {
-    if (saveTimer) clearTimeout(saveTimer);
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+    }
     saveTimer = setTimeout(saveTask, 1000);
   };
 
   createEffect(
     on(taskBody, () => {
-      if (selectedTask() && !isHydrating) scheduleSaveTask();
+      if (selectedTask() && !isHydrating) {
+        scheduleSaveTask();
+      }
     }),
   );
   createEffect(
     on(taskTitle, () => {
-      if (selectedTask() && !isHydrating) scheduleSaveTask();
+      if (selectedTask() && !isHydrating) {
+        scheduleSaveTask();
+      }
     }),
   );
   createEffect(
     on(taskTagsInput, () => {
-      if (selectedTask() && !isHydrating) scheduleSaveTask();
+      if (selectedTask() && !isHydrating) {
+        scheduleSaveTask();
+      }
     }),
   );
 
@@ -116,7 +153,9 @@ export default function Tasks() {
     if (saveTimer) {
       clearTimeout(saveTimer);
       // 未保存の編集を破棄せずフラッシュする
-      if (selectedTask() && viewMode() === "edit") void saveTask();
+      if (selectedTask() && viewMode() === "edit") {
+        void saveTask();
+      }
     }
   });
 
@@ -132,8 +171,6 @@ export default function Tasks() {
     return projects()?.find((p) => p.slug === slug);
   };
 
-  const isActiveTask = (task: Task) => !task.completed;
-
   const handleSelectProject = (slug: string) => {
     setSelectedProject(slug);
     setShowProjectPicker(false);
@@ -141,47 +178,53 @@ export default function Tasks() {
 
   const handleCreateProject = async () => {
     const name = newProjectName().trim();
-    if (!name) return;
+    if (!name) {
+      return;
+    }
     const slug = toSlug(name);
     if (!slug) {
-      setError("Invalid name");
+      setErrorMessage("Invalid name");
       return;
     }
     try {
       await typedInvoke("create_project", { slug, name, description: "" });
       setNewProjectName("");
-      setError("");
+      setErrorMessage("");
       setShowNewProject(false);
       refetchProjects();
       setSelectedProject(slug);
       setShowProjectPicker(false);
-    } catch (e) {
-      setError(String(e));
+    } catch (error) {
+      setErrorMessage(String(error));
     }
   };
 
   const handleCreateTask = async () => {
     const title = newTaskTitle().trim();
     const slug = selectedProject();
-    if (!title || !slug) return;
+    if (!title || !slug) {
+      return;
+    }
     try {
       await typedInvoke("create_task", { projectSlug: slug, title, tags: [], body: "" });
       setNewTaskTitle("");
       refetchTasks();
-    } catch (e) {
-      setError(String(e));
+    } catch (error) {
+      setErrorMessage(String(error));
     }
   };
 
   const handleCompleteTask = async (filename: string) => {
     const slug = selectedProject();
-    if (!slug) return;
+    if (!slug) {
+      return;
+    }
     try {
       await typedInvoke("complete_task", { projectSlug: slug, filename });
       refetchTasks();
       refetchDoneTasks();
-    } catch (e) {
-      setError(String(e));
+    } catch (error) {
+      setErrorMessage(String(error));
     }
   };
 
@@ -207,7 +250,9 @@ export default function Tasks() {
   };
 
   const goBack = async () => {
-    if (saveTimer) clearTimeout(saveTimer);
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+    }
     if (viewMode() === "edit" && selectedTask()) {
       await saveTask();
     }
@@ -221,24 +266,32 @@ export default function Tasks() {
   const handleDelete = async () => {
     const task = selectedTask();
     const slug = selectedProject();
-    if (!task || !slug) return;
+    if (!task || !slug) {
+      return;
+    }
     setConfirmOpen(false);
-    if (saveTimer) clearTimeout(saveTimer);
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+    }
     try {
       await typedInvoke("delete_task", { projectSlug: slug, filename: task.filename });
       refetchTasks();
       refetchDoneTasks();
       navigateToList();
-    } catch (e) {
-      setError(String(e));
+    } catch (error) {
+      setErrorMessage(String(error));
     }
   };
 
   const handleCompleteFromPreview = async () => {
     const task = selectedTask();
     const slug = selectedProject();
-    if (!task || !slug) return;
-    if (saveTimer) clearTimeout(saveTimer);
+    if (!task || !slug) {
+      return;
+    }
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+    }
     try {
       if (viewMode() === "edit") {
         await saveTask();
@@ -247,20 +300,9 @@ export default function Tasks() {
       refetchTasks();
       refetchDoneTasks();
       navigateToList();
-    } catch (e) {
-      setError(String(e));
+    } catch (error) {
+      setErrorMessage(String(error));
     }
-  };
-
-  const formatTime = (time?: string) => {
-    if (!time) return "";
-    const d = new Date(time);
-    return d.toLocaleString("ja-JP", {
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
   };
 
   return (
@@ -306,8 +348,8 @@ export default function Tasks() {
               </div>
             </Show>
 
-            <Show when={error()}>
-              <p class="error-text">{error()}</p>
+            <Show when={errorMessage()}>
+              <p class="error-text">{errorMessage()}</p>
             </Show>
 
             {/* Task list */}
@@ -344,7 +386,9 @@ export default function Tasks() {
                     value={newTaskTitle()}
                     onInput={(e) => setNewTaskTitle(e.currentTarget.value)}
                     onKeyDown={(e) => {
-                      if (e.key === "Enter") handleCreateTask();
+                      if (e.key === "Enter") {
+                        handleCreateTask();
+                      }
                     }}
                   />
                 </div>
@@ -376,8 +420,12 @@ export default function Tasks() {
 
           {/* Project creation dialog */}
           <Show when={showNewProject()}>
-            <div class="dialog-overlay" onClick={() => setShowNewProject(false)}>
-              <div class="dialog" onClick={(e) => e.stopPropagation()}>
+            <div
+              class="dialog-overlay"
+              role="presentation"
+              onClick={() => setShowNewProject(false)}
+            >
+              <div class="dialog" role="presentation" onClick={(e) => e.stopPropagation()}>
                 <h3 class="dialog-title">New Project</h3>
                 <input
                   type="text"
@@ -386,13 +434,17 @@ export default function Tasks() {
                   value={newProjectName()}
                   onInput={(e) => setNewProjectName(e.currentTarget.value)}
                   onKeyDown={(e) => {
-                    if (e.key === "Enter") handleCreateProject();
-                    if (e.key === "Escape") setShowNewProject(false);
+                    if (e.key === "Enter") {
+                      handleCreateProject();
+                    }
+                    if (e.key === "Escape") {
+                      setShowNewProject(false);
+                    }
                   }}
                   autofocus
                 />
-                <Show when={error()}>
-                  <p class="error-text">{error()}</p>
+                <Show when={errorMessage()}>
+                  <p class="error-text">{errorMessage()}</p>
                 </Show>
                 <div class="dialog-actions">
                   <button type="button" class="btn-small" onClick={() => setShowNewProject(false)}>
@@ -485,7 +537,7 @@ export default function Tasks() {
             </div>
             <div class="task-preview-body">
               <Show when={selectedTask()?.body} fallback={<p class="empty-state">本文なし</p>}>
-                <MarkdownPreview source={selectedTask()!.body} />
+                {(body) => <MarkdownPreview source={body()} />}
               </Show>
             </div>
           </div>

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -4,22 +4,23 @@ import ActionBar from "../components/ActionBar";
 import Icon from "../components/Icon";
 import TimelineEntry from "../components/TimelineEntry";
 import { getLocation } from "../lib/location";
+import type { JSX } from "solid-js";
 
 type ViewMode = "input" | "list" | "preview";
 
-async function fetchEntries(): Promise<string[]> {
+function fetchEntries(): Promise<string[]> {
   return typedInvoke("read_timeline");
 }
 
-async function fetchDates(): Promise<string[]> {
+function fetchDates(): Promise<string[]> {
   return typedInvoke("list_timeline_dates");
 }
 
-async function fetchEntriesByDate(date: string): Promise<string[]> {
+function fetchEntriesByDate(date: string): Promise<string[]> {
   return typedInvoke("read_timeline_by_date", { date });
 }
 
-export default function Timeline() {
+export default function Timeline(): JSX.Element {
   const [text, setText] = createSignal("");
   const [saving, setSaving] = createSignal(false);
   const [sendError, setSendError] = createSignal("");
@@ -33,7 +34,9 @@ export default function Timeline() {
 
   const handleSend = async () => {
     const trimmed = text().trim();
-    if (!trimmed) return;
+    if (!trimmed) {
+      return;
+    }
 
     setSaving(true);
     setSendError("");
@@ -46,8 +49,8 @@ export default function Timeline() {
       });
       setText("");
       refetch();
-    } catch (e) {
-      setSendError(String(e));
+    } catch (error) {
+      setSendError(String(error));
     } finally {
       setSaving(false);
     }
@@ -99,7 +102,7 @@ export default function Timeline() {
 
             <Show when={entries()?.length}>
               <div class="timeline-entries">
-                <For each={entries()!.slice().reverse()}>
+                <For each={[...(entries() ?? [])].toReversed()}>
                   {(entry) => <TimelineEntry raw={entry} />}
                 </For>
               </div>

--- a/tauri-app/tsconfig.json
+++ b/tauri-app/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2023",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",

--- a/workers/.oxlintrc.json
+++ b/workers/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../.oxlintrc.json"]
+}

--- a/workers/justfile
+++ b/workers/justfile
@@ -9,6 +9,7 @@ setup:
 check: setup
   oxlint src/
   tsgo -p tsconfig.check.json --noEmit
+  pnpm knip
 
 test: setup
   pnpm test

--- a/workers/knip.jsonc
+++ b/workers/knip.jsonc
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  // `cloudflare:test` is a virtual module supplied by
+  // @cloudflare/vitest-pool-workers; knip reads it as a `cloudflare` package.
+  "ignoreDependencies": ["cloudflare"],
+}

--- a/workers/package.json
+++ b/workers/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.8",
     "@cloudflare/workers-types": "^4",
+    "knip": "^6.31.0",
     "typescript": "^5.6",
     "vitest": "^3",
     "wrangler": "^4"

--- a/workers/pnpm-lock.yaml
+++ b/workers/pnpm-lock.yaml
@@ -14,16 +14,19 @@ importers:
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.8
-        version: 0.8.71(@cloudflare/workers-types@4.20260422.1)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4)
+        version: 0.8.71(@cloudflare/workers-types@4.20260422.1)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(jiti@2.7.0)(yaml@2.9.0))
       '@cloudflare/workers-types':
         specifier: ^4
         version: 4.20260422.1
+      knip:
+        specifier: ^6.31.0
+        version: 6.31.0
       typescript:
         specifier: ^5.6
         version: 5.9.3
       vitest:
         specifier: ^3
-        version: 3.2.4
+        version: 3.2.4(jiti@2.7.0)(yaml@2.9.0)
       wrangler:
         specifier: ^4
         version: 4.84.1(@cloudflare/workers-types@4.20260422.1)
@@ -130,8 +133,17 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild/aix-ppc64@0.25.4':
     resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
@@ -875,6 +887,246 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@napi-rs/wasm-runtime@1.2.2':
+    resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
+
+  '@oxc-parser/binding-android-arm-eabi@0.142.0':
+    resolution: {integrity: sha512-ZiRGDutGsv1G6bL/ozy/koC0Sv39T1DqyoC4KD1DOy9ZoACm1O5UWhEK2c02Qdk+4lfLVkvFa/mQ0fm/4h1BtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.142.0':
+    resolution: {integrity: sha512-WZkvGRLNQTz8lR9zP5nLjUdlroRCopBu3g9zF1p/laE6DzT1UbQo8Rdz5MWhaJUPYg/6gp+jo7HUgsyKaN1FtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.142.0':
+    resolution: {integrity: sha512-l4khS8LQOOVYsGRVARo1gSaCT/aBSceUVXgtovWc2+drnxVuDr082WA3OCHVdVzIz5JIrP/y9CWsSKxBDNmYGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.142.0':
+    resolution: {integrity: sha512-QBsNF3nqlXmcH2B1YOPqQYmCJoy4HuIjUxGbBO/k5JAJUl68ghU2psRY2zPk+RyBaWqKP/qfL4oaFgEMCdwskA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.142.0':
+    resolution: {integrity: sha512-b7Q7m4Cqc6XqNhri3R+QhU+GVy646Pn+bkdhrDdWym/Fdi0ZUa+d73H9dm5H91JtbtAQ/z1d8XKMW3oOV8a4tQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.142.0':
+    resolution: {integrity: sha512-3riVS5IhdH3uCZj1Y9ftDQlR0dvLsIlw/edrRqk8JhgNd5K0XSs+UBtgh50N13CAlW9/TXj6sVGXaKNBocd0Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.142.0':
+    resolution: {integrity: sha512-NmXUOpgpTSkhl795TiXmWppTwmSJ92RC1qvD6e4XOF+slgmo3e6Ah+kEu+6AN8s7NAOEwqGmir58MgSQSWmBSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.142.0':
+    resolution: {integrity: sha512-gc0EXsKtXgerujmU2Bql3u1L1HsSQ2774R83idq/FoNMPVV/RY/1ErFsvnit7KoiP/sLvzQixeUo4Ut0ic0wmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.142.0':
+    resolution: {integrity: sha512-F2XvmWSE0uWpie+jHKKIFgdVOe9ypGhkEZxKx5DuW215K6cbAC274yYaPkcM7EqY4Df3Weyhpcz3lsURyH2LVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.142.0':
+    resolution: {integrity: sha512-wLMbT21U/QxknQsk+VvNF0b9D2/aGWhcaQQQ+VYlE8FwD5+GoWZIPPXNzyHmkYyhm0KB3itL+TBavjMatqNnYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.142.0':
+    resolution: {integrity: sha512-+G8F/4ckwT7FCJV4H2bt09xEzJbjNCfuL4Sp1AYNaFtFMVtgIGMuJlteT82U+K0UIZ/DzAR/LDlMFnEuajG7Kw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.142.0':
+    resolution: {integrity: sha512-hTsHtTLxMAfCo+rpF5K3qZJKW2NpPN/CHd4mYB3y7XlSdspHkd2gehDIofP64AacA9nWQw2tY3O7wR6UY8IVOA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.142.0':
+    resolution: {integrity: sha512-6y7qYY3TCUDYjqswImdTGl92y+KA/80twALegQPN27kfY+bG7Ib1+L3jbmrCZQx6wrVnai9IPsEZp07I0hx7JQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.142.0':
+    resolution: {integrity: sha512-i69kAWU+2LgoH5bR+zWiiu+UzAw7Oxkwv7COeJTeY19pn4e70nKQcr9Pm6cL2Z0Z54d+gl9qADlK/0yyuCPiBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.142.0':
+    resolution: {integrity: sha512-4SQs678MmjYVrmhAgCWD4o0vpaFszXw9xLX5p2Z9MMFcltxiLkA88wQjh80YHjPrXtpyZ2CWI5m+1yNKM0m2Pw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.142.0':
+    resolution: {integrity: sha512-YHpx9N7Ln3a++Tc8rv+H7mrK1zyJQOAwCFg8LZ3lTs1T5afGWeZrLPhPT9HLnIwSjCyJqPWVMIrMxbjcmBr2oQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.142.0':
+    resolution: {integrity: sha512-3pLDyY3+oogW73RM5uehNgAiR/Xfb7fvO2Q1Z1gIqZ2+50XDVQmBVlRkHXZTU4gKnQHpwETNsYQVsJ3joVB2iA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.142.0':
+    resolution: {integrity: sha512-Had/VeVY28Oyb0K+Q4FV8KCzoBycIh93oDK6pCbya9lkzdq+ikMHMgBubsdqqlybjJmQRawCQRrnBRHyQwYvcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.142.0':
+    resolution: {integrity: sha512-GGi3+YphVHavvgs6gum2UXoNCqzHAmPt/nXkn8ZQZstV2Q1qZD1Mn8fz/nWrDkefHQtrG/+1/XrbMxsBTo6Svw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.142.0':
+    resolution: {integrity: sha512-Ny/Wv4Us1LGC/ljwNTp+Hx3r/pH15EFfeDF0p+n898gt+TtRd6C9SccHcuUhDiNTb8s5tt7jdeAMDRQZ4Vq6hg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.142.0':
+    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
+    resolution: {integrity: sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-resolver/binding-android-arm64@11.24.2':
+    resolution: {integrity: sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
+    resolution: {integrity: sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
+    resolution: {integrity: sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
+    resolution: {integrity: sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
+    resolution: {integrity: sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
+    resolution: {integrity: sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
+    resolution: {integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
+    resolution: {integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
+    resolution: {integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
+    resolution: {integrity: sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
+    resolution: {integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
+    resolution: {integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
+    resolution: {integrity: sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
+    resolution: {integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
+    resolution: {integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
+    resolution: {integrity: sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
+    resolution: {integrity: sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    resolution: {integrity: sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==}
+    cpu: [x64]
+    os: [win32]
+
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
 
@@ -1029,6 +1281,9 @@ packages:
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1177,6 +1432,9 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
+  fd-package-json@2.0.0:
+    resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1186,16 +1444,28 @@ packages:
       picomatch:
         optional: true
 
+  formatly@0.3.0:
+    resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
+    engines: {node: '>=18.3.0'}
+    hasBin: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
   is-arrayish@0.3.4:
     resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
@@ -1206,6 +1476,11 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  knip@6.31.0:
+    resolution: {integrity: sha512-NbeIEmUS2VUMjAkbiSNOKPJeV9wpCsr0660sUyKyMQbk4Iom0++nTLInVp4MJ+LfR4kORnw67bDi5tvO7YLnzA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -1239,6 +1514,13 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  oxc-parser@0.142.0:
+    resolution: {integrity: sha512-kKR+jPiRJYJDexVoziIg/FVGvr1fT1FZSSJOk6tVoMKKSlsf1Cso+cgGCJkOEDWOP174vRntCPFKg+AS7InWvw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-resolver@11.24.2:
+    resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
+
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
@@ -1256,9 +1538,16 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
@@ -1284,6 +1573,10 @@ packages:
   simple-swizzle@0.2.4:
     resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
+  smol-toml@1.7.1:
+    resolution: {integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==}
+    engines: {node: '>= 18'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1297,6 +1590,10 @@ packages:
   stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
     engines: {node: '>=4', npm: '>=6'}
+
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
@@ -1313,6 +1610,10 @@ packages:
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
@@ -1337,6 +1638,10 @@ packages:
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  unbash@4.0.6:
+    resolution: {integrity: sha512-YGBMSVG/WrA2vgaZbXVvxrGgoMcWZecyyS4foGt8clbtY7s1nIKNmt7Z9LR74XE6FkYTSqDmKk2lIOhOjIvmrw==}
+    engines: {node: '>=14'}
 
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
@@ -1425,6 +1730,10 @@ packages:
       jsdom:
         optional: true
 
+  walk-up-path@4.0.0:
+    resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
+    engines: {node: 20 || >=22}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -1472,6 +1781,11 @@ packages:
       utf-8-validate:
         optional: true
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
 
@@ -1483,6 +1797,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -1504,7 +1821,7 @@ snapshots:
     optionalDependencies:
       workerd: 1.20250906.0
 
-  '@cloudflare/vitest-pool-workers@0.8.71(@cloudflare/workers-types@4.20260422.1)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4)':
+  '@cloudflare/vitest-pool-workers@0.8.71(@cloudflare/workers-types@4.20260422.1)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -1513,7 +1830,7 @@ snapshots:
       devalue: 5.7.1
       miniflare: 4.20250906.0
       semver: 7.7.4
-      vitest: 3.2.4
+      vitest: 3.2.4(jiti@2.7.0)(yaml@2.9.0)
       wrangler: 4.35.0(@cloudflare/workers-types@4.20260422.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -1557,7 +1874,23 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@emnapi/core@1.11.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -1973,6 +2306,140 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@oxc-parser/binding-android-arm-eabi@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.142.0':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.142.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.142.0':
+    optional: true
+
+  '@oxc-project/types@0.142.0': {}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-android-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    optional: true
+
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -2064,6 +2531,11 @@ snapshots:
 
   '@speed-highlight/core@1.2.15': {}
 
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -2081,13 +2553,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.2)':
+  '@vitest/mocker@3.2.4(vite@7.3.2(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2
+      vite: 7.3.2(jiti@2.7.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -2269,22 +2741,56 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  fd-package-json@2.0.0:
+    dependencies:
+      walk-up-path: 4.0.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
 
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  formatly@0.3.0:
+    dependencies:
+      fd-package-json: 2.0.0
+
   fsevents@2.3.3:
     optional: true
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   glob-to-regexp@0.4.1: {}
 
   is-arrayish@0.3.4: {}
+
+  jiti@2.7.0: {}
 
   jose@6.2.3: {}
 
   js-tokens@9.0.1: {}
 
   kleur@4.1.5: {}
+
+  knip@6.31.0:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      formatly: 0.3.0
+      get-tsconfig: 4.14.0
+      jiti: 2.7.0
+      oxc-parser: 0.142.0
+      oxc-resolver: 11.24.2
+      picomatch: 4.0.5
+      smol-toml: 1.7.1
+      strip-json-comments: 5.0.3
+      tinyglobby: 0.2.17
+      unbash: 4.0.6
+      yaml: 2.9.0
+      zod: 4.4.3
 
   loupe@3.2.1: {}
 
@@ -2330,6 +2836,53 @@ snapshots:
 
   ohash@2.0.11: {}
 
+  oxc-parser@0.142.0:
+    dependencies:
+      '@oxc-project/types': 0.142.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.142.0
+      '@oxc-parser/binding-android-arm64': 0.142.0
+      '@oxc-parser/binding-darwin-arm64': 0.142.0
+      '@oxc-parser/binding-darwin-x64': 0.142.0
+      '@oxc-parser/binding-freebsd-x64': 0.142.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.142.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.142.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.142.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.142.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.142.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.142.0
+      '@oxc-parser/binding-linux-x64-musl': 0.142.0
+      '@oxc-parser/binding-openharmony-arm64': 0.142.0
+      '@oxc-parser/binding-wasm32-wasi': 0.142.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.142.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.142.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.142.0
+
+  oxc-resolver@11.24.2:
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.24.2
+      '@oxc-resolver/binding-android-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-x64': 11.24.2
+      '@oxc-resolver/binding-freebsd-x64': 11.24.2
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-musl': 11.24.2
+      '@oxc-resolver/binding-openharmony-arm64': 11.24.2
+      '@oxc-resolver/binding-wasm32-wasi': 11.24.2
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
+      '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
+
   path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
@@ -2340,11 +2893,15 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  picomatch@4.0.5: {}
+
   postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  resolve-pkg-maps@1.0.0: {}
 
   rollup@4.60.2:
     dependencies:
@@ -2442,6 +2999,8 @@ snapshots:
     dependencies:
       is-arrayish: 0.3.4
 
+  smol-toml@1.7.1: {}
+
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
@@ -2449,6 +3008,8 @@ snapshots:
   std-env@3.10.0: {}
 
   stoppable@1.1.0: {}
+
+  strip-json-comments@5.0.3: {}
 
   strip-literal@3.1.0:
     dependencies:
@@ -2465,6 +3026,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
   tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
@@ -2477,6 +3043,8 @@ snapshots:
   typescript@5.9.3: {}
 
   ufo@1.6.3: {}
+
+  unbash@4.0.6: {}
 
   undici@7.24.8: {}
 
@@ -2494,13 +3062,13 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
-  vite-node@3.2.4:
+  vite-node@3.2.4(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2
+      vite: 7.3.2(jiti@2.7.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2515,7 +3083,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.2:
+  vite@7.3.2(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -2525,12 +3093,14 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       fsevents: 2.3.3
+      jiti: 2.7.0
+      yaml: 2.9.0
 
-  vitest@3.2.4:
+  vitest@3.2.4(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2)
+      '@vitest/mocker': 3.2.4(vite@7.3.2(jiti@2.7.0)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -2548,8 +3118,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.2
-      vite-node: 3.2.4
+      vite: 7.3.2(jiti@2.7.0)(yaml@2.9.0)
+      vite-node: 3.2.4(jiti@2.7.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - jiti
@@ -2564,6 +3134,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  walk-up-path@4.0.0: {}
 
   why-is-node-running@2.3.0:
     dependencies:
@@ -2622,6 +3194,8 @@ snapshots:
 
   ws@8.18.0: {}
 
+  yaml@2.9.0: {}
+
   youch-core@0.3.3:
     dependencies:
       '@poppinss/exception': 1.2.3
@@ -2638,3 +3212,5 @@ snapshots:
   zod@3.22.3: {}
 
   zod@3.25.76: {}
+
+  zod@4.4.3: {}

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { SignJWT } from "jose";
 import worker from "./index";
 
-async function makeJwt(
+function makeJwt(
   payload: { sub: string; email: string; exp: number },
   secret = env.JWT_SECRET,
 ): Promise<string> {
@@ -37,8 +37,15 @@ function request(
   return new Request(`http://localhost${path}`, { ...options, headers });
 }
 
-async function jsonBody<T>(response: Response): Promise<T> {
+function jsonBody<T>(response: Response): Promise<T> {
   return response.json() as Promise<T>;
+}
+
+function objectText(object: R2ObjectBody | null): Promise<string> {
+  if (!object) {
+    throw new Error("expected the object to exist in R2");
+  }
+  return object.text();
 }
 
 function b64(s: string): string {
@@ -61,7 +68,7 @@ describe("Workers Sync API", () => {
     await clearBucket();
   });
 
-  describe("Authentication", () => {
+  describe("authentication", () => {
     it("rejects requests without Authorization header", async () => {
       const req = new Request("http://localhost/sync-state");
       const ctx = createExecutionContext();
@@ -99,7 +106,7 @@ describe("Workers Sync API", () => {
     });
   });
 
-  describe("GET /sync-state", () => {
+  describe("gET /sync-state", () => {
     it("returns empty state for new user", async () => {
       const req = request("/sync-state");
       const ctx = createExecutionContext();
@@ -157,11 +164,11 @@ describe("Workers Sync API", () => {
         etag: string | null;
       }>(stateRes);
       expect(state.files["notes/a.md"].hash).toBe("h1");
-      expect(state.etag).toBeTruthy();
+      expect(state.etag.length).toBeGreaterThan(0);
     });
   });
 
-  describe("POST /sync/bulk", () => {
+  describe("pOST /sync/bulk", () => {
     it("uploads files to R2", async () => {
       const req = request("/sync/bulk", {
         method: "POST",
@@ -191,7 +198,7 @@ describe("Workers Sync API", () => {
       expect(res.status).toBe(200);
       const obj = await env.BUCKET.get("notes/up.md");
       expect(obj).not.toBeNull();
-      expect(await obj!.text()).toBe("uploaded content");
+      expect(await objectText(obj)).toBe("uploaded content");
     });
 
     it("downloads files from R2", async () => {
@@ -281,10 +288,10 @@ describe("Workers Sync API", () => {
 
       const conflict = await env.BUCKET.get("notes/c.sync-conflict-20260512-120000.md");
       expect(conflict).not.toBeNull();
-      expect(await conflict!.text()).toBe("remote version");
+      expect(await objectText(conflict)).toBe("remote version");
 
       const main = await env.BUCKET.get("notes/c.md");
-      expect(await main!.text()).toBe("local version");
+      expect(await objectText(main)).toBe("local version");
     });
 
     it("handles conflict with keep_remote: returns remote content for client to save", async () => {
@@ -472,7 +479,7 @@ describe("Workers Sync API", () => {
     });
   });
 
-  describe("Unknown routes", () => {
+  describe("unknown routes", () => {
     it("returns 404 for unknown paths", async () => {
       const req = request("/unknown");
       const ctx = createExecutionContext();

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -1,5 +1,6 @@
 import { SignJWT, jwtVerify } from "jose";
-import { type BulkRequest, executeBulk, loadSyncState, saveSyncState } from "./sync";
+import { executeBulk, loadSyncState, saveSyncState } from "./sync";
+import type { BulkRequest } from "./sync";
 
 export interface Env {
   BUCKET: R2Bucket;
@@ -24,13 +25,10 @@ interface GoogleUserInfo {
   email: string;
 }
 
-const DEFAULT_JWT_EXPIRY_SECONDS = 259200; // 3 days
+const DEFAULT_JWT_EXPIRY_SECONDS = 259_200; // 3 days
 
 function jsonResponse(data: unknown, status = 200): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
+  return Response.json(data, { status });
 }
 
 function errorResponse(message: string, status: number): Response {
@@ -44,13 +42,19 @@ async function handleSyncState(bucket: R2Bucket, userId: string): Promise<Respon
 
 // 不正なタイムスタンプを保存すると、それを読んだ全クライアントで
 // そのファイルが sync 対象から静かに消える
-function hasInvalidTimestamp(body: BulkRequest): boolean {
-  const invalid = (value: unknown) => typeof value !== "string" || Number.isNaN(Date.parse(value));
+function isInvalidTimestamp(value: unknown): boolean {
+  return typeof value !== "string" || Number.isNaN(Date.parse(value));
+}
 
-  if (body.uploads.some((u) => invalid(u.last_modified))) return true;
-  const files = body.new_state.files;
-  if (typeof files !== "object" || files === null) return true;
-  return Object.values(files).some((rec) => invalid(rec?.last_modified));
+function hasInvalidTimestamp(body: BulkRequest): boolean {
+  if (body.uploads.some((u) => isInvalidTimestamp(u.last_modified))) {
+    return true;
+  }
+  const { files } = body.new_state;
+  if (typeof files !== "object" || files === null) {
+    return true;
+  }
+  return Object.values(files).some((rec) => isInvalidTimestamp(rec?.last_modified));
 }
 
 async function handleSyncBulk(
@@ -87,8 +91,8 @@ async function handleSyncBulk(
   let result;
   try {
     result = await executeBulk(bucket, body);
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
     return errorResponse(`Bulk execution failed: ${msg}`, 400);
   }
 
@@ -101,7 +105,7 @@ async function handleSyncBulk(
   return jsonResponse(result);
 }
 
-async function signJwt(payload: JwtPayload, secret: string): Promise<string> {
+function signJwt(payload: JwtPayload, secret: string): Promise<string> {
   const key = new TextEncoder().encode(secret);
   return new SignJWT({ email: payload.email })
     .setProtectedHeader({ alg: "HS256" })
@@ -114,8 +118,14 @@ async function verifyJwt(token: string, secret: string): Promise<JwtPayload | nu
   try {
     const key = new TextEncoder().encode(secret);
     const { payload } = await jwtVerify(token, key);
-    if (typeof payload.sub !== "string" || typeof payload.email !== "string") return null;
-    return { sub: payload.sub, email: payload.email as string, exp: payload.exp! };
+    if (
+      typeof payload.sub !== "string" ||
+      typeof payload.email !== "string" ||
+      typeof payload.exp !== "number"
+    ) {
+      return null;
+    }
+    return { sub: payload.sub, email: payload.email, exp: payload.exp };
   } catch {
     return null;
   }
@@ -127,7 +137,9 @@ function generateState(): string {
 
 function getCookie(request: Request, name: string): string | null {
   const cookie = request.headers.get("Cookie");
-  if (!cookie) return null;
+  if (!cookie) {
+    return null;
+  }
   const match = cookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
   return match ? match[1] : null;
 }
@@ -139,7 +151,9 @@ function isAllowedRedirect(redirect: string): boolean {
 function getJwtExpiry(env: Env): number {
   if (env.JWT_EXPIRY_SECONDS) {
     const parsed = parseInt(env.JWT_EXPIRY_SECONDS, 10);
-    if (!isNaN(parsed) && parsed > 0) return parsed;
+    if (!isNaN(parsed) && parsed > 0) {
+      return parsed;
+    }
   }
   return DEFAULT_JWT_EXPIRY_SECONDS;
 }
@@ -148,7 +162,7 @@ export default {
   async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
     const { pathname } = url;
-    const method = request.method;
+    const { method } = request;
 
     // OAuth: redirect to Google
     if (pathname === "/auth/google" && method === "GET") {

--- a/workers/src/sync.ts
+++ b/workers/src/sync.ts
@@ -8,13 +8,13 @@ export interface SyncState {
   last_sync: string | null;
 }
 
-export interface FileContent {
+interface FileContent {
   key: string;
   content_base64: string;
   last_modified: string;
 }
 
-export interface ConflictOp {
+interface ConflictOp {
   key: string;
   conflict_key: string;
   resolution: "keep_local" | "keep_remote";

--- a/workers/src/sync.ts
+++ b/workers/src/sync.ts
@@ -72,14 +72,18 @@ export async function saveSyncState(
 function base64Encode(bytes: ArrayBuffer): string {
   const arr = new Uint8Array(bytes);
   let binary = "";
-  for (let i = 0; i < arr.length; i++) binary += String.fromCharCode(arr[i]);
+  for (const byte of arr) {
+    binary += String.fromCodePoint(byte);
+  }
   return btoa(binary);
 }
 
 function base64Decode(s: string): Uint8Array {
   const binary = atob(s);
   const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.codePointAt(i) ?? 0;
+  }
   return bytes;
 }
 
@@ -93,7 +97,9 @@ export function isUnsafeKey(key: string): boolean {
 }
 
 async function executeUpload(bucket: R2Bucket, f: FileContent): Promise<void> {
-  if (isUnsafeKey(f.key)) throw new Error(`unsafe key: ${f.key}`);
+  if (isUnsafeKey(f.key)) {
+    throw new Error(`unsafe key: ${f.key}`);
+  }
   const body = base64Decode(f.content_base64);
   await bucket.put(f.key, body, {
     customMetadata: { lastModified: f.last_modified },
@@ -101,9 +107,13 @@ async function executeUpload(bucket: R2Bucket, f: FileContent): Promise<void> {
 }
 
 async function executeDownload(bucket: R2Bucket, key: string): Promise<FileContent> {
-  if (isUnsafeKey(key)) throw new Error(`unsafe key: ${key}`);
+  if (isUnsafeKey(key)) {
+    throw new Error(`unsafe key: ${key}`);
+  }
   const obj = await bucket.get(key);
-  if (!obj) throw new Error(`not found: ${key}`);
+  if (!obj) {
+    throw new Error(`not found: ${key}`);
+  }
   const lastModified = obj.customMetadata?.lastModified ?? obj.uploaded.toISOString();
   const buf = await obj.arrayBuffer();
   return {
@@ -134,31 +144,38 @@ async function executeConflict(bucket: R2Bucket, c: ConflictOp): Promise<FileCon
       });
     }
     return null;
-  } else {
-    // keep_remote: client will save local as conflict copy locally,
-    // and downloads remote content. We just return remote content so client can write both.
-    const obj = await bucket.get(c.key);
-    if (!obj) throw new Error(`conflict download not found: ${c.key}`);
-    const lastModified = obj.customMetadata?.lastModified ?? obj.uploaded.toISOString();
-    const buf = await obj.arrayBuffer();
-    return {
-      key: c.key,
-      content_base64: base64Encode(buf),
-      last_modified: lastModified,
-    };
   }
+  // keep_remote: client will save local as conflict copy locally,
+  // and downloads remote content. We just return remote content so client can write both.
+  const obj = await bucket.get(c.key);
+  if (!obj) {
+    throw new Error(`conflict download not found: ${c.key}`);
+  }
+  const lastModified = obj.customMetadata?.lastModified ?? obj.uploaded.toISOString();
+  const buf = await obj.arrayBuffer();
+  return {
+    key: c.key,
+    content_base64: base64Encode(buf),
+    last_modified: lastModified,
+  };
 }
 
 export async function executeBulk(bucket: R2Bucket, req: BulkRequest): Promise<BulkResponse> {
   // Validate all keys upfront
   for (const u of req.uploads) {
-    if (isUnsafeKey(u.key)) throw new Error(`unsafe upload key: ${u.key}`);
+    if (isUnsafeKey(u.key)) {
+      throw new Error(`unsafe upload key: ${u.key}`);
+    }
   }
   for (const d of req.downloads) {
-    if (isUnsafeKey(d)) throw new Error(`unsafe download key: ${d}`);
+    if (isUnsafeKey(d)) {
+      throw new Error(`unsafe download key: ${d}`);
+    }
   }
   for (const d of req.delete_remote) {
-    if (isUnsafeKey(d)) throw new Error(`unsafe delete key: ${d}`);
+    if (isUnsafeKey(d)) {
+      throw new Error(`unsafe delete key: ${d}`);
+    }
   }
 
   // Run all R2 operations concurrently

--- a/workers/src/test-env.d.ts
+++ b/workers/src/test-env.d.ts
@@ -1,5 +1,8 @@
 import type { Env } from "./index";
 
 declare module "cloudflare:test" {
+  // Module augmentation merges into `cloudflare:test`'s own `ProvidedEnv`
+  // interface, so a type alias cannot be used and the body has to stay empty.
+  // oxlint-disable-next-line typescript/no-empty-interface
   interface ProvidedEnv extends Env {}
 }


### PR DESCRIPTION
## 概要

Rust と TypeScript の lint を、それぞれのツールが提供する最大強度まで引き上げ、検出された全違反を修正しました。

- Rust: 874 件 → 0
- TypeScript: 1617 件（最大設定時）→ 0

## 設定内容

### Rust (`Cargo.toml`)

- rustc の lint グループ `future_incompatible` / `nonstandard_style` / `rust_2018_idioms` / `unused` を `deny`
- clippy の `all` / `pedantic` / `nursery` / `cargo` を全て `deny`
- `restriction` から厳選して採用: `unwrap_used`, `expect_used`, `undocumented_unsafe_blocks`, `mod_module_files`, `impl_trait_in_params`
- `just rust::check` を `--all-targets` に拡張し、テストコードも lint 対象に

`unwrap_used` は本番コードに 0 件だったため維持し、テストのみ `#![cfg_attr(test, allow(...))]` で許可しています。

### TypeScript (`.oxlintrc.json` を新規追加、tauri-app / workers が `extends`)

- `correctness` / `suspicious` / `pedantic` / `perf` / `style` / `nursery` を全て `error`
- `typescript` / `unicorn` / `oxc` / `import` / `promise` / `node` / `jsx-a11y` プラグインを有効化
- `restriction` から厳選: `no-explicit-any`, `no-non-null-assertion`, `explicit-module-boundary-types`, `no-import-type-side-effects`, `no-eq-null`, `no-use-before-define`, `no-void`
- `vitest` プラグインはテストファイルの glob に限定（全ファイルをテスト扱いするため）
- `tsconfig` の `target` / `lib` を ES2020 → ES2023

`workers/` はこれまで lint 設定ファイルが無く、既定の correctness カテゴリのみで動いていました。

## 無効化したルールと理由

設定ファイル内に全て理由をコメントで記載しています。

| 分類 | 例 | 理由 |
|---|---|---|
| 相互矛盾 | `prefer-default-export` vs `no-default-export`、`prefer-to-be-truthy` vs `prefer-strict-boolean-matchers`、`redundant_pub_crate` vs `unreachable_pub` | 両立不可能なため、厳しい方を採用 |
| フレームワーク不一致 | oxlint の `react` プラグイン全体 | SolidJS であり React ではない（`class` を不正な prop と判定する等） |
| 対象環境違い | `oxc/no-async-await` 等 | 旧ブラウザ向けの構文制限。Tauri webview と workerd はいずれも modern V8 |
| プロジェクト方針 | `missing_docs`, `missing_errors_doc`, `jsdoc/*` | CLAUDE.md の「コードが How、コメントが Why not」と衝突（Rust だけで 186 箇所の doc 強制） |
| 任意の閾値 | `max-lines`, `no-magic-numbers`, `sort-keys`, `id-length` | 欠陥ではなく好みの問題 |

## 主なコード修正

- `unreachable_pub` に従い、公開 API を実際に到達可能な範囲まで縮小
- mutex の `unwrap()` を `PoisonError::into_inner` による毒化回復に変更
- `get_project_activity_summary` の `expect()` をエラー伝播に変更
- 非 null アサーションを全て除去（テストでは失敗理由が読めるヘルパーに置換）
- `verifyJwt` が `exp` の型を検証してから返すように
- `.then()` チェーンを await による直列化に書き換え
- jsx-a11y 対応

## レビュー時の注意点

1. **`SyncButton` の同期トーストを `div` → `button` に変更**しました（キーボードで閉じられるようにするため）。`.sync-toast` に `appearance: none; font-family: inherit; text-align: start;` を追加して見た目は維持していますが、実機確認をお願いします。
2. `oxlint --fix-suggestions` は意味を変える修正を含み、実際にテストを壊しました（`toHaveBeenCalled()` → `toHaveBeenCalledWith()` 等）。安全な `--fix` のみを使い、`charCodeAt` → `codePointAt`、`toBeTruthy()` → `toBe(true)` といった意味の変わった箇所も検出して手作業で修正しています。

## 検証

- `just check` パス
- テスト: Rust 137 / tauri-app 64 / workers 23 すべてパス
- `nix fmt` 適用済み
