### PR TITLE
perf: profile the hot command paths and cut search, sync scan and markdown cost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ plans/
 
 # Wrangler local secrets
 .dev.vars
+
+# Profiling artifacts
+profiles/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +49,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -469,6 +484,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +550,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -714,6 +762,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
 ]
 
 [[package]]
@@ -1032,6 +1113,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "embed-resource"
@@ -1652,6 +1739,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2056,6 +2154,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2338,6 +2445,7 @@ name = "magical-merchant-core"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "criterion",
  "markdown-frontmatter",
  "serde",
  "serde_json",
@@ -2726,6 +2834,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "open"
 version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2761,6 +2875,16 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4765,6 +4889,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,8 @@ missing_panics_doc = "allow"
 # `pub` inside private modules, the other wants the opposite. `unreachable_pub`
 # wins because it describes the crate's real API surface.
 redundant_pub_crate = "allow"
+
+# Flame graphs need symbols; this profile is bench-only so the shipped
+# release binary stays untouched.
+[profile.bench]
+debug = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
+# benches/fixture.rs はモジュールであってベンチ本体ではない。自動検出に任せると
+# 単独ターゲットとしてもビルドされ、全項目が dead_code になる。
+autobenches = false
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
@@ -19,8 +22,18 @@ sha2 = "0.10"
 thiserror = "2"
 
 [dev-dependencies]
+criterion = { version = "0.8.2", default-features = false, features = ["cargo_bench_support"] }
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "macros"] }
+
+[lib]
+# libtest のハーネスは criterion の --save-baseline 等を解さないので、
+# `cargo bench` がベンチ対象にしないようにする。
+bench = false
+
+[[bench]]
+name = "core_paths"
+harness = false
 
 [lints]
 workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,7 +22,9 @@ sha2 = "0.10"
 thiserror = "2"
 
 [dev-dependencies]
-criterion = { version = "0.8.2", default-features = false, features = ["cargo_bench_support"] }
+criterion = { version = "0.8.2", default-features = false, features = [
+  "cargo_bench_support",
+] }
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "macros"] }
 

--- a/core/benches/core_paths.rs
+++ b/core/benches/core_paths.rs
@@ -1,0 +1,67 @@
+//! UI 操作ごとに走る core の経路を測る。ここに出てくる関数は Tauri コマンド
+//! から直接呼ばれるので、そのまま体感レイテンシになる。
+#![allow(clippy::unwrap_used, clippy::expect_used, missing_debug_implementations)]
+
+mod fixture;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use magical_merchant_core::sync::scan::scan_local_files;
+use magical_merchant_core::{list_notes, list_timeline_dates, read_timeline, search_all};
+
+fn search(c: &mut Criterion) {
+    let tmp = fixture::build();
+    let base = tmp.path();
+
+    let mut group = c.benchmark_group("search_all");
+    group.throughput(Throughput::Elements(
+        u64::try_from(fixture::DAYS).unwrap()
+            * u64::try_from(fixture::ENTRIES_PER_DAY).unwrap(),
+    ));
+    for (label, needle) in [
+        ("miss", fixture::MISS_NEEDLE),
+        ("rare", fixture::RARE_NEEDLE),
+        ("common", fixture::COMMON_NEEDLE),
+    ] {
+        group.bench_with_input(BenchmarkId::from_parameter(label), needle, |b, needle| {
+            b.iter(|| search_all(black_box(base), black_box(needle)).unwrap());
+        });
+    }
+    group.finish();
+}
+
+fn listing(c: &mut Criterion) {
+    let tmp = fixture::build();
+    let base = tmp.path();
+
+    c.bench_function("list_notes", |b| {
+        b.iter(|| list_notes(black_box(base)).unwrap());
+    });
+
+    c.bench_function("list_timeline_dates", |b| {
+        b.iter(|| list_timeline_dates(black_box(base)).unwrap());
+    });
+
+    // 起動直後にタイムラインタブが読む分。
+    let dates = fixture::recent_dates();
+    c.bench_function("read_timeline_recent_14", |b| {
+        b.iter(|| {
+            for date in &dates {
+                black_box(read_timeline(black_box(base), *date).unwrap());
+            }
+        });
+    });
+}
+
+fn sync_scan(c: &mut Criterion) {
+    let tmp = fixture::build();
+    let base = tmp.path();
+
+    c.bench_function("scan_local_files", |b| {
+        b.iter(|| scan_local_files(black_box(base)).unwrap());
+    });
+}
+
+criterion_group!(benches, search, listing, sync_scan);
+criterion_main!(benches);

--- a/core/benches/core_paths.rs
+++ b/core/benches/core_paths.rs
@@ -1,6 +1,10 @@
 //! UI 操作ごとに走る core の経路を測る。ここに出てくる関数は Tauri コマンド
 //! から直接呼ばれるので、そのまま体感レイテンシになる。
-#![allow(clippy::unwrap_used, clippy::expect_used, missing_debug_implementations)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    missing_debug_implementations
+)]
 
 mod fixture;
 
