### PR TITLE
fix(build): install node deps before the dev recipes

### DIFF
--- a/tauri-app/justfile
+++ b/tauri-app/justfile
@@ -17,13 +17,13 @@ check: setup
 test: setup
   pnpm test
 
-dev:
+dev: setup
   pnpm tauri dev
 
 android-init:
   pnpm tauri android init
 
-android-dev:
+android-dev: setup
   pnpm tauri android dev
 
 android-build:


### PR DESCRIPTION
## 何が問題だったか

`just dev` が起動しなかった。`src/lib/mermaid.ts` の dynamic import を Vite が解決できず 500 を返していた。

```
[vite] Internal server error: Failed to resolve import "mermaid" from "src/lib/mermaid.ts". Does the file exist?
```

`package.json` には `mermaid ^11.16.0` があるのに `node_modules` に入っていなかった。#76 で追加された依存が、ブランチ切り替え後に `pnpm install` されないままだったため。

## 原因

`tauri-app/justfile` で `dev` と `android-dev` だけが `setup`（`pnpm install`）に依存していなかった。`assets` / `check` / `test` はすでに依存している。

## 変更

```diff
-dev:
+dev: setup
   pnpm tauri dev

-android-dev:
+android-dev: setup
   pnpm tauri android dev
```

## 確認

- `just --unstable --evaluate` でパース確認
- `just dev` でアプリ起動を確認

## スコープ外

`build` / `android-build*` 系も同じく `setup` に依存していない。必要なら別途。