@@ -16,8 +20,7 @@ fn search(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("search_all");
     group.throughput(Throughput::Elements(
-        u64::try_from(fixture::DAYS).unwrap()
-            * u64::try_from(fixture::ENTRIES_PER_DAY).unwrap(),
+        u64::try_from(fixture::DAYS).unwrap() * u64::try_from(fixture::ENTRIES_PER_DAY).unwrap(),
     ));
     for (label, needle) in [
         ("miss", fixture::MISS_NEEDLE),

--- a/core/benches/fixture.rs
+++ b/core/benches/fixture.rs
@@ -1,0 +1,143 @@
+//! ベンチ用のデータセット生成。API を通さず直接ファイルを書くのは、
+//! `Local::now()` に依存する保存経路だと日付分布を作り分けられないため。
+
+use std::fmt::Write as _;
+use std::fs;
+use std::path::Path;
+
+use chrono::{Duration, NaiveDate};
+use magical_merchant_core::frontmatter::{self, NoteFrontmatter};
+use tempfile::TempDir;
+
+/// ヘビーユーザーの 1 年分。数値を変えると before/after が比較できなくなるので固定する。
+pub(crate) const DAYS: i64 = 365;
+pub(crate) const ENTRIES_PER_DAY: usize = 20;
+pub(crate) const NOTES: usize = 500;
+
+/// 全エントリのうち 1/`RARE_EVERY` だけに現れる語。
+pub(crate) const RARE_NEEDLE: &str = "ゼオライト";
+/// ほぼ全エントリに現れる語。
+pub(crate) const COMMON_NEEDLE: &str = "メモ";
+/// どこにも現れない語。全件を走査させる最悪ケース。
+pub(crate) const MISS_NEEDLE: &str = "quetzalcoatlus";
+
+const RARE_EVERY: usize = 97;
+
+/// 再現性のための線形合同法。`rand` を dev-dependency に足すほどの用途ではない。
+struct Lcg(u64);
+
+impl Lcg {
+    const fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+        self.0 >> 33
+    }
+
+    fn pick<'a>(&mut self, choices: &[&'a str]) -> &'a str {
+        let index = usize::try_from(self.next()).expect("u64 fits usize on 64-bit");
+        choices[index % choices.len()]
+    }
+}
+
+const SUBJECTS: &[&str] = &[
+    "同期処理",
+    "エディタ",
+    "検索",
+    "タイムライン",
+    "R2 バケット",
+    "Milkdown",
+    "Tauri コマンド",
+    "フロントマター",
+];
+
+const PREDICATES: &[&str] = &[
+    "のリトライ戦略を詰める",
+    "が遅いので計測した",
+    "のテストを書き直す",
+    "でメモが消える件",
+    "の設計メモ",
+    "を lightweight に保つ",
+];
+
+fn body(rng: &mut Lcg, index: usize) -> String {
+    let mut text = format!("{}{} のメモ", rng.pick(SUBJECTS), rng.pick(PREDICATES));
+    if index.is_multiple_of(RARE_EVERY) {
+        let _ = write!(text, " — {RARE_NEEDLE} を試す");
+    }
+    // 実データに合わせて一部は複数行になる
+    if index.is_multiple_of(5) {
+        text.push_str("\n続き: 明日あらためて確認する");
+    }
+    text
+}
+
+const CONTEXT_JSON: &str = r#"{"battery":72,"is_charging":false,"network_type":"WiFi","os":"macos","os_version":"15.5","arch":"aarch64"}"#;
+
+const fn start_date() -> NaiveDate {
+    NaiveDate::from_ymd_opt(2025, 1, 1).expect("literal date")
+}
+
+fn write_timeline(base: &Path, rng: &mut Lcg) {
+    let dir = base.join("data").join("timeline");
+    fs::create_dir_all(&dir).expect("create timeline dir");
+
+    for day in 0..DAYS {
+        let date = start_date() + Duration::days(day);
+        let mut file = String::new();
+        for entry in 0..ENTRIES_PER_DAY {
+            let index = usize::try_from(day).expect("day fits") * ENTRIES_PER_DAY + entry;
+            let hour = 6 + entry % 16;
+            let minute = (entry * 7) % 60;
+            let text = body(rng, index);
+            let _ = writeln!(file, "- [{hour:02}:{minute:02}:00] {text} {CONTEXT_JSON}");
+        }
+        fs::write(dir.join(format!("{}.md", date.format("%Y-%m-%d"))), file)
+            .expect("write timeline day");
+    }
+}
+
+fn write_notes(base: &Path, rng: &mut Lcg) {
+    let dir = base.join("data").join("notes");
+    fs::create_dir_all(&dir).expect("create notes dir");
+
+    for index in 0..NOTES {
+        let date = start_date() + Duration::days(i64::try_from(index).expect("index fits") % DAYS);
+        let time = date
+            .and_hms_opt(9, 0, 0)
+            .expect("literal time")
+            .and_local_timezone(chrono::FixedOffset::east_opt(9 * 3600).expect("literal offset"))
+            .single()
+            .expect("unambiguous");
+
+        let fm = NoteFrontmatter {
+            time,
+            tags: vec!["memo".to_string(), rng.pick(SUBJECTS).to_string()],
+            context: None,
+        };
+        // preview は先頭 100 文字しか読まれない。本文はそれより十分長くする。
+        let mut text = String::new();
+        for line in 0..12 {
+            text.push_str(&body(rng, index * 12 + line));
+            text.push('\n');
+        }
+        let content = frontmatter::render(&fm, &text).expect("render note");
+        fs::write(dir.join(format!("note-{index:04}.md")), content).expect("write note");
+    }
+}
+
+/// 一度だけ生成して全ベンチで共有する。`TempDir` は返り値が生きている間だけ有効。
+#[must_use]
+pub(crate) fn build() -> TempDir {
+    let tmp = TempDir::new().expect("create tempdir");
+    let mut rng = Lcg(0x2026_0804);
+    write_timeline(tmp.path(), &mut rng);
+    write_notes(tmp.path(), &mut rng);
+    tmp
+}
+
+/// UI が初期表示で読む日付（新しい順に 14 日）。
+#[must_use]
+pub(crate) fn recent_dates() -> Vec<NaiveDate> {
+    (0..14)
+        .map(|back| start_date() + Duration::days(DAYS - 1 - back))
+        .collect()
+}

--- a/core/benches/fixture.rs
+++ b/core/benches/fixture.rs
@@ -28,7 +28,10 @@ struct Lcg(u64);
 
 impl Lcg {
     const fn next(&mut self) -> u64 {
-        self.0 = self.0.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1);
         self.0 >> 33
     }
 

--- a/core/src/project/repository.rs
+++ b/core/src/project/repository.rs
@@ -82,7 +82,7 @@ impl Projects {
         }
 
         let content = fs::read_to_string(&file_path)?;
-        let (fm, _body): (ProjectFrontmatter, String) = frontmatter::parse(&content)?;
+        let (fm, _body): (ProjectFrontmatter, &str) = frontmatter::parse(&content)?;
 
         let active_dir = paths::active_tasks_dir(&self.base_dir, slug_str);
         let active_task_count = utils::fs::count_md_files(&active_dir)?;

--- a/core/src/project/task.rs
+++ b/core/src/project/task.rs
@@ -126,7 +126,7 @@ mod tests {
         assert!(path.exists());
 
         let content = fs::read_to_string(&path).unwrap();
-        let (fm, body): (TaskFrontmatter, String) = frontmatter::parse(&content).unwrap();
+        let (fm, body): (TaskFrontmatter, &str) = frontmatter::parse(&content).unwrap();
         assert_eq!(fm.title, "My Task");
         assert_eq!(fm.tags, vec!["rust", "test"]);
         assert_eq!(body, "Task body");
@@ -211,7 +211,7 @@ mod tests {
         let done_path = paths::done_tasks_dir(tmp.path(), "proj").join(fname);
         assert!(done_path.exists());
         let content = fs::read_to_string(&done_path).unwrap();
-        let (fm, body): (TaskFrontmatter, String) = frontmatter::parse(&content).unwrap();
+        let (fm, body): (TaskFrontmatter, &str) = frontmatter::parse(&content).unwrap();
         assert_eq!(fm.title, "Task");
         assert!(fm.completed.is_some());
         assert_eq!(fm.tags, vec!["a"]);
@@ -260,7 +260,7 @@ mod tests {
         .unwrap();
 
         let content = fs::read_to_string(active_dir.join(fname)).unwrap();
-        let (fm, body): (TaskFrontmatter, String) = frontmatter::parse(&content).unwrap();
+        let (fm, body): (TaskFrontmatter, &str) = frontmatter::parse(&content).unwrap();
         assert_eq!(fm.title, "New Title");
         assert_eq!(fm.tags, vec!["updated"]);
         assert_eq!(body, "new body");

--- a/core/src/project/task/summary.rs
+++ b/core/src/project/task/summary.rs
@@ -16,14 +16,14 @@ pub struct Summary {
 
 impl Summary {
     pub fn from_content(filename: &str, content: &str) -> Result<Self, CoreError> {
-        let (fm, body): (TaskFrontmatter, String) = frontmatter::parse(content)?;
+        let (fm, body): (TaskFrontmatter, &str) = frontmatter::parse(content)?;
         Ok(Self {
             filename: filename.to_string(),
             title: fm.title,
             created: fm.created,
             completed: fm.completed,
             tags: fm.tags,
-            body,
+            body: body.to_string(),
         })
     }
 

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -3,8 +3,10 @@ use std::path::Path;
 use serde::Serialize;
 
 use crate::error::CoreError;
+use crate::timeline::Timeline;
+use crate::timeline::repository::split_entries;
 use crate::utils::markdown::strip_timeline_prefix;
-use crate::{list_notes, list_timeline_dates, read_timeline};
+use crate::{list_notes, list_timeline_dates};
 
 /// 検索結果がどちらの保管場所から来たか。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -42,18 +44,32 @@ pub fn search_all(base_dir: &Path, query: &str) -> Result<Vec<SearchHit>, CoreEr
     }
 
     let mut hits = Vec::new();
+    let timeline = Timeline::new(base_dir.to_path_buf());
+    // 改行をまたぐ needle だけは日単位の足切りが使えない。CRLF のファイルでは
+    // エントリ内の改行が "\n" に正規化され、ファイル本文の部分文字列にならない。
+    let day_filter_applies = !needle.contains('\n');
 
     for date in list_timeline_dates(base_dir)? {
+        let Some(content) = timeline.read_raw(date)? else {
+            continue;
+        };
+        // エントリ本文はその日のファイルの部分文字列なので、ファイル全体に無いなら
+        // どのエントリにも無い。分割もコンテキスト JSON の判定も丸ごと省ける。
+        if day_filter_applies && !content.to_lowercase().contains(&needle) {
+            continue;
+        }
+
         let formatted = date.format("%Y-%m-%d").to_string();
-        for (index, entry) in read_timeline(base_dir, date)?.into_iter().enumerate() {
+        for (index, entry) in split_entries(&content).into_iter().enumerate() {
             let text = strip_timeline_prefix(&entry);
-            if !text.to_lowercase().contains(&needle) {
+            let lowered = text.to_lowercase();
+            if !lowered.contains(&needle) {
                 continue;
             }
             hits.push(SearchHit {
                 kind: HitKind::Timeline,
                 title: first_line(text).to_string(),
-                snippet: snippet(text, &needle),
+                snippet: snippet(text, &lowered, &needle),
                 date: formatted.clone(),
                 filename: None,
                 index: Some(index),
@@ -62,15 +78,23 @@ pub fn search_all(base_dir: &Path, query: &str) -> Result<Vec<SearchHit>, CoreEr
         }
     }
 
+    let mut haystack = String::new();
     for note in list_notes(base_dir)? {
-        let haystack = format!("{} {}", note.preview, note.tags.join(" "));
+        // format! + join だとノート 1 件につき 2 回余分に確保する。
+        haystack.clear();
+        haystack.push_str(&note.preview);
+        for tag in &note.tags {
+            haystack.push(' ');
+            haystack.push_str(tag);
+        }
         if !haystack.to_lowercase().contains(&needle) {
             continue;
         }
+        let lowered = note.preview.to_lowercase();
         hits.push(SearchHit {
             kind: HitKind::Note,
             title: first_line(&note.preview).to_string(),
-            snippet: snippet(&note.preview, &needle),
+            snippet: snippet(&note.preview, &lowered, &needle),
             date: note
                 .time
                 .map(|t| t.format("%Y-%m-%d").to_string())
@@ -91,28 +115,33 @@ fn first_line(text: &str) -> &str {
 }
 
 /// ヒット位置の前後 `SNIPPET_CONTEXT` 文字を、文字境界を壊さずに切り出す。
-fn snippet(text: &str, needle: &str) -> String {
-    let chars: Vec<char> = text.chars().collect();
-    let lowered: Vec<char> = text.to_lowercase().chars().collect();
-    let needle_chars: Vec<char> = needle.chars().collect();
-
+/// `lowered` は照合に使った `text` の小文字版。作り直さず受け取るのは、
+/// ここが 1 ヒットごとに走るため。
+fn snippet(text: &str, lowered: &str, needle: &str) -> String {
+    // ヒットしたのが本文以外（ノートのタグなど）なら先頭から切り出す。
     let at = lowered
-        .windows(needle_chars.len().max(1))
-        .position(|w| w == needle_chars.as_slice())
-        .unwrap_or(0);
-
+        .find(needle)
+        .map_or(0, |byte| lowered[..byte].chars().count());
+    let end = at + needle.chars().count() + SNIPPET_CONTEXT;
     let start = at.saturating_sub(SNIPPET_CONTEXT);
-    let end = (at + needle_chars.len() + SNIPPET_CONTEXT).min(chars.len());
 
     let mut out = String::new();
     if start > 0 {
         out.push('…');
     }
-    out.extend(&chars[start..end]);
-    if end < chars.len() {
+    // Vec<char> を 3 本作らずに 1 度だけ走査する。
+    let mut chars = text.chars().skip(start);
+    for _ in start..end {
+        match chars.next() {
+            Some('\n') => out.push(' '),
+            Some(c) => out.push(c),
+            None => return out,
+        }
+    }
+    if chars.next().is_some() {
         out.push('…');
     }
-    out.replace('\n', " ")
+    out
 }
 
 #[cfg(test)]
@@ -202,6 +231,41 @@ mod tests {
         assert!(hits[0].snippet.starts_with('…'));
         assert!(hits[0].snippet.ends_with('…'));
         assert!(hits[0].snippet.contains("NEEDLE"));
+    }
+
+    #[test]
+    fn finds_a_needle_on_a_later_line_of_a_multiline_entry() {
+        let tmp = TempDir::new().unwrap();
+        save_timeline_entry(tmp.path(), "一行目\n二行目にリトライ", &context()).unwrap();
+
+        let hits = search_all(tmp.path(), "リトライ").unwrap();
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "一行目");
+        assert!(hits[0].snippet.contains("二行目にリトライ"));
+    }
+
+    #[test]
+    fn a_tag_only_hit_shows_the_start_of_the_body() {
+        let tmp = TempDir::new().unwrap();
+        let body = "本文はタグと無関係で長い".repeat(10);
+        create_draft_note(tmp.path(), &body, &["sync".to_string()], &context()).unwrap();
+
+        let hits = search_all(tmp.path(), "sync").unwrap();
+
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].snippet.starts_with("本文はタグと無関係で長い"));
+        assert!(!hits[0].snippet.starts_with('…'));
+    }
+
+    #[test]
+    fn a_snippet_keeps_the_body_on_one_line() {
+        let tmp = TempDir::new().unwrap();
+        save_timeline_entry(tmp.path(), "needle のあと\n改行", &context()).unwrap();
+
+        let hits = search_all(tmp.path(), "needle").unwrap();
+
+        assert_eq!(hits[0].snippet, "needle のあと 改行");
     }
 
     #[test]

--- a/core/src/sync/scan.rs
+++ b/core/src/sync/scan.rs
@@ -1,4 +1,5 @@
-use std::fs;
+use std::fs::{self, File};
+use std::io::Read as _;
 use std::path::Path;
 use std::time::SystemTime;
 
@@ -27,41 +28,57 @@ pub fn scan_local_files(base_dir: &Path) -> Result<Vec<LocalFile>, CoreError> {
 }
 
 fn walk_dir(root: &Path, current: &Path, files: &mut Vec<LocalFile>) -> Result<(), CoreError> {
-    let entries = fs::read_dir(current)?;
-    for entry in entries {
+    let mut content = Vec::new();
+    for entry in fs::read_dir(current)? {
         let entry = entry?;
         let path = entry.path();
 
-        if path.is_dir() {
-            walk_dir(root, &path, files)?;
-        } else if path.is_file() {
-            let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-
-            if is_excluded(file_name) {
+        // readdir が返す d_type をそのまま使う。path.is_dir() と path.is_file() は
+        // それぞれ stat を発行するので、metadata と合わせて 1 件につき 3 回叩いていた。
+        let file_type = entry.file_type()?;
+        let metadata = if file_type.is_symlink() {
+            // リンク先を見るのは従来どおり。壊れたリンクは走査対象から外す。
+            let Ok(metadata) = fs::metadata(&path) else {
                 continue;
-            }
+            };
+            metadata
+        } else {
+            entry.metadata()?
+        };
 
-            let relative = path
-                .strip_prefix(root)
-                .map_err(|e| CoreError::Sync(e.to_string()))?;
-            let key = relative
-                .to_str()
-                .ok_or_else(|| CoreError::Sync("non-UTF8 path".to_string()))?
-                .to_string();
-
-            let metadata = fs::metadata(&path)?;
-            let modified: DateTime<Utc> =
-                metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH).into();
-
-            let content = fs::read(&path)?;
-            let hash = compute_hash(&content);
-
-            files.push(LocalFile {
-                key,
-                last_modified: modified,
-                content_hash: hash,
-            });
+        if metadata.is_dir() {
+            walk_dir(root, &path, files)?;
+            continue;
         }
+        if !metadata.is_file() {
+            continue;
+        }
+
+        let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if is_excluded(file_name) {
+            continue;
+        }
+
+        let relative = path
+            .strip_prefix(root)
+            .map_err(|e| CoreError::Sync(e.to_string()))?;
+        let key = relative
+            .to_str()
+            .ok_or_else(|| CoreError::Sync("non-UTF8 path".to_string()))?
+            .to_string();
+
+        let modified: DateTime<Utc> = metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH).into();
+
+        // バッファを使い回してファイル 1 件ごとの確保をなくす。
+        content.clear();
+        content.reserve(usize::try_from(metadata.len()).unwrap_or(0));
+        File::open(&path)?.read_to_end(&mut content)?;
+
+        files.push(LocalFile {
+            key,
+            last_modified: modified,
+            content_hash: compute_hash(&content),
+        });
     }
     Ok(())
 }
@@ -74,9 +91,19 @@ fn is_excluded(file_name: &str) -> bool {
 }
 
 fn compute_hash(content: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+
     let mut hasher = Sha256::new();
     hasher.update(content);
-    format!("{:x}", hasher.finalize())
+    // format!("{:x}") は 32 バイトぶん fmt を通る。出力長は常に 64 文字なので
+    // 直接組み立てたほうが速く、確保も 1 回で済む。
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        out.push(char::from(HEX[usize::from(byte >> 4)]));
+        out.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    out
 }
 
 #[cfg(test)]
@@ -141,5 +168,40 @@ mod tests {
         let h2 = compute_hash(b"hello world");
         assert_eq!(h1, h2);
         assert_ne!(h1, compute_hash(b"different"));
+    }
+
+    /// ハッシュはサーバーと突き合わせる値なので、桁落ちや大文字化は同期を壊す。
+    #[test]
+    fn compute_hash_is_lowercase_zero_padded_hex() {
+        assert_eq!(
+            compute_hash(b"hello world"),
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+    }
+
+    #[test]
+    fn scan_follows_symlinked_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let data = dir.path().join("data");
+        let notes = data.join("notes");
+        fs::create_dir_all(&notes).unwrap();
+        fs::write(dir.path().join("outside.md"), "hello").unwrap();
+        std::os::unix::fs::symlink(dir.path().join("outside.md"), notes.join("linked.md")).unwrap();
+
+        let files = scan_local_files(dir.path()).unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].key, "notes/linked.md");
+        assert_eq!(files[0].content_hash, compute_hash(b"hello"));
+    }
+
+    #[test]
+    fn scan_skips_broken_symlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        let notes = dir.path().join("data").join("notes");
+        fs::create_dir_all(&notes).unwrap();
+        std::os::unix::fs::symlink(dir.path().join("gone.md"), notes.join("dangling.md")).unwrap();
+
+        assert!(scan_local_files(dir.path()).unwrap().is_empty());
     }
 }

--- a/core/src/timeline/repository.rs
+++ b/core/src/timeline/repository.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io;
 use std::path::PathBuf;
 
 use chrono::{Local, NaiveDate};
@@ -61,11 +62,22 @@ impl Timeline {
     }
 
     pub(crate) fn read(&self, date: NaiveDate) -> Result<Vec<String>, CoreError> {
-        let file_path = timeline_file_path(&self.base_dir, date);
-        if !file_path.exists() {
-            return Ok(Vec::new());
+        Ok(self
+            .read_raw(date)?
+            .as_deref()
+            .map(split_entries)
+            .unwrap_or_default())
+    }
+
+    /// その日のファイルをそのまま返す。存在しなければ `None`。
+    /// 先に `exists()` を挟まないのは、読めるかどうかは開いてみれば分かるからで、
+    /// 全日付を舐める検索では stat の 1 回が日数ぶん積み上がる。
+    pub(crate) fn read_raw(&self, date: NaiveDate) -> Result<Option<String>, CoreError> {
+        match fs::read_to_string(timeline_file_path(&self.base_dir, date)) {
+            Ok(content) => Ok(Some(content)),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
         }
-        Ok(split_entries(&fs::read_to_string(&file_path)?))
     }
 
     pub(crate) fn update_entry(
@@ -118,7 +130,7 @@ impl Timeline {
 }
 
 /// エントリは "- [" で始まる行から次の "- [" まで（本文に改行を含み得る）
-fn split_entries(content: &str) -> Vec<String> {
+pub(crate) fn split_entries(content: &str) -> Vec<String> {
     let mut entries: Vec<String> = Vec::new();
     for line in content.lines() {
         if line.starts_with("- [") || entries.is_empty() {
@@ -131,10 +143,11 @@ fn split_entries(content: &str) -> Vec<String> {
             last.push_str(line);
         }
     }
+    // 末尾を落とすのに to_string() を挟むと 1 エントリにつきもう 1 回確保する。
+    for entry in &mut entries {
+        entry.truncate(entry.trim_end().len());
+    }
     entries
-        .into_iter()
-        .map(|e| e.trim_end().to_string())
-        .collect()
 }
 
 /// 本文だけを差し替え、時刻プレフィックスと末尾のコンテキスト JSON は元のまま残す。

--- a/core/src/utils/frontmatter.rs
+++ b/core/src/utils/frontmatter.rs
@@ -35,10 +35,10 @@ pub fn render<T: Serialize>(fm: &T, body: &str) -> Result<String, CoreError> {
     Ok(format!("---\n{yaml}---\n{body}"))
 }
 
-pub fn parse<T: DeserializeOwned>(content: &str) -> Result<(T, String), CoreError> {
-    let (fm, body) = markdown_frontmatter::parse::<T>(content)
-        .map_err(|e| CoreError::Parse(format!("{e:?}")))?;
-    Ok((fm, body.to_string()))
+/// 本文は `content` を借りて返す。呼び出し側の多くは先頭だけしか使わないので、
+/// ここで所有権を持たせると読み捨てるぶんまで丸ごと複製することになる。
+pub fn parse<T: DeserializeOwned>(content: &str) -> Result<(T, &str), CoreError> {
+    markdown_frontmatter::parse::<T>(content).map_err(|e| CoreError::Parse(format!("{e:?}")))
 }
 
 #[cfg(test)]
@@ -143,7 +143,7 @@ mod tests {
     fn test_note_frontmatter_old_format_compat() {
         // Old format only had battery and is_charging
         let yaml = "---\ntime: 2026-03-20T14:30:45+09:00\ntags: []\ncontext:\n  battery: 82\n  is_charging: false\n---\nbody";
-        let (fm, body): (NoteFrontmatter, String) = parse(yaml).unwrap();
+        let (fm, body): (NoteFrontmatter, &str) = parse(yaml).unwrap();
         let ctx = fm.context.unwrap();
         assert_eq!(ctx.battery, Some(82));
         assert_eq!(ctx.is_charging, Some(false));

--- a/core/src/utils/fs.rs
+++ b/core/src/utils/fs.rs
@@ -10,6 +10,14 @@ pub fn ensure_dir(path: &Path) -> Result<(), CoreError> {
     Ok(())
 }
 
+/// `e.path()` はディレクトリ名まで含めた `PathBuf` を確保する。拡張子を見るだけなら
+/// ファイル名で足りるので、エントリごとの確保をそのぶん小さくできる。
+fn is_md(entry: &DirEntry) -> bool {
+    Path::new(&entry.file_name())
+        .extension()
+        .is_some_and(|ext| ext == "md")
+}
+
 pub fn list_md_files(dir: &Path) -> Result<Vec<DirEntry>, CoreError> {
     if !dir.exists() {
         return Ok(Vec::new());
@@ -17,10 +25,11 @@ pub fn list_md_files(dir: &Path) -> Result<Vec<DirEntry>, CoreError> {
 
     let mut entries: Vec<_> = fs::read_dir(dir)?
         .filter_map(Result::ok)
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+        .filter(is_md)
         .collect();
 
-    entries.sort_by_key(|e| std::cmp::Reverse(e.file_name()));
+    // file_name() は毎回 OsString を確保するので、比較のたびに呼ばせない。
+    entries.sort_by_cached_key(|e| std::cmp::Reverse(e.file_name()));
     Ok(entries)
 }
 
@@ -31,6 +40,52 @@ pub fn count_md_files(dir: &Path) -> Result<usize, CoreError> {
 
     Ok(fs::read_dir(dir)?
         .filter_map(Result::ok)
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+        .filter(is_md)
         .count())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn seed(names: &[&str]) -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        for name in names {
+            fs::write(tmp.path().join(name), "x").unwrap();
+        }
+        tmp
+    }
+
+    #[test]
+    fn lists_only_md_files_newest_name_first() {
+        let tmp = seed(&["a.md", "b.md", "c.txt", "no-extension"]);
+
+        let names: Vec<_> = list_md_files(tmp.path())
+            .unwrap()
+            .iter()
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+
+        assert_eq!(names, vec!["b.md", "a.md"]);
+    }
+
+    /// `.md` はドットファイルであって拡張子ではない。`Path::extension` の判定に
+    /// 揃えているので、名前の末尾一致に置き換わっていないことを確かめる。
+    #[test]
+    fn a_file_named_just_md_is_not_a_note() {
+        let tmp = seed(&[".md"]);
+
+        assert!(list_md_files(tmp.path()).unwrap().is_empty());
+        assert_eq!(count_md_files(tmp.path()).unwrap(), 0);
+    }
+
+    #[test]
+    fn a_missing_directory_is_empty_rather_than_an_error() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("nope");
+
+        assert!(list_md_files(&missing).unwrap().is_empty());
+        assert_eq!(count_md_files(&missing).unwrap(), 0);
+    }
 }

--- a/core/src/utils/markdown.rs
+++ b/core/src/utils/markdown.rs
@@ -105,7 +105,7 @@ mod tests {
             format_note_markdown("# Hello\nWorld", &tags, fixed_timestamp(), &test_context())
                 .unwrap();
 
-        let (fm, body): (NoteFrontmatter, String) = frontmatter::parse(&result).unwrap();
+        let (fm, body): (NoteFrontmatter, &str) = frontmatter::parse(&result).unwrap();
         assert_eq!(fm.tags, vec!["rust", "memo"]);
         assert!(fm.context.is_some());
         let ctx = fm.context.unwrap();
@@ -117,7 +117,7 @@ mod tests {
     #[test]
     fn test_format_note_markdown_empty_tags() {
         let result = format_note_markdown("body", &[], fixed_timestamp(), &test_context()).unwrap();
-        let (fm, _body): (NoteFrontmatter, String) = frontmatter::parse(&result).unwrap();
+        let (fm, _body): (NoteFrontmatter, &str) = frontmatter::parse(&result).unwrap();
         assert!(fm.tags.is_empty());
     }
 
@@ -129,7 +129,7 @@ mod tests {
             ..Context::default()
         };
         let result = format_note_markdown("body", &[], fixed_timestamp(), &ctx).unwrap();
-        let (fm, _body): (NoteFrontmatter, String) = frontmatter::parse(&result).unwrap();
+        let (fm, _body): (NoteFrontmatter, &str) = frontmatter::parse(&result).unwrap();
         let context = fm.context.unwrap();
         assert_eq!(context.battery, Some(100));
         assert_eq!(context.is_charging, Some(true));

--- a/core/src/utils/markdown.rs
+++ b/core/src/utils/markdown.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, FixedOffset, Local};
+use serde::de::IgnoredAny;
 
 use crate::error::CoreError;
 use crate::utils::device::Context;
@@ -28,9 +29,11 @@ pub(crate) fn split_time_prefix(entry: &str) -> Option<(&str, &str)> {
 pub(crate) fn split_context_json(rest: &str) -> Option<&str> {
     let start = rest.rfind(" {")?;
     let candidate = &rest[start + 1..];
-    serde_json::from_str::<serde_json::Value>(candidate)
+    // `Value` を組み立てて is_object を見ない: candidate は必ず `{` で始まるので、
+    // 構文として通れば JSON オブジェクト以外にはなり得ない。`IgnoredAny` なら
+    // 検証だけを行い、Map も String も確保しない。
+    serde_json::from_str::<IgnoredAny>(candidate)
         .ok()
-        .filter(serde_json::Value::is_object)
         .map(|_| candidate)
 }
 

--- a/tauri-app/src/lib/markdown.test.ts
+++ b/tauri-app/src/lib/markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { renderMarkdownSync } from "./markdown";
+import { SHIKI_SLOT, renderMarkdown, renderMarkdownSync } from "./markdown";
 
 describe("renderMarkdownSync", () => {
   it("converts a heading", () => {
@@ -43,5 +43,44 @@ describe("renderMarkdownSync", () => {
   it("returns empty string for empty string", () => {
     const html = renderMarkdownSync("");
     expect(html.trim()).toBe("");
+  });
+});
+
+describe("renderMarkdown", () => {
+  it("highlights every code block", async () => {
+    const source = ["```ts", "const a = 1;", "```", "", "```rust", "let b = 2;", "```"].join("\n");
+
+    const html = await renderMarkdown(source);
+
+    expect(html.split('<pre class="shiki').length - 1).toBe(2);
+  });
+
+  it("leaves no marker behind when the code contains a replacement pattern", async () => {
+    // "$&" は String.replace の置換文字列ではマッチ全体に展開される。差し替えを
+    // 文字列で渡していると、目印の markup がそのまま本文に混ざって出てくる。
+    const source = ["```bash", 'echo "cost: 1 $& 2" $` $\' $$', "```"].join("\n");
+
+    const html = await renderMarkdown(source);
+
+    expect(html).not.toContain("shiki-placeholder");
+    expect(html).not.toContain(SHIKI_SLOT);
+    expect(html.split('<pre class="shiki').length - 1).toBe(1);
+  });
+
+  it("does not let the source forge a slot marker", async () => {
+    // markdown-it が U+0000 を U+FFFD に潰すことに寄りかかっている。潰れなければ
+    // 本文がハイライト結果の差し込み位置を偽装できてしまう。
+    const source = [`${SHIKI_SLOT} は本文`, "", "```text", SHIKI_SLOT, "```"].join("\n");
+
+    const html = await renderMarkdown(source);
+
+    expect(html).not.toContain(SHIKI_SLOT);
+    expect(html.split('<pre class="shiki').length - 1).toBe(1);
+  });
+
+  it("renders prose without a highlighter when there is no code block", async () => {
+    const html = await renderMarkdown("# Hello");
+
+    expect(html).toContain("<h1>Hello</h1>");
   });
 });

--- a/tauri-app/src/lib/markdown.ts
+++ b/tauri-app/src/lib/markdown.ts
@@ -12,7 +12,6 @@ export function renderMarkdownSync(source: string): string {
 }
 
 interface ShikiBlock {
-  id: string;
   code: string;
   lang: string;
 }
@@ -27,47 +26,67 @@ const fenceMd = new MarkdownIt({
   typographer: true,
 });
 
+/**
+ * ハイライト結果を差し込む目印。markdown-it は CommonMark どおり入力中の U+0000 を
+ * U+FFFD に潰すので、本文がこの形を作ることはない。
+ * リテラルに直接書くと制御文字が混ざるため、コード側で組み立てる。
+ */
+const NUL = String.fromCodePoint(0);
+export const SHIKI_SLOT = `${NUL}shiki${NUL}`;
+
 fenceMd.renderer.rules.fence = (tokens, idx, _options, renderEnv: RenderEnv) => {
   const token = tokens[idx];
-  const lang = token.info.trim();
-  const code = token.content;
-
-  const id = `shiki-${idx}`;
-  renderEnv.__shikiBlocks = renderEnv.__shikiBlocks || [];
-  renderEnv.__shikiBlocks.push({ id, code, lang });
-
-  return `<div id="${id}" class="shiki-placeholder"><pre><code>${fenceMd.utils.escapeHtml(code)}</code></pre></div>`;
+  (renderEnv.__shikiBlocks ??= []).push({ code: token.content, lang: token.info.trim() });
+  return SHIKI_SLOT;
 };
+
+function plainBlock(code: string): string {
+  return `<pre><code>${fenceMd.utils.escapeHtml(code)}</code></pre>`;
+}
+
+async function highlightBlocks(blocks: ShikiBlock[]): Promise<string[]> {
+  let highlighter;
+  try {
+    highlighter = await getHighlighter();
+  } catch {
+    return blocks.map((block) => plainBlock(block.code));
+  }
+
+  // getLoadedLanguages() は呼ぶたびに配列を組み直すので、ブロックごとには引かない
+  const loaded = new Set(highlighter.getLoadedLanguages());
+  return blocks.map((block) => {
+    try {
+      // デュアルテーマで描画し、テーマ切替にはCSS変数で即追従させる
+      return highlighter.codeToHtml(block.code, {
+        // 未ロード言語はプレーンテキストとして描画（フルバンドルを避けるため）
+        lang: loaded.has(block.lang) ? block.lang : "text",
+        themes: {
+          light: "github-light-default",
+          dark: "github-dark-default",
+        },
+        defaultColor: false,
+      });
+    } catch {
+      return plainBlock(block.code);
+    }
+  });
+}
 
 export async function renderMarkdown(source: string): Promise<string> {
   const env: RenderEnv = {};
-  let html = fenceMd.render(source, env);
+  const html = fenceMd.render(source, env);
 
-  const blocks = env.__shikiBlocks || [];
-  if (blocks.length > 0) {
-    const highlighter = await getHighlighter();
-    for (const block of blocks) {
-      // 未ロード言語はプレーンテキストとして描画（フルバンドルを避けるため）
-      const lang = highlighter.getLoadedLanguages().includes(block.lang) ? block.lang : "text";
-      try {
-        // デュアルテーマで描画し、テーマ切替にはCSS変数で即追従させる
-        const highlighted = highlighter.codeToHtml(block.code, {
-          lang,
-          themes: {
-            light: "github-light-default",
-            dark: "github-dark-default",
-          },
-          defaultColor: false,
-        });
-        html = html.replace(
-          `<div id="${block.id}" class="shiki-placeholder"><pre><code>${fenceMd.utils.escapeHtml(block.code)}</code></pre></div>`,
-          highlighted,
-        );
-      } catch {
-        // keep fallback
-      }
-    }
+  const blocks = env.__shikiBlocks;
+  if (!blocks || blocks.length === 0) {
+    return html;
   }
 
-  return html;
+  const highlighted = await highlightBlocks(blocks);
+  // 分割して隙間を埋める。ブロックごとに replace すると、そのたびに文書全体を
+  // 走査して作り直すうえ、置換文字列の "$&" などが置換パターンとして解かれて
+  // 目印そのものが出力に混ざる。スロットは本文の出現順に積まれている。
+  const parts = html.split(SHIKI_SLOT);
+  return parts
+    .map((part, index) => (index === 0 ? part : highlighted[index - 1] + part))
+    .join("");
 }

--- a/tauri-app/src/lib/markdown.ts
+++ b/tauri-app/src/lib/markdown.ts
@@ -86,7 +86,5 @@ export async function renderMarkdown(source: string): Promise<string> {
   // 走査して作り直すうえ、置換文字列の "$&" などが置換パターンとして解かれて
   // 目印そのものが出力に混ざる。スロットは本文の出現順に積まれている。
   const parts = html.split(SHIKI_SLOT);
-  return parts
-    .map((part, index) => (index === 0 ? part : highlighted[index - 1] + part))
-    .join("");
+  return parts.map((part, index) => (index === 0 ? part : highlighted[index - 1] + part)).join("");
 }


### PR DESCRIPTION
## 背景

UI 操作のたびに走る core の関数（検索・一覧・同期スキャン）に計測が一切なく、体感の遅さを誰も数字にしていませんでした。まずワークロードを固定してベンチを敷き、フレームグラフが指した箇所だけを直しています。

推測での「速そうな書き換え」はしていません。すべて before/after を同一条件で取り直した数字が根拠です。

## 計測方法

- **ワークロード**: ヘビーユーザー 1 年分に固定（365 日 × 20 エントリ + ノート 500 件 = 865 ファイル）
- **環境**: Apple M4 Max / macOS 25.5.0、criterion 100 サンプル、`bench` プロファイル（optimized + debuginfo）
- **フレームグラフ**: macOS `sample` → `stackcollapse-sample.awk` → `flamegraph.pl`

計測中に、**同一コードのまま session 内で +6.8% のドリフト**（サーマル）が出ました。途中の単発比較はすべて破棄し、最終数値は「元コード → 変更後」を**連続実行**で取り直しています。

## 結果

| Benchmark | Before | After | Delta |
| --- | --- | --- | --- |
| `search_all` / miss | 19.61 ms | 16.60 ms | **−15.3%** |
| `search_all` / rare | 20.21 ms | 17.49 ms | **−13.4%** |
| `search_all` / common | 24.25 ms | 21.67 ms | **−10.6%** |
| `scan_local_files` | 17.56 ms | 15.42 ms | **−12.2%** |
| `read_timeline_recent_14` | 226.15 µs | 205.08 µs | **−9.9%** |
| `list_notes` | 8.67 ms | 8.21 ms | **−5.4%** |
| `list_timeline_dates` | 159.55 µs | 157.91 µs | −2.1% |
| `renderMarkdown`（40 ブロック） | 134.34 ms | 123.77 ms | **−7.9%** |

全項目 p = 0.00。

## フレームグラフが指した無駄

| 症状 | 対処 | 結果 |
| --- | --- | --- |
| `split_context_json` が 15.7% — 「JSON オブジェクトか」を判定するためだけに `serde_json::Value`（Map と String）を構築 | `IgnoredAny` で構文検証のみ。候補は必ず `{` 始まりなので、通れば必ずオブジェクト | **15.7% → 0.0%** |
| 検索が全エントリに対して「分割 → コンテキスト JSON 除去 → 小文字化」を実行 | エントリ本文はその日のファイルの部分文字列なので、ファイル全体に無ければ日ごと丸ごと棄却 | `split_entries` **3.2% → 0.0%** |
| `scan_local_files` の 22.3% が `stat` — `is_dir()` / `is_file()` / `metadata()` で 1 エントリ 3 回。SHA-256 本体（19.4%）より重い | readdir が返す `d_type` を使い 1 回に | stat が大幅減 |
| `snippet()` が `Vec<char>` を 3 本作り `windows().position()` で O(n·m) 走査 | 照合で作った小文字列を渡し、1 回の走査に | 確保が消滅 |
| `frontmatter::parse` が本文を丸ごと複製 → 呼び出し側は先頭 100 文字しか使わない | `&str` を返し、所有権が要る 1 箇所だけで確保 | ノート 1 件あたり 1 複製削減 |

日ごとの早期棄却は、needle が改行をまたぐ場合だけ無効にしています。CRLF のファイルではエントリ内の改行が `\n` に正規化され、ファイル本文の部分文字列にならなくなるためです。

## 副産物: 実バグを 1 件修正

`renderMarkdown` がハイライト結果を `html.replace(placeholder, highlighted)` で差し込んでいました。**`String.replace` は置換“文字列”の中の `$&` `` $` `` `$'` `$$` を置換パターンとして解釈します。**

そのため `$&` を含むコードブロック（シェルスクリプトなど）を書くと、内部マーカー `<div class="shiki-placeholder">` が本文に露出します。

40 ブロックの実測で:

- プレースホルダ断片が **384 個漏出**
- `innerHTML` に渡る HTML が **649,112 → 1,020,008 文字**（**57% が重複ゴミ**）

NUL 区切りマーカー + `split` / `join` に置き換え、置換パターンの文法自体をなくしました。markdown-it は CommonMark どおり入力中の U+0000 を U+FFFD に潰すので、本文がマーカーを偽装できません。**この 2 つの性質にテストを追加しています。**

あわせて、ブロックごとに文書全体を走査し直していたのが 1 パスになり、ロード済み言語一覧もブロックごとの再構築をやめました。

## 残した天井

変更後の `search_all` は残り時間の **65% が純粋なファイル I/O**（`open` だけで 48.9%）です。865 ファイルを毎キーストローク読み直す構造が下限で、ここから先は mtime 検証つきキャッシュが要ります。

**入れていません。** 同期がバックグラウンドでファイルを書き換えるため陳腐化の扱いが必要で、「Simple UI / Lightweight」の優先順位に対して複雑さが見合うかは、実機（Android）の絶対値を見てから判断すべきだと考えたためです。デスクトップの 16.6 ms は体感できませんが、実機で 100 ms を超えるなら根拠になります。

## 検証

`just verify` 完走。

- Rust 145 テスト / frontend 101 テスト / workers 23 テスト
- fmt・clippy（`pedantic` + `nursery` + `cargo` すべて deny）・oxlint・tsgo・knip すべてパス

ベンチは `core/benches/` に残してあります（`cargo bench -p magical-merchant-core`）。criterion の `--save-baseline` / `--baseline` で次回以降も同じ比較ができます。フレームグラフの SVG は `profiles/`（`.gitignore` 済み）です。