### PR TITLE
fix(sync): let the Worker own the sync state, and ship macOS/Android builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       rust: ${{ steps.filter.outputs.rust || 'true' }}
       frontend: ${{ steps.filter.outputs.frontend || 'true' }}
       workers: ${{ steps.filter.outputs.workers || 'true' }}
+      nix-package: ${{ steps.filter.outputs.nix-package || 'true' }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -58,6 +59,12 @@ jobs:
             workers:
               - 'workers/**'
               - '.oxlintrc.json'
+              - 'flake.nix'
+              - 'flake.lock'
+            nix-package:
+              - 'tauri-app/pnpm-lock.yaml'
+              - 'tauri-app/package.json'
+              - 'nix/package.nix'
               - 'flake.nix'
               - 'flake.lock'
 
@@ -140,6 +147,24 @@ jobs:
         run: nix develop .#workers --command just workers::check
       - name: test
         run: nix develop .#workers --command just workers::test
+
+  # pnpm-lock.yaml を変えると nix/package.nix の pnpmDeps.hash が黙って腐る。
+  # 気付くのが macOS 配布 (nix build) の時では遅い
+  nix-package:
+    needs: changes
+    if: needs.changes.outputs.nix-package == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: nixbuild/nix-quick-install-action@v35
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-pnpmdeps-${{ hashFiles('flake.lock', 'flake.nix', 'tauri-app/pnpm-lock.yaml') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-pnpmdeps-
+          gc-max-store-size-linux: 2G
+      - name: pnpm deps hash is current
+        run: nix build .#pnpm-deps --no-link
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: Release
+
+# 個人利用のテスト配信。Play Store には出さず、署名済み APK を
+# GitHub Release に添付する（端末側で「提供元不明のアプリ」を許可して入れる）。
+# macOS は Nix 経由で配るのでここではビルドしない (README の Install を参照)。
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.1.0). Must already exist."
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  android:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      # tauri.conf.json の version が Android の versionCode の元になる。
+      # タグとずれていると、更新のつもりが上書きインストールできない APK になる
+      - name: Check the tag matches tauri.conf.json
+        id: version
+        run: |
+          tag="${{ inputs.tag || github.ref_name }}"
+          version=$(jq -r .version tauri-app/src-tauri/tauri.conf.json)
+          if [ "$tag" != "v$version" ]; then
+            echo "::error::tag $tag does not match tauri.conf.json version $version"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Free disk space
+        run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+
+      - uses: nixbuild/nix-quick-install-action@v35
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-android-${{ hashFiles('flake.lock', 'flake.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-android-
+          gc-max-store-size-linux: 6G
+
+      - name: Generate the Android project
+        run: nix develop .#android --command just tauri_app::android-init
+
+      - name: Restore the signing keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          if [ -z "$KEYSTORE_BASE64" ]; then
+            echo "::error::secret ANDROID_KEYSTORE_BASE64 is not set (see tauri-app/android-signing/README.md)"
+            exit 1
+          fi
+          keystore="$RUNNER_TEMP/release.jks"
+          printf '%s' "$KEYSTORE_BASE64" | base64 -d > "$keystore"
+          # gen/android は gitignore 済み。パスワードはこのファイルにしか書かない
+          cat > tauri-app/src-tauri/gen/android/keystore.properties <<EOF
+          storeFile=$keystore
+          storePassword=$STORE_PASSWORD
+          keyAlias=$KEY_ALIAS
+          keyPassword=$KEY_PASSWORD
+          EOF
+
+      - name: Inject the signing config
+        run: nix develop .#android --command just tauri_app::android-sign-setup
+
+      - name: Build the signed APK
+        run: nix develop .#android --command just tauri_app::android-release-build
+
+      - name: Collect the APK
+        id: apk
+        run: |
+          src=tauri-app/src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release.apk
+          out="magical-merchant-${{ steps.version.outputs.version }}.apk"
+          cp "$src" "$out"
+          echo "path=$out" >> "$GITHUB_OUTPUT"
+
+      - name: Remove the signing material
+        if: always()
+        run: rm -f "$RUNNER_TEMP/release.jks" tauri-app/src-tauri/gen/android/keystore.properties
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          files: ${{ steps.apk.outputs.path }}
+          fail_on_unmatched_files: true
+          body: |
+            テスト配信ビルドです。Play Store 経由ではないので、端末側で
+            「提供元不明のアプリのインストール」を許可してから APK を開いてください。
+
+            macOS は Nix から入れてください:
+
+            ```sh
+            nix profile install github:Xantibody/magical-merchant/${{ inputs.tag || github.ref_name }}
+            ```

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ keystore.properties
 # Nix shims
 .nix-shims/
 
+# Nix build output symlink
+/result
+/result-*
+
 # Plans
 plans/
 

--- a/README.md
+++ b/README.md
@@ -67,23 +67,66 @@ just dev
 | -------- | ------------------------------------------------ |
 | Rust     | stable toolchain, clippy, rust-analyzer          |
 | Frontend | Node.js 22, pnpm, tsgo (type check), oxlint      |
-| Build    | just, cargo-tauri                                |
+| Build    | just, cargo-tauri, go (Android signing patcher)  |
 | Android  | JDK 17, Android SDK (API 36), NDK 29             |
 | Format   | nix fmt (treefmt: nixfmt, rustfmt, taplo, oxfmt) |
 
-## Build & Install (macOS)
+`nix develop` also exposes narrower shells so CI (and the release build) only
+fetch what they need:
 
-### Option 1: Nix (Recommended)
+| Shell        | Contents                             | Used by           |
+| ------------ | ------------------------------------ | ----------------- |
+| `.#default`  | Everything above                     | Local development |
+| `.#rust`     | Rust + clippy + just                 | CI (`rust`)       |
+| `.#frontend` | Node toolchain + Playwright browsers | CI (`frontend`)   |
+| `.#workers`  | Node toolchain                       | CI (`workers`)    |
+| `.#android`  | `.#default` minus browser automation | Release APK build |
+
+## Install
+
+### macOS — Nix (Recommended)
 
 ```sh
-# Build the .app bundle from source
-nix build .#default
+# Install into your Nix profile (adds /Applications/Nix Apps/Magical Merchant.app)
+nix profile install github:Xantibody/magical-merchant
 
-# The app is at result/Applications/Magical Merchant.app
+# …or pin a released version
+nix profile install github:Xantibody/magical-merchant/v0.1.0
+
+# Update later
+nix profile upgrade magical-merchant
+```
+
+To build from a local checkout instead:
+
+```sh
+nix build .#default
 open result/Applications/Magical\ Merchant.app
 ```
 
-### Option 2: nix-darwin module
+### Android — signed test APK
+
+Releases are side-loaded, not published to the Play Store. Grab the APK from
+[Releases](https://github.com/Xantibody/magical-merchant/releases), allow
+"install from unknown sources" on the device, and open it. Because every
+release is signed with the same key, a new APK installs over the previous one
+as an update.
+
+Tagging `vX.Y.Z` (matching `version` in `tauri-app/src-tauri/tauri.conf.json`)
+runs `.github/workflows/release.yml`, which builds and attaches the APK. The
+workflow needs these repository secrets:
+
+| Secret                      | Value                                            |
+| --------------------------- | ------------------------------------------------ |
+| `ANDROID_KEYSTORE_BASE64`   | `base64 -i ~/.android-keys/magical-merchant.jks` |
+| `ANDROID_KEYSTORE_PASSWORD` | Keystore password                                |
+| `ANDROID_KEY_ALIAS`         | Key alias (e.g. `magical-merchant`)              |
+| `ANDROID_KEY_PASSWORD`      | Key password                                     |
+
+See [`tauri-app/android-signing/README.md`](tauri-app/android-signing/README.md)
+for creating the keystore and for building locally.
+
+### macOS — nix-darwin module
 
 Add the flake input and enable the module in your nix-darwin configuration:
 
@@ -100,6 +143,7 @@ Add the flake input and enable the module in your nix-darwin configuration:
           services.magical-merchant = {
             enable = true;
             workersUrl = "https://your-worker.example.workers.dev"; # R2 sync URL; must not end with a trailing slash, or sync requests may become `//files`
+            autoSync = true; # sync after every successful save
           };
         }
       ];
@@ -108,9 +152,11 @@ Add the flake input and enable the module in your nix-darwin configuration:
 }
 ```
 
-The module installs the app to `/Applications/Nix Apps/` and writes `sync-config.json` with the configured `workersUrl`.
+The module installs the app to `/Applications/Nix Apps/` and writes a read-only
+`sync-config.json` from the options above (the app then hides the Settings
+fields it no longer owns).
 
-### Option 3: Manual build
+### macOS — manual build
 
 ```sh
 # Build the .app bundle
@@ -126,6 +172,41 @@ xattr -cr "/Applications/Magical Merchant.app"
 ## Sync Backend (Cloudflare Workers)
 
 The `workers/` directory contains a Cloudflare Workers backend that syncs data via R2. Authentication uses Google OAuth with self-issued JWTs.
+
+### How sync decides what to do
+
+The Worker owns the sync state. `_sync-state/<user>.json` maps every key to a
+content hash and a **server-issued version stamp**; both the Worker and each
+client store exactly those values, so change detection never depends on the
+filesystem mtime or on a device's clock.
+
+One sync is `GET /sync-state` → local scan → diff → one `POST /sync/bulk`:
+
+| Client sees                        | Action        | Effect on state       |
+| ---------------------------------- | ------------- | --------------------- |
+| Hash differs from the record       | Upload        | New hash, new stamp   |
+| Stamp differs from the record      | Download      | Unchanged             |
+| Both differ                        | Conflict      | Local wins, new stamp |
+| Gone locally, stamp still matching | Delete remote | Key removed           |
+| Gone remotely, hash still matching | Delete local  | (already removed)     |
+
+The client never sends a state of its own: doing so drops keys it has not
+downloaded yet, and the next sync would read that as "deleted everywhere" and
+erase the notes on every device. Writes use `expected_etag` for compare-and-swap,
+and the client retries a losing race automatically.
+
+Turning on **Auto sync** (sync popover, or `autoSync` in the nix-darwin module)
+runs a sync a few seconds after any successful write, so a note taken on the
+phone reaches the Mac without touching the sync button.
+
+The session JWT lives in the macOS Keychain on desktop. Android has no
+Keychain equivalent that `keyring` supports — it silently falls back to an
+in-memory store, which loses the token immediately — so on Android the token is
+written to the app-private data directory (mode `600`) instead.
+
+On a conflict the local copy wins the key, and the overwritten remote copy is
+kept both in R2 under `…​.sync-conflict-<timestamp>.md` and on disk next to the
+note. Conflict copies are excluded from scanning, so they never sync back.
 
 ### 1. Deploy the Worker
 
@@ -227,6 +308,14 @@ Communicates via stdio transport and provides the following read-only tools:
 | `just android-dev`   | Development on Android device       |     |
 | `just android-build` | Build Android APK                   |     |
 | `just build`         | Build macOS .app (Apple Silicon)    |     |
+
+### Android release recipes (`tauri_app::`)
+
+| Command                                   | Description                              |
+| ----------------------------------------- | ---------------------------------------- |
+| `just tauri_app::android-sign-setup`      | Re-inject the signing config into Gradle |
+| `just tauri_app::android-build-release`   | Build a signed release APK               |
+| `just tauri_app::android-install-release` | Build and install it over USB            |
 
 ### Rust recipes (`rust::`)
 

--- a/README.md
+++ b/README.md
@@ -214,8 +214,11 @@ note. Conflict copies are excluded from scanning, so they never sync back.
 cd workers
 pnpm install
 wrangler login
-wrangler deploy
+pnpm run deploy:worker
 ```
+
+> The script is not called `deploy` because `pnpm deploy` resolves to pnpm's
+> own workspace command and never runs the script.
 
 ### 2. Custom Domain (Optional)
 

--- a/flake.nix
+++ b/flake.nix
@@ -106,6 +106,36 @@
           just
         ];
 
+        # `tauri android init` は rustup 前提。Nix がターゲットを持っているので no-op にする
+        rustupShimHook = ''
+          mkdir -p "$PWD/.nix-shims"
+          cat > "$PWD/.nix-shims/rustup" << 'SHIM'
+          #!/usr/bin/env bash
+          # Nix manages Rust targets, so rustup calls are no-ops
+          if [[ "$1" == "target" && "$2" == "add" ]]; then
+            echo "info: target '$3' is already installed (managed by Nix)"
+            exit 0
+          fi
+          exec "$@"
+          SHIM
+          chmod +x "$PWD/.nix-shims/rustup"
+          export PATH="$PWD/.nix-shims:$PATH"
+        '';
+
+        androidEnv = {
+          ANDROID_HOME = androidSdkRoot;
+          NDK_HOME = "${androidSdkRoot}/ndk/${androidNdkVersion}";
+        };
+
+        # apply-signing.go (`just android-sign-setup`) と cargo-tauri の android サブコマンド
+        androidToolchain = [
+          rustToolchain
+          androidSdk
+          pkgs.cargo-tauri
+          pkgs.jdk17
+          pkgs.go
+        ];
+
         treefmtEval = treefmt-nix.lib.evalModule pkgs {
           projectRootFile = "flake.nix";
           programs.nixfmt.enable = true;
@@ -115,39 +145,37 @@
         };
       in
       {
-        packages.default = pkgs.callPackage ./nix/package.nix { };
+        packages = rec {
+          default = pkgs.callPackage ./nix/package.nix { };
+          # pnpm-lock.yaml を変えると package.nix の hash が黙って腐り、
+          # nix build (= macOS の配布経路) だけが後から壊れる。CI で単体で検証できるよう出す
+          pnpm-deps = default.pnpmDeps;
+        };
         formatter = treefmtEval.config.build.wrapper;
         checks.formatting = treefmtEval.config.build.check self;
         devShells.default = pkgs.mkShell (
           playwrightEnv
+          // androidEnv
           // {
-            buildInputs = [
-              rustToolchain
-              androidSdk
-              pkgs.cargo-tauri
-              pkgs.jdk17
-              pkgs.wrangler
-              pkgs.agent-browser
-            ]
-            ++ jsToolchain
-            ++ linuxTauriDeps;
-            ANDROID_HOME = androidSdkRoot;
-            NDK_HOME = "${androidSdkRoot}/ndk/${androidNdkVersion}";
-            shellHook = ''
-              # Create a rustup shim that no-ops for tauri android init
-              mkdir -p "$PWD/.nix-shims"
-              cat > "$PWD/.nix-shims/rustup" << 'SHIM'
-              #!/usr/bin/env bash
-              # Nix manages Rust targets, so rustup calls are no-ops
-              if [[ "$1" == "target" && "$2" == "add" ]]; then
-                echo "info: target '$3' is already installed (managed by Nix)"
-                exit 0
-              fi
-              exec "$@"
-              SHIM
-              chmod +x "$PWD/.nix-shims/rustup"
-              export PATH="$PWD/.nix-shims:$PATH"
-            '';
+            buildInputs =
+              androidToolchain
+              ++ [
+                pkgs.wrangler
+                pkgs.agent-browser
+              ]
+              ++ jsToolchain
+              ++ linuxTauriDeps;
+            shellHook = rustupShimHook;
+          }
+        );
+
+        # リリース用 APK をビルドする最小構成。default から Playwright と
+        # ブラウザ自動化を落としたぶん、CI の取得量が小さい
+        devShells.android = pkgs.mkShell (
+          androidEnv
+          // {
+            buildInputs = androidToolchain ++ jsToolchain;
+            shellHook = rustupShimHook;
           }
         );
 
@@ -170,6 +198,15 @@
       }
     )
     // {
-      darwinModules.default = import ./nix/darwin-module.nix;
+      # このフレークのパッケージを既定値として差し込む。nixpkgs には無いので
+      # mkPackageOption の既定値のままでは評価に失敗する
+      darwinModules.default =
+        { pkgs, lib, ... }:
+        {
+          imports = [ ./nix/darwin-module.nix ];
+          services.magical-merchant.package =
+            lib.mkDefault
+              self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+        };
     };
 }

--- a/nix/darwin-module.nix
+++ b/nix/darwin-module.nix
@@ -18,6 +18,12 @@ in
       default = "";
       description = "Cloudflare Workers URL for R2 sync.";
     };
+
+    autoSync = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Sync automatically after each successful save.";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -30,7 +36,12 @@ in
         SYNC_DIR="$USER_HOME/Library/Application Support/com.magical-merchant.app"
         mkdir -p "$SYNC_DIR"
         printf '%s\n' ${
-          lib.escapeShellArg (builtins.toJSON { workers_url = cfg.workersUrl; })
+          lib.escapeShellArg (
+            builtins.toJSON {
+              workers_url = cfg.workersUrl;
+              auto_sync = cfg.autoSync;
+            }
+          )
         } > "$SYNC_DIR/sync-config.json"
         chmod 444 "$SYNC_DIR/sync-config.json"
         chown "$CONSOLE_USER" "$SYNC_DIR" "$SYNC_DIR/sync-config.json"

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     pnpm = pnpm_10;
     sourceRoot = "${finalAttrs.src.name}/tauri-app";
     fetcherVersion = 3;
-    hash = "sha256-4A2Xd2vCGTs+RvTt2+Wl+SCpMv9IsHOxnFI4wlYagOE=";
+    hash = "sha256-MQ1tFmm80rItS5rl6zxU/Rxa7irTf7OoXbLjmpxte/o=";
   };
 
   nativeBuildInputs = [

--- a/tauri-app/android-signing/apply-signing.go
+++ b/tauri-app/android-signing/apply-signing.go
@@ -23,6 +23,14 @@ import (
 
 const gradlePath = "src-tauri/gen/android/app/build.gradle.kts"
 
+// keystorePath is where the Gradle script looks the file up, and therefore the
+// only place it may live. `rootProject.file` resolves against the Android
+// project root; plain `file` would resolve against the :app module instead, and
+// a keystore.properties one directory up would be silently ignored — the build
+// then runs for minutes before failing with "missing required property
+// storeFile".
+const keystorePath = "src-tauri/gen/android/keystore.properties"
+
 // injection describes one marker-delimited region to insert into the build
 // script. body holds the Kotlin source (already indented); anchor is a literal
 // substring of the original file used as the insertion point.
@@ -41,7 +49,7 @@ var injections = []injection{
 		anchor: "android {",
 		after:  false,
 		body: `val keystoreProperties = Properties().apply {
-    val propFile = file("keystore.properties")
+    val propFile = rootProject.file("keystore.properties")
     if (propFile.exists()) {
         propFile.inputStream().use { load(it) }
     }
@@ -85,6 +93,12 @@ func run() error {
 	}
 	content := string(raw)
 
+	// Gradle only notices a bad keystore once it signs the APK, which is
+	// minutes of Rust and R8 later. Say so now instead.
+	if err := checkKeystore(); err != nil {
+		return err
+	}
+
 	// Strip any previously injected regions so re-runs are idempotent.
 	for _, inj := range injections {
 		content = removeBlock(content, inj.id)
@@ -108,6 +122,56 @@ func run() error {
 		return fmt.Errorf("write %s: %w", gradlePath, err)
 	}
 	fmt.Printf("apply-signing: signing config injected into %s\n", gradlePath)
+	return nil
+}
+
+// readProperties parses the `key=value` subset of the Java properties format
+// that keystore.properties uses. Values are taken verbatim, so a password
+// containing '=' survives.
+func readProperties(path string) (map[string]string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	props := map[string]string{}
+	for _, line := range strings.Split(string(raw), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "!") {
+			continue
+		}
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		props[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	return props, nil
+}
+
+// checkKeystore rejects the states Gradle would only report at signing time:
+// a missing file, an unfilled template, or a keystore path that does not exist.
+func checkKeystore() error {
+	props, err := readProperties(keystorePath)
+	if err != nil {
+		return fmt.Errorf("no %s: copy android-signing/keystore.properties.example there "+
+			"and fill it in (see android-signing/README.md)", keystorePath)
+	}
+
+	for _, key := range []string{"storeFile", "storePassword", "keyAlias", "keyPassword"} {
+		if props[key] == "" {
+			return fmt.Errorf("%s: %s is empty", keystorePath, key)
+		}
+	}
+
+	store := props["storeFile"]
+	// Gradle's file() does not expand ~, so it would look for a literal "~" dir.
+	if strings.HasPrefix(store, "~") {
+		return fmt.Errorf("%s: storeFile must be an absolute path, not %q", keystorePath, store)
+	}
+	if _, err := os.Stat(store); err != nil {
+		return fmt.Errorf("%s: storeFile %q does not exist "+
+			"(the example ships a placeholder path — replace it)", keystorePath, store)
+	}
 	return nil
 }
 

--- a/tauri-app/justfile
+++ b/tauri-app/justfile
@@ -45,6 +45,12 @@ android-sign-setup:
 android-build-release: android-sign-setup
   pnpm tauri android build --apk
 
+# Same, but from a checkout with no gen/android yet (CI). keystore.properties
+# has to be written after android-init, so this recipe does not build on its own —
+# see .github/workflows/release.yml.
+android-release-build: setup
+  pnpm tauri android build --apk
+
 # Build and install the signed release APK onto a connected device (-r updates in place).
 android-install-release: android-build-release
   adb install -r src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release.apk

--- a/tauri-app/src-tauri/src/auth.rs
+++ b/tauri-app/src-tauri/src/auth.rs
@@ -7,8 +7,6 @@ use tauri::{AppHandle, Manager};
 use tauri_plugin_opener::OpenerExt;
 use url::Url;
 
-const KEYCHAIN_SERVICE: &str = "com.magical-merchant.app";
-const KEYCHAIN_ACCOUNT: &str = "auth-jwt";
 const SYNC_CONFIG_FILENAME: &str = "sync-config.json";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -69,31 +67,91 @@ fn normalize_workers_url(input: &str) -> Result<String, String> {
     Ok(trimmed.to_string())
 }
 
-pub(crate) fn store_token(token: &str) -> Result<(), String> {
-    let entry =
-        keyring::Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT).map_err(|e| e.to_string())?;
-    entry.set_password(token).map_err(|e| e.to_string())?;
-    Ok(())
-}
+// ──────────── Token storage ────────────
+//
+// keyring クレートは Android にストアを持たず、既定でプロセス内 mock に落ちる。
+// mock は Entry ごとに空の入れ物を作るので、保存したトークンは二度と読めない
+// （ログイン直後から「未ログイン」のまま）。Android だけアプリ専用ディレクトリの
+// ファイルに置く。OS がアプリ間のアクセスを遮断しているので、他アプリからは読めない。
 
-pub(crate) fn get_token() -> Result<Option<String>, String> {
-    let entry =
-        keyring::Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT).map_err(|e| e.to_string())?;
-    match entry.get_password() {
-        Ok(token) => Ok(Some(token)),
-        Err(keyring::Error::NoEntry) => Ok(None),
-        Err(e) => Err(e.to_string()),
+#[cfg(target_os = "android")]
+mod token_store {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt as _;
+    use std::path::{Path, PathBuf};
+
+    const TOKEN_FILENAME: &str = "auth-token";
+
+    fn path(base_dir: &Path) -> PathBuf {
+        base_dir.join(TOKEN_FILENAME)
+    }
+
+    pub(super) fn store(base_dir: &Path, token: &str) -> Result<(), String> {
+        fs::create_dir_all(base_dir).map_err(|e| e.to_string())?;
+        let path = path(base_dir);
+        fs::write(&path, token).map_err(|e| e.to_string())?;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).map_err(|e| e.to_string())
+    }
+
+    pub(super) fn get(base_dir: &Path) -> Result<Option<String>, String> {
+        match fs::read_to_string(path(base_dir)) {
+            Ok(token) => Ok(Some(token.trim().to_string()).filter(|t| !t.is_empty())),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    pub(super) fn clear(base_dir: &Path) -> Result<(), String> {
+        match fs::remove_file(path(base_dir)) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.to_string()),
+        }
     }
 }
 
-pub(crate) fn clear_token() -> Result<(), String> {
-    let entry =
-        keyring::Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT).map_err(|e| e.to_string())?;
-    match entry.delete_credential() {
-        // Deleting a credential that was never stored leaves the desired state.
-        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
-        Err(e) => Err(e.to_string()),
+#[cfg(not(target_os = "android"))]
+mod token_store {
+    use std::path::Path;
+
+    const KEYCHAIN_SERVICE: &str = "com.magical-merchant.app";
+    const KEYCHAIN_ACCOUNT: &str = "auth-jwt";
+
+    fn entry() -> Result<keyring::Entry, String> {
+        keyring::Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT).map_err(|e| e.to_string())
     }
+
+    pub(super) fn store(_base_dir: &Path, token: &str) -> Result<(), String> {
+        entry()?.set_password(token).map_err(|e| e.to_string())
+    }
+
+    pub(super) fn get(_base_dir: &Path) -> Result<Option<String>, String> {
+        match entry()?.get_password() {
+            Ok(token) => Ok(Some(token)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    pub(super) fn clear(_base_dir: &Path) -> Result<(), String> {
+        match entry()?.delete_credential() {
+            // Deleting a credential that was never stored leaves the desired state.
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+}
+
+pub(crate) fn store_token(base_dir: &Path, token: &str) -> Result<(), String> {
+    token_store::store(base_dir, token)
+}
+
+pub(crate) fn get_token(base_dir: &Path) -> Result<Option<String>, String> {
+    token_store::get(base_dir)
+}
+
+pub(crate) fn clear_token(base_dir: &Path) -> Result<(), String> {
+    token_store::clear(base_dir)
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -127,7 +185,11 @@ fn build_auth_url(workers_url: &str, app_redirect: &str) -> String {
 }
 
 #[cfg(not(target_os = "android"))]
-async fn login_with_loopback(handle: &AppHandle, config: &SyncConfig) -> Result<(), String> {
+async fn login_with_loopback(
+    handle: &AppHandle,
+    base_dir: &Path,
+    config: &SyncConfig,
+) -> Result<(), String> {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -167,7 +229,7 @@ async fn login_with_loopback(handle: &AppHandle, config: &SyncConfig) -> Result<
             .map(|(_, v)| v.to_string());
 
         if let Some(token) = token {
-            store_token(&token)?;
+            store_token(base_dir, &token)?;
             // SyncButton などが認証状態を即時反映できるよう通知する
             let _ = tauri::Emitter::emit(handle, "auth-success", ());
             "<html><body><p>Login successful. You can close this tab.</p></body></html>"
@@ -199,7 +261,7 @@ pub(crate) async fn auth_login(handle: AppHandle) -> Result<(), String> {
 
     #[cfg(not(target_os = "android"))]
     {
-        login_with_loopback(&handle, &config).await
+        login_with_loopback(&handle, &base_dir, &config).await
     }
 
     #[cfg(target_os = "android")]
@@ -214,13 +276,15 @@ pub(crate) async fn auth_login(handle: AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub(crate) fn auth_status() -> Result<bool, String> {
-    Ok(get_token()?.is_some_and(|token| is_token_valid(&token)))
+pub(crate) fn auth_status(handle: AppHandle) -> Result<bool, String> {
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    Ok(get_token(&base_dir)?.is_some_and(|token| is_token_valid(&token)))
 }
 
 #[tauri::command]
-pub(crate) fn auth_logout() -> Result<(), String> {
-    clear_token()
+pub(crate) fn auth_logout(handle: AppHandle) -> Result<(), String> {
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    clear_token(&base_dir)
 }
 
 #[tauri::command]

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -154,7 +154,11 @@ fn delete_note(handle: AppHandle, filename: String) -> Result<(), String> {
 /// OAuth のコールバックで返ってきた JWT を保存する。
 /// 保存結果をフロントに通知しないと、ログイン完了が UI に反映されず
 /// 失敗も握りつぶされてしまう。
-fn store_token_from_urls(handle: &AppHandle, urls: Vec<url::Url>) {
+///
+/// Android では `app_data_dir` がプラグインへの同期呼び出しで、その応答を運ぶ
+/// のはメインスレッド。deep link のイベントはそのメインスレッドで配送されるため、
+/// ここで直に呼ぶと自分の応答を待って Activity ごと固まる。必ず別スレッドに移す。
+fn store_token_from_urls(handle: &AppHandle, urls: &[url::Url]) {
     let Some(token) = urls
         .iter()
         .flat_map(url::Url::query_pairs)
@@ -164,20 +168,23 @@ fn store_token_from_urls(handle: &AppHandle, urls: Vec<url::Url>) {
         return;
     };
 
-    let stored = handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| e.to_string())
-        .and_then(|dir| auth::store_token(&dir, &token));
+    let handle = handle.clone();
+    std::thread::spawn(move || {
+        let stored = handle
+            .path()
+            .app_data_dir()
+            .map_err(|e| e.to_string())
+            .and_then(|dir| auth::store_token(&dir, &token));
 
-    match stored {
-        Ok(()) => {
-            let _ = handle.emit("auth-success", ());
+        match stored {
+            Ok(()) => {
+                let _ = handle.emit("auth-success", ());
+            }
+            Err(e) => {
+                let _ = handle.emit("auth-error", e);
+            }
         }
-        Err(e) => {
-            let _ = handle.emit("auth-error", e);
-        }
-    }
+    });
 }
 
 // `mobile_entry_point` fixes the signature to `fn run()`, so a failed startup
@@ -195,19 +202,17 @@ pub fn run() {
             // 起動 URL として届く。`new-url` イベントはアプリが生きていた場合に
             // しか飛ばないので、両方を見ないとログインが黙って失敗する。
             //
-            // get_current は Android プラグインへの同期呼び出しで、応答を運ぶ
-            // のは setup と同じメインスレッド。ここで直に待つと Activity ごと
-            // 固まる (pause / stop がタイムアウトする) ので別スレッドに逃がす。
+            // get_current も同期プラグイン呼び出しなので setup の中で待たない。
             let launch_handle = app.handle().clone();
             std::thread::spawn(move || {
                 if let Ok(Some(urls)) = launch_handle.deep_link().get_current() {
-                    store_token_from_urls(&launch_handle, urls);
+                    store_token_from_urls(&launch_handle, &urls);
                 }
             });
 
             let handle = app.handle().clone();
             app.deep_link()
-                .on_open_url(move |event| store_token_from_urls(&handle, event.urls()));
+                .on_open_url(move |event| store_token_from_urls(&handle, &event.urls()));
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -170,7 +170,12 @@ pub fn run() {
                                 if key == "token" {
                                     // 保存結果をフロントに通知しないと、ログイン完了が
                                     // UI に反映されず失敗も握りつぶされてしまう
-                                    match auth::store_token(&value) {
+                                    let stored = handle
+                                        .path()
+                                        .app_data_dir()
+                                        .map_err(|e| e.to_string())
+                                        .and_then(|dir| auth::store_token(&dir, &value));
+                                    match stored {
                                         Ok(()) => {
                                             let _ = handle.emit("auth-success", ());
                                         }

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -193,10 +193,17 @@ pub fn run() {
         .setup(|app| {
             // ブラウザで認証している間に OS がアプリを回収すると、トークンは
             // 起動 URL として届く。`new-url` イベントはアプリが生きていた場合に
-            // しか飛ばないので、両方を見ないとログインが黙って失敗する
-            if let Ok(Some(urls)) = app.deep_link().get_current() {
-                store_token_from_urls(app.handle(), urls);
-            }
+            // しか飛ばないので、両方を見ないとログインが黙って失敗する。
+            //
+            // get_current は Android プラグインへの同期呼び出しで、応答を運ぶ
+            // のは setup と同じメインスレッド。ここで直に待つと Activity ごと
+            // 固まる (pause / stop がタイムアウトする) ので別スレッドに逃がす。
+            let launch_handle = app.handle().clone();
+            std::thread::spawn(move || {
+                if let Ok(Some(urls)) = launch_handle.deep_link().get_current() {
+                    store_token_from_urls(&launch_handle, urls);
+                }
+            });
 
             let handle = app.handle().clone();
             app.deep_link()

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -12,7 +12,8 @@ mod sync;
 
 use magical_merchant_core::utils::device::Location;
 use magical_merchant_core::{NoteFilename, NoteSummary, SearchHit};
-use tauri::{AppHandle, Emitter, Listener, Manager};
+use tauri::{AppHandle, Emitter, Manager};
+use tauri_plugin_deep_link::DeepLinkExt as _;
 
 const fn make_location(latitude: Option<f64>, longitude: Option<f64>) -> Option<Location> {
     match (latitude, longitude) {
@@ -150,6 +151,35 @@ fn delete_note(handle: AppHandle, filename: String) -> Result<(), String> {
     magical_merchant_core::delete_note(&base_dir, &filename).map_err(|e| e.to_string())
 }
 
+/// OAuth のコールバックで返ってきた JWT を保存する。
+/// 保存結果をフロントに通知しないと、ログイン完了が UI に反映されず
+/// 失敗も握りつぶされてしまう。
+fn store_token_from_urls(handle: &AppHandle, urls: Vec<url::Url>) {
+    let Some(token) = urls
+        .iter()
+        .flat_map(url::Url::query_pairs)
+        .find(|(key, _)| key == "token")
+        .map(|(_, value)| value.into_owned())
+    else {
+        return;
+    };
+
+    let stored = handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())
+        .and_then(|dir| auth::store_token(&dir, &token));
+
+    match stored {
+        Ok(()) => {
+            let _ = handle.emit("auth-success", ());
+        }
+        Err(e) => {
+            let _ = handle.emit("auth-error", e);
+        }
+    }
+}
+
 // `mobile_entry_point` fixes the signature to `fn run()`, so a failed startup
 // has nowhere to be returned to — panicking is the only way to report it.
 #[allow(clippy::expect_used)]
@@ -161,35 +191,16 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .manage(sync::AppSyncState::default())
         .setup(|app| {
+            // ブラウザで認証している間に OS がアプリを回収すると、トークンは
+            // 起動 URL として届く。`new-url` イベントはアプリが生きていた場合に
+            // しか飛ばないので、両方を見ないとログインが黙って失敗する
+            if let Ok(Some(urls)) = app.deep_link().get_current() {
+                store_token_from_urls(app.handle(), urls);
+            }
+
             let handle = app.handle().clone();
-            app.listen("deep-link://new-url", move |event| {
-                if let Ok(urls) = serde_json::from_str::<Vec<String>>(event.payload()) {
-                    for url_str in urls {
-                        if let Ok(url) = url::Url::parse(&url_str) {
-                            for (key, value) in url.query_pairs() {
-                                if key == "token" {
-                                    // 保存結果をフロントに通知しないと、ログイン完了が
-                                    // UI に反映されず失敗も握りつぶされてしまう
-                                    let stored = handle
-                                        .path()
-                                        .app_data_dir()
-                                        .map_err(|e| e.to_string())
-                                        .and_then(|dir| auth::store_token(&dir, &value));
-                                    match stored {
-                                        Ok(()) => {
-                                            let _ = handle.emit("auth-success", ());
-                                        }
-                                        Err(e) => {
-                                            let _ = handle.emit("auth-error", e);
-                                        }
-                                    }
-                                    return;
-                                }
-                            }
-                        }
-                    }
-                }
-            });
+            app.deep_link()
+                .on_open_url(move |event| store_token_from_urls(&handle, event.urls()));
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/tauri-app/src-tauri/src/sync.rs
+++ b/tauri-app/src-tauri/src/sync.rs
@@ -75,61 +75,58 @@ impl Default for AppSyncState {
 
 // ──────────── HTTP wire types ────────────
 
-#[derive(Deserialize)]
+/// 同期状態はサーバーが持つ。クライアントは受け取った状態をそのまま保存するだけで、
+/// 自分で組み立てて送り返さない（送り返すと、まだ手元に無いファイルが状態から
+/// 抜け落ち、次の同期で全端末がそれを「削除された」と解釈してしまう）
+#[derive(Debug, Clone, Deserialize)]
 struct ServerSyncState {
     files: std::collections::HashMap<String, ServerFileRecord>,
     #[allow(dead_code)]
     last_sync: Option<String>,
+    /// bulk レスポンスの `new_state` には付かない
+    #[serde(default)]
     etag: Option<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct ServerFileRecord {
     hash: String,
     last_modified: String,
 }
 
 #[derive(Serialize)]
-struct WireSyncState {
-    files: std::collections::HashMap<String, WireFileRecord>,
-    last_sync: String,
+struct WireUpload {
+    key: String,
+    content_base64: String,
+    last_modified: String,
+    hash: String,
 }
 
+/// 競合は常にローカル優先。上書きされるリモート側は `conflict_key` に退避され、
+/// レスポンスでも返ってくるのでローカルにも競合コピーとして残す
 #[derive(Serialize)]
-struct WireFileRecord {
+struct WireConflictOp {
+    key: String,
+    conflict_key: String,
+    content_base64: String,
     hash: String,
     last_modified: String,
 }
 
 #[derive(Serialize)]
-struct WireFileContent {
-    key: String,
-    content_base64: String,
-    last_modified: String,
-}
-
-#[derive(Serialize)]
-struct WireConflictOp {
-    key: String,
-    conflict_key: String,
-    resolution: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    content_base64: Option<String>,
-}
-
-#[derive(Serialize)]
 struct BulkRequest {
-    uploads: Vec<WireFileContent>,
+    uploads: Vec<WireUpload>,
     downloads: Vec<String>,
     delete_remote: Vec<String>,
     conflicts: Vec<WireConflictOp>,
-    new_state: WireSyncState,
     expected_etag: Option<String>,
 }
 
 #[derive(Deserialize)]
 struct BulkResponse {
     downloads: Vec<DownloadedFile>,
+    conflict_downloads: Vec<DownloadedFile>,
+    new_state: ServerSyncState,
 }
 
 #[derive(Deserialize)]
@@ -304,7 +301,7 @@ async fn do_sync(handle: &AppHandle) -> Result<SyncResult, SyncErrorInfo> {
             "Sync is not set up. Add your Workers URL in Settings.",
         ));
     }
-    let token = auth::get_token()
+    let token = auth::get_token(&base_dir)
         .map_err(SyncErrorInfo::other)?
         .ok_or_else(|| {
             SyncErrorInfo::new("notAuthenticated", "Not logged in. Log in from Settings.")
@@ -318,21 +315,38 @@ async fn do_sync(handle: &AppHandle) -> Result<SyncResult, SyncErrorInfo> {
 
     let client = HttpClient::new(config.workers_url, token);
 
+    // 他端末と同時に同期すると CAS で弾かれる。ユーザーに再試行させる理由はないので
+    // 取得し直して自動でやり直す
+    for attempt in 1..=MAX_SYNC_ATTEMPTS {
+        let outcome = sync_once(&client, &base_dir).await;
+        let retryable =
+            matches!(&outcome, Err(err) if err.kind == "conflict") && attempt < MAX_SYNC_ATTEMPTS;
+        if !retryable {
+            return outcome;
+        }
+    }
+    unreachable!("the loop returns on its last attempt")
+}
+
+const MAX_SYNC_ATTEMPTS: usize = 3;
+
+async fn sync_once(client: &HttpClient, base_dir: &Path) -> Result<SyncResult, SyncErrorInfo> {
     // 1. Server state を1リクエストで取得
     let server_state = client.get_sync_state().await?;
 
     // 2. ローカルスキャン
     let local_files =
-        scan::scan_local_files(&base_dir).map_err(|e| SyncErrorInfo::other(e.to_string()))?;
-    let local_state =
-        SyncState::load(&base_dir).map_err(|e| SyncErrorInfo::other(e.to_string()))?;
+        scan::scan_local_files(base_dir).map_err(|e| SyncErrorInfo::other(e.to_string()))?;
+    let local_state = SyncState::load(base_dir).map_err(|e| SyncErrorInfo::other(e.to_string()))?;
 
     // 3. Rust core で diff 計算
     let remote_files = server_state_to_remote_files(&server_state);
     let actions = diff::compute(&local_files, &remote_files, &local_state);
 
+    refuse_wholesale_local_deletion(&actions, &local_files)?;
+
     // 4. アクションを bulk request に変換
-    let data_dir = magical_merchant_core::utils::paths::data_dir(&base_dir);
+    let data_dir = magical_merchant_core::utils::paths::data_dir(base_dir);
     let mut result = SyncResult::default();
     let bulk_req = build_bulk_request(
         &actions,
@@ -346,13 +360,44 @@ async fn do_sync(handle: &AppHandle) -> Result<SyncResult, SyncErrorInfo> {
     // 5. 一括実行
     let bulk_resp = client.bulk(bulk_req).await?;
 
-    // 6. downloads + conflict ローカル書き込み
-    apply_downloads(&bulk_resp, &actions, &data_dir, &mut result).map_err(SyncErrorInfo::other)?;
+    // 6. downloads + conflict コピー + ローカル削除を反映
+    apply_response(&bulk_resp, &actions, &data_dir, &mut result).map_err(SyncErrorInfo::other)?;
 
-    // 7. ローカル sync state 更新
-    save_local_state(&base_dir).map_err(SyncErrorInfo::other)?;
+    // 7. サーバーが確定させた状態をそのままローカルにも記録する。
+    //    ここでローカルを再スキャンして組み直すと、ダウンロード直後の mtime が
+    //    サーバーの版と食い違い、同じファイルを永久に再取得し続ける
+    save_local_state(base_dir, &bulk_resp.new_state, &data_dir).map_err(SyncErrorInfo::other)?;
 
     Ok(result)
+}
+
+/// これ以下ならユーザーが本当に消したと考えて素通しする。
+/// 1〜2件の全消しは事故が起きても取り返しがつく
+const WHOLESALE_DELETION_THRESHOLD: usize = 3;
+
+/// サーバーの同期状態が壊れて空になっていると、差分計算にはローカル全消しに見える。
+/// 1回の同期で手元のノートが全部消えるのはまず意図された結果ではないので止める。
+fn refuse_wholesale_local_deletion(
+    actions: &[SyncAction],
+    local_files: &[LocalFile],
+) -> Result<(), SyncErrorInfo> {
+    if local_files.len() < WHOLESALE_DELETION_THRESHOLD {
+        return Ok(());
+    }
+    let deletions = actions
+        .iter()
+        .filter(|a| matches!(a, SyncAction::DeleteLocal { .. }))
+        .count();
+    if deletions < local_files.len() {
+        return Ok(());
+    }
+    Err(SyncErrorInfo::new(
+        "unsafeDeletion",
+        format!(
+            "Sync stopped: the server reports every one of your {deletions} local files as deleted. \
+             If that is really what you want, delete .sync-state.json in the app data directory and sync again."
+        ),
+    ))
 }
 
 fn server_state_to_remote_files(state: &ServerSyncState) -> Vec<RemoteFile> {
@@ -384,7 +429,7 @@ fn build_bulk_request(
     let local_map: std::collections::HashMap<&str, &LocalFile> =
         local_files.iter().map(|f| (f.key.as_str(), f)).collect();
 
-    let mut uploads: Vec<WireFileContent> = Vec::new();
+    let mut uploads: Vec<WireUpload> = Vec::new();
     let mut downloads: Vec<String> = Vec::new();
     let mut delete_remote: Vec<String> = Vec::new();
     let mut conflicts: Vec<WireConflictOp> = Vec::new();
@@ -403,10 +448,11 @@ fn build_bulk_request(
                     .ok_or_else(|| format!("missing local file for upload: {key}"))?;
                 let content =
                     fs::read(data_dir.join(key)).map_err(|e| format!("read {key}: {e}"))?;
-                uploads.push(WireFileContent {
+                uploads.push(WireUpload {
                     key: key.clone(),
                     content_base64: B64.encode(&content),
                     last_modified: local.last_modified.to_rfc3339(),
+                    hash: local.content_hash.clone(),
                 });
             }
             SyncAction::DownloadNew { key } | SyncAction::DownloadModified { key } => {
@@ -419,46 +465,22 @@ fn build_bulk_request(
                 // ローカル削除は client 側だけで完結（bulk request には含めない）
             }
             SyncAction::Conflict { key } => {
-                // conflict 解決ロジック: LWW
-                let local = local_map.get(key.as_str());
-                // remote の last_modified は server_state から…
-                // 簡略化: local があれば last_modified を local 側として比較できないので
-                // 単純に local 優先（後で改善余地あり）
-                let conflict_key = conflict::conflict_filename(key, Utc::now());
-
-                if local.is_some() {
-                    let content = fs::read(data_dir.join(key))
-                        .map_err(|e| format!("read conflict {key}: {e}"))?;
-                    conflicts.push(WireConflictOp {
-                        key: key.clone(),
-                        conflict_key,
-                        resolution: "keep_local".to_string(),
-                        content_base64: Some(B64.encode(&content)),
-                    });
-                } else {
-                    conflicts.push(WireConflictOp {
-                        key: key.clone(),
-                        conflict_key,
-                        resolution: "keep_remote".to_string(),
-                        content_base64: None,
-                    });
-                }
+                // 双方が変わっていたらローカルを採用する。捨てたほうも競合コピーとして
+                // 残るので、どちらの編集も失われない
+                let local = local_map
+                    .get(key.as_str())
+                    .ok_or_else(|| format!("missing local file for conflict: {key}"))?;
+                let content = fs::read(data_dir.join(key))
+                    .map_err(|e| format!("read conflict {key}: {e}"))?;
+                conflicts.push(WireConflictOp {
+                    key: key.clone(),
+                    conflict_key: conflict::conflict_filename(key, Utc::now()),
+                    content_base64: B64.encode(&content),
+                    hash: local.content_hash.clone(),
+                    last_modified: local.last_modified.to_rfc3339(),
+                });
             }
         }
-    }
-
-    // new_state: ローカルの現在のファイル一覧（upload 後の状態を仮想的に表現）
-    // 実際は bulk が成功した後にローカル scan + state 保存するが、
-    // ここでは local_files をそのまま new_state として送る（簡易版）
-    let mut new_files_map = std::collections::HashMap::new();
-    for f in local_files {
-        new_files_map.insert(
-            f.key.clone(),
-            WireFileRecord {
-                hash: f.content_hash.clone(),
-                last_modified: f.last_modified.to_rfc3339(),
-            },
-        );
     }
 
     Ok(BulkRequest {
@@ -466,71 +488,43 @@ fn build_bulk_request(
         downloads,
         delete_remote,
         conflicts,
-        new_state: WireSyncState {
-            files: new_files_map,
-            last_sync: Utc::now().to_rfc3339(),
-        },
         expected_etag,
     })
 }
 
-fn apply_downloads(
+fn write_under(data_dir: &Path, key: &str, content: &[u8]) -> Result<(), String> {
+    if !is_safe_key(key) {
+        return Err(format!("unsafe key from server: {key}"));
+    }
+    let path = data_dir.join(key);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("mkdir {key}: {e}"))?;
+    }
+    fs::write(&path, content).map_err(|e| format!("write {key}: {e}"))
+}
+
+fn decode(file: &DownloadedFile) -> Result<Vec<u8>, String> {
+    B64.decode(&file.content_base64)
+        .map_err(|e| format!("base64 decode {}: {e}", file.key))
+}
+
+fn apply_response(
     bulk_resp: &BulkResponse,
     actions: &[SyncAction],
     data_dir: &Path,
     result: &mut SyncResult,
 ) -> Result<(), String> {
-    // action map for distinguishing normal download vs conflict (keep_remote)
-    let conflict_keys: std::collections::HashSet<String> = actions
-        .iter()
-        .filter_map(|a| match a {
-            SyncAction::Conflict { key } => Some(key.clone()),
-            _ => None,
-        })
-        .collect();
-
-    // For conflicts where we chose keep_remote, the server returned remote content.
-    // We need to first save current local as conflict_key, then overwrite with remote.
-    // For uploads, we don't get downloads back.
-    // For normal downloads, just write.
-
-    let now = Utc::now();
     for d in &bulk_resp.downloads {
-        let content = B64
-            .decode(&d.content_base64)
-            .map_err(|e| format!("base64 decode {}: {e}", d.key))?;
-        let path = data_dir.join(&d.key);
-
-        if conflict_keys.contains(&d.key) {
-            // Save current local content as conflict copy before overwriting
-            if path.exists() {
-                let local_content =
-                    fs::read(&path).map_err(|e| format!("read local conflict {}: {e}", d.key))?;
-                let conflict_key = conflict::conflict_filename(&d.key, now);
-                let conflict_path = data_dir.join(&conflict_key);
-                if let Some(parent) = conflict_path.parent() {
-                    fs::create_dir_all(parent)
-                        .map_err(|e| format!("mkdir conflict {conflict_key}: {e}"))?;
-                }
-                fs::write(&conflict_path, &local_content)
-                    .map_err(|e| format!("write conflict {conflict_key}: {e}"))?;
-            }
-            // Overwrite with remote content
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent).map_err(|e| format!("mkdir {}: {e}", d.key))?;
-            }
-            fs::write(&path, &content).map_err(|e| format!("write {}: {e}", d.key))?;
-            result.conflicts += 1;
-        } else {
-            if let Some(parent) = path.parent() {
-                fs::create_dir_all(parent).map_err(|e| format!("mkdir {}: {e}", d.key))?;
-            }
-            fs::write(&path, &content).map_err(|e| format!("write {}: {e}", d.key))?;
-            result.downloaded += 1;
-        }
+        write_under(data_dir, &d.key, &decode(d)?)?;
+        result.downloaded += 1;
     }
 
-    // Count uploads, deletes, and apply delete_local
+    // 競合で負けたリモート側。`.sync-conflict-` はスキャン対象外なので、
+    // ローカルに置いても同期ループにはならない
+    for d in &bulk_resp.conflict_downloads {
+        write_under(data_dir, &d.key, &decode(d)?)?;
+    }
+
     for action in actions {
         match action {
             SyncAction::UploadNew { .. } | SyncAction::UploadModified { .. } => {
@@ -538,6 +532,9 @@ fn apply_downloads(
             }
             SyncAction::DeleteRemote { .. } => {
                 result.deleted_remote += 1;
+            }
+            SyncAction::Conflict { .. } => {
+                result.conflicts += 1;
             }
             SyncAction::DeleteLocal { key } => {
                 let path = data_dir.join(key);
@@ -551,39 +548,46 @@ fn apply_downloads(
                     result.deleted_local += 1;
                 }
             }
-            SyncAction::Conflict { key } => {
-                // For keep_local conflicts, the server processed it; count here
-                // For keep_remote conflicts, counted already in download loop above
-                // To avoid double-count, only count if not in downloads
-                let in_downloads = bulk_resp.downloads.iter().any(|d| &d.key == key);
-                if !in_downloads {
-                    result.conflicts += 1;
-                }
-            }
-            _ => {}
+            SyncAction::DownloadNew { .. } | SyncAction::DownloadModified { .. } => {}
         }
     }
 
     Ok(())
 }
 
-fn save_local_state(base_dir: &Path) -> Result<(), String> {
-    let updated_files = scan::scan_local_files(base_dir).map_err(|e| e.to_string())?;
-    let mut new_state = SyncState {
+/// サーバーが確定させた状態を、実際に手元にあるファイルだけに絞って保存する。
+/// 手元に無いものを「同期済み」と記録すると、次の同期でリモート側を消してしまう。
+fn to_local_state(server_state: &ServerSyncState, data_dir: &Path) -> SyncState {
+    let mut state = SyncState {
         last_sync: Some(Utc::now()),
         ..Default::default()
     };
-    for f in &updated_files {
-        new_state.files.insert(
-            f.key.clone(),
+    for (key, record) in &server_state.files {
+        let Ok(last_synced_modified) = record.last_modified.parse() else {
+            continue;
+        };
+        if !is_safe_key(key) || !data_dir.join(key).exists() {
+            continue;
+        }
+        state.files.insert(
+            key.clone(),
             FileSyncRecord {
-                last_synced_modified: f.last_modified,
-                content_hash: f.content_hash.clone(),
+                last_synced_modified,
+                content_hash: record.hash.clone(),
             },
         );
     }
-    new_state.save(base_dir).map_err(|e| e.to_string())?;
-    Ok(())
+    state
+}
+
+fn save_local_state(
+    base_dir: &Path,
+    server_state: &ServerSyncState,
+    data_dir: &Path,
+) -> Result<(), String> {
+    to_local_state(server_state, data_dir)
+        .save(base_dir)
+        .map_err(|e| e.to_string())
 }
 
 fn action_key(action: &SyncAction) -> &str {
@@ -622,5 +626,200 @@ mod tests {
             let _guard = SyncingGuard(&flag);
         }
         assert!(!flag.load(Ordering::SeqCst));
+    }
+
+    fn local_file(key: &str, hash: &str) -> LocalFile {
+        LocalFile {
+            key: key.to_string(),
+            last_modified: "2026-08-05T00:00:00Z".parse().unwrap(),
+            content_hash: hash.to_string(),
+        }
+    }
+
+    fn server_state(entries: &[(&str, &str, &str)]) -> ServerSyncState {
+        ServerSyncState {
+            files: entries
+                .iter()
+                .map(|(key, hash, last_modified)| {
+                    (
+                        (*key).to_string(),
+                        ServerFileRecord {
+                            hash: (*hash).to_string(),
+                            last_modified: (*last_modified).to_string(),
+                        },
+                    )
+                })
+                .collect(),
+            last_sync: None,
+            etag: None,
+        }
+    }
+
+    fn seed(data_dir: &Path, key: &str, content: &str) {
+        let path = data_dir.join(key);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, content).unwrap();
+    }
+
+    /// ハッシュが欠けたアップロードはサーバーが 400 で弾く
+    #[test]
+    fn upload_carries_the_local_content_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        seed(dir.path(), "notes/a.md", "hello");
+        let locals = vec![local_file("notes/a.md", "deadbeef")];
+        let actions = vec![SyncAction::UploadNew {
+            key: "notes/a.md".to_string(),
+        }];
+
+        let mut result = SyncResult::default();
+        let req = build_bulk_request(&actions, &locals, dir.path(), None, &mut result).unwrap();
+
+        assert_eq!(req.uploads.len(), 1);
+        assert_eq!(req.uploads[0].hash, "deadbeef");
+        assert_eq!(req.uploads[0].content_base64, B64.encode(b"hello"));
+    }
+
+    #[test]
+    fn conflict_sends_local_content_so_the_local_edit_wins() {
+        let dir = tempfile::tempdir().unwrap();
+        seed(dir.path(), "notes/a.md", "local edit");
+        let locals = vec![local_file("notes/a.md", "hash-local")];
+        let actions = vec![SyncAction::Conflict {
+            key: "notes/a.md".to_string(),
+        }];
+
+        let mut result = SyncResult::default();
+        let req = build_bulk_request(&actions, &locals, dir.path(), None, &mut result).unwrap();
+
+        assert_eq!(req.conflicts.len(), 1);
+        assert_eq!(req.conflicts[0].hash, "hash-local");
+        assert_eq!(req.conflicts[0].content_base64, B64.encode(b"local edit"));
+        assert!(req.conflicts[0].conflict_key.contains(".sync-conflict-"));
+    }
+
+    #[test]
+    fn local_state_mirrors_what_the_server_recorded() {
+        let dir = tempfile::tempdir().unwrap();
+        seed(dir.path(), "notes/a.md", "content");
+        let state = server_state(&[("notes/a.md", "hash-a", "2026-08-05T00:00:00Z")]);
+
+        let local = to_local_state(&state, dir.path());
+
+        let record = &local.files["notes/a.md"];
+        assert_eq!(record.content_hash, "hash-a");
+        assert_eq!(
+            record.last_synced_modified,
+            "2026-08-05T00:00:00Z".parse::<DateTime<Utc>>().unwrap()
+        );
+    }
+
+    /// 手元に無いファイルを「同期済み」と記録すると、次の同期で
+    /// リモート側が削除扱いになって消える
+    #[test]
+    fn local_state_drops_files_that_are_not_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = server_state(&[("notes/missing.md", "hash-a", "2026-08-05T00:00:00Z")]);
+
+        assert!(to_local_state(&state, dir.path()).files.is_empty());
+    }
+
+    #[test]
+    fn local_state_drops_unsafe_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = server_state(&[("../escape.md", "hash-a", "2026-08-05T00:00:00Z")]);
+
+        assert!(to_local_state(&state, dir.path()).files.is_empty());
+    }
+
+    #[test]
+    fn applying_the_response_writes_downloads_and_conflict_copies() {
+        let dir = tempfile::tempdir().unwrap();
+        let resp = BulkResponse {
+            downloads: vec![DownloadedFile {
+                key: "notes/a.md".to_string(),
+                content_base64: B64.encode(b"remote"),
+            }],
+            conflict_downloads: vec![DownloadedFile {
+                key: "notes/a.sync-conflict-20260805-000000.md".to_string(),
+                content_base64: B64.encode(b"other device"),
+            }],
+            new_state: server_state(&[]),
+        };
+
+        let mut result = SyncResult::default();
+        apply_response(&resp, &[], dir.path(), &mut result).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(dir.path().join("notes/a.md")).unwrap(),
+            "remote"
+        );
+        assert_eq!(
+            fs::read_to_string(dir.path().join("notes/a.sync-conflict-20260805-000000.md"))
+                .unwrap(),
+            "other device"
+        );
+        assert_eq!(result.downloaded, 1);
+    }
+
+    fn delete_local(key: &str) -> SyncAction {
+        SyncAction::DeleteLocal {
+            key: key.to_string(),
+        }
+    }
+
+    /// サーバーの同期状態が壊れて空になったときに、それを「全部削除された」と
+    /// 解釈してノートを消してしまうのを防ぐ
+    #[test]
+    fn refuses_a_sync_that_would_delete_every_local_file() {
+        let locals = vec![
+            local_file("notes/a.md", "h1"),
+            local_file("notes/b.md", "h2"),
+            local_file("notes/c.md", "h3"),
+        ];
+        let actions = vec![
+            delete_local("notes/a.md"),
+            delete_local("notes/b.md"),
+            delete_local("notes/c.md"),
+        ];
+
+        let err = refuse_wholesale_local_deletion(&actions, &locals).unwrap_err();
+        assert_eq!(err.kind, "unsafeDeletion");
+    }
+
+    #[test]
+    fn allows_deleting_some_of_the_local_files() {
+        let locals = vec![
+            local_file("notes/a.md", "h1"),
+            local_file("notes/b.md", "h2"),
+            local_file("notes/c.md", "h3"),
+        ];
+        let actions = vec![delete_local("notes/a.md"), delete_local("notes/b.md")];
+
+        assert!(refuse_wholesale_local_deletion(&actions, &locals).is_ok());
+    }
+
+    /// 数件しか無いうちは取り返しがつくので素通しする
+    #[test]
+    fn allows_clearing_a_tiny_workspace() {
+        let locals = vec![local_file("notes/a.md", "h1")];
+        let actions = vec![delete_local("notes/a.md")];
+
+        assert!(refuse_wholesale_local_deletion(&actions, &locals).is_ok());
+    }
+
+    #[test]
+    fn applying_the_response_rejects_a_traversal_key_from_the_server() {
+        let dir = tempfile::tempdir().unwrap();
+        let resp = BulkResponse {
+            downloads: vec![DownloadedFile {
+                key: "../escaped.md".to_string(),
+                content_base64: B64.encode(b"evil"),
+            }],
+            conflict_downloads: Vec::new(),
+            new_state: server_state(&[]),
+        };
+
+        let mut result = SyncResult::default();
+        assert!(apply_response(&resp, &[], dir.path(), &mut result).is_err());
     }
 }

--- a/tauri-app/src/lib/commands.test.ts
+++ b/tauri-app/src/lib/commands.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { onLocalMutation, typedInvoke } from "./commands";
+
+vi.mock(import("@tauri-apps/api/core"), () => ({
+  invoke: vi.fn<(cmd: string, args?: unknown) => Promise<unknown>>(),
+}));
+
+const invokeMock = vi.mocked(invoke);
+
+describe("typedInvoke local mutation notifications", () => {
+  const seen: string[] = [];
+  let stop: () => void;
+
+  beforeEach(() => {
+    seen.length = 0;
+    invokeMock.mockReset();
+    invokeMock.mockResolvedValue(null);
+    stop = onLocalMutation(() => seen.push("mutated"));
+  });
+
+  afterEach(() => stop());
+
+  // 自動同期の合図。呼び出し側ごとに書くと必ず取りこぼす
+  it("notifies after a write command succeeds", async () => {
+    await typedInvoke("update_draft", {
+      filePath: "a.md",
+      body: "x",
+      tags: [],
+      latitude: null,
+      longitude: null,
+    });
+    expect(seen).toHaveLength(1);
+  });
+
+  it("notifies for a quick capture", async () => {
+    await typedInvoke("save_quick_capture", { text: "hi", latitude: null, longitude: null });
+    expect(seen).toHaveLength(1);
+  });
+
+  it("stays quiet for read-only commands", async () => {
+    invokeMock.mockResolvedValue([]);
+    await typedInvoke("list_notes");
+    expect(seen).toHaveLength(0);
+  });
+
+  // 失敗した書き込みで同期すると、書けなかった内容を「同期済み」と見せてしまう
+  it("stays quiet when the write fails", async () => {
+    invokeMock.mockRejectedValue(new Error("disk full"));
+    await expect(typedInvoke("delete_note", { filename: "a.md" })).rejects.toThrow("disk full");
+    expect(seen).toHaveLength(0);
+  });
+
+  it("stops notifying once unsubscribed", async () => {
+    stop();
+    await typedInvoke("save_document", { body: "x", tags: [], latitude: null, longitude: null });
+    expect(seen).toHaveLength(0);
+  });
+});

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -59,13 +59,44 @@ interface CommandMap {
 
 export type CommandName = keyof CommandMap;
 
+/** ノート/タイムラインのファイルを書き換えるコマンド。 */
+const MUTATING: ReadonlySet<CommandName> = new Set<CommandName>([
+  "save_quick_capture",
+  "update_timeline_entry",
+  "delete_timeline_entry",
+  "create_draft",
+  "update_draft",
+  "delete_note",
+  "save_document",
+]);
+
+const mutationListeners = new Set<() => void>();
+
+/**
+ * 書き込みコマンドが成功するたびに呼ばれる。
+ * 呼び出し側ごとに通知を書くと必ずどこかで漏れるので、ここ一箇所に寄せる。
+ */
+export function onLocalMutation(listener: () => void): () => void {
+  mutationListeners.add(listener);
+  return () => mutationListeners.delete(listener);
+}
+
 export function typedInvoke<K extends CommandName>(
   cmd: K,
   ...args: CommandMap[K]["args"] extends void ? [] : [CommandMap[K]["args"]]
 ): Promise<CommandMap[K]["result"]> {
-  if (args.length === 0) {
-    return invoke<CommandMap[K]["result"]>(cmd);
-  }
+  const call =
+    args.length === 0
+      ? invoke<CommandMap[K]["result"]>(cmd)
+      : invoke<CommandMap[K]["result"]>(cmd, args[0] as Record<string, unknown>);
 
-  return invoke<CommandMap[K]["result"]>(cmd, args[0] as Record<string, unknown>);
+  if (!MUTATING.has(cmd)) {
+    return call;
+  }
+  return call.then((result) => {
+    for (const listener of mutationListeners) {
+      listener();
+    }
+    return result;
+  });
 }

--- a/tauri-app/src/lib/sync.ts
+++ b/tauri-app/src/lib/sync.ts
@@ -2,13 +2,16 @@ import { createSignal, onMount, onCleanup } from "solid-js";
 import type { Accessor } from "solid-js";
 import { listen } from "@tauri-apps/api/event";
 import type { UnlistenFn } from "@tauri-apps/api/event";
-import { typedInvoke } from "./commands";
+import { onLocalMutation, typedInvoke } from "./commands";
 import { EVENTS } from "./events";
 import { describeSyncError, describeSyncResult } from "./sync-status";
 import type { SyncResultPayload } from "./sync-status";
 import type { IconName } from "../components/Icon";
 
 export type SyncStatus = "idle" | "syncing" | "success" | "error" | "needs-setup";
+
+/** 自動保存 (1秒 debounce) の連打をまとめてから同期する。 */
+const AUTO_SYNC_DEBOUNCE_MS = 5000;
 
 export interface SyncState {
   status: Accessor<SyncStatus>;
@@ -95,8 +98,35 @@ export function createSyncState(onSynced: () => void): SyncState {
     setAlertVersion((v) => v + 1);
   };
 
+  const syncNow = async (): Promise<void> => {
+    if (status() === "syncing") {
+      return;
+    }
+    setStatus("syncing");
+    setMessage("同期中…");
+    try {
+      await typedInvoke("sync_start");
+      // 結果は sync-complete / sync-error イベントで反映する
+    } catch (error) {
+      applyError(error);
+    }
+  };
+
+  let autoSyncTimer: ReturnType<typeof setTimeout> | undefined;
+  const scheduleAutoSync = (): void => {
+    if (!autoSync() || status() === "needs-setup") {
+      return;
+    }
+    if (autoSyncTimer) {
+      clearTimeout(autoSyncTimer);
+    }
+    autoSyncTimer = setTimeout(() => void syncNow(), AUTO_SYNC_DEBOUNCE_MS);
+  };
+
   onMount(async () => {
     await checkReadiness();
+
+    unlisteners.push(onLocalMutation(scheduleAutoSync));
 
     unlisteners.push(
       await listen<SyncResultPayload>(EVENTS.SYNC_COMPLETE, (e) => {
@@ -118,24 +148,13 @@ export function createSyncState(onSynced: () => void): SyncState {
   });
 
   onCleanup(() => {
+    if (autoSyncTimer) {
+      clearTimeout(autoSyncTimer);
+    }
     for (const unlisten of unlisteners) {
       unlisten();
     }
   });
-
-  const syncNow = async (): Promise<void> => {
-    if (status() === "syncing") {
-      return;
-    }
-    setStatus("syncing");
-    setMessage("同期中…");
-    try {
-      await typedInvoke("sync_start");
-      // 結果は sync-complete / sync-error イベントで反映する
-    } catch (error) {
-      applyError(error);
-    }
-  };
 
   const setAutoSync = async (on: boolean): Promise<void> => {
     setAutoSyncSignal(on);

--- a/tauri-app/src/styles/markdown-preview.css
+++ b/tauri-app/src/styles/markdown-preview.css
@@ -115,15 +115,17 @@
   color: var(--app-text-muted);
 }
 
-/* Shiki dual theme: data-theme に応じて CSS 変数で配色を切り替える */
+/* Shiki dual theme: data-theme に応じて CSS 変数で配色を切り替える。
+   下地は Shiki のテーマ色ではなく .markdown-preview pre の --app-surface-2 に
+   任せる。インラインコードや mermaid の図と同じ下地に揃える (#75) */
 .markdown-preview .shiki,
 .markdown-preview .shiki span {
   color: var(--shiki-light);
-  background-color: var(--shiki-light-bg);
+  background-color: transparent;
 }
 
 [data-theme="dark"] .markdown-preview .shiki,
 [data-theme="dark"] .markdown-preview .shiki span {
   color: var(--shiki-dark);
-  background-color: var(--shiki-dark-bg);
+  background-color: transparent;
 }

--- a/workers/package.json
+++ b/workers/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
+    "deploy:worker": "wrangler deploy",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -1,7 +1,7 @@
 import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
 import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { SignJWT } from "jose";
-import worker from "./index";
+import worker, { deepLinkPage } from "./index";
 
 function makeJwt(
   payload: { sub: string; email: string; exp: number },
@@ -37,6 +37,13 @@ function request(
   return new Request(`http://localhost${path}`, { ...options, headers });
 }
 
+async function send(req: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(req, env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
 function jsonBody<T>(response: Response): Promise<T> {
   return response.json() as Promise<T>;
 }
@@ -56,6 +63,70 @@ function b64Decode(s: string): string {
   return atob(s);
 }
 
+/// テスト用のダミーハッシュ。Worker は 64 桁小文字 hex しか受け付けない
+function hash(seed: string): string {
+  return seed
+    .repeat(64)
+    .slice(0, 64)
+    .replaceAll(/[^0-9a-f]/g, "a");
+}
+
+interface FileContent {
+  key: string;
+  content_base64: string;
+  last_modified: string;
+}
+
+interface SyncStateBody {
+  files: Record<string, { hash: string; last_modified: string }>;
+  last_sync: string | null;
+  etag: string | null;
+}
+
+interface BulkBody {
+  downloads: FileContent[];
+  conflict_downloads: FileContent[];
+  new_state: SyncStateBody;
+}
+
+type BulkInput = Partial<{
+  uploads: unknown[];
+  downloads: unknown[];
+  delete_remote: unknown[];
+  conflicts: unknown[];
+  expected_etag: string | null;
+}>;
+
+function bulk(body: BulkInput): Promise<Response> {
+  return send(
+    request("/sync/bulk", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        uploads: [],
+        downloads: [],
+        delete_remote: [],
+        conflicts: [],
+        expected_etag: null,
+        ...body,
+      }),
+    }),
+  );
+}
+
+function upload(key: string, content: string, seed = "b"): Record<string, string> {
+  return {
+    key,
+    content_base64: b64(content),
+    last_modified: "2026-05-12T10:00:00Z",
+    hash: hash(seed),
+  };
+}
+
+async function currentState(): Promise<SyncStateBody> {
+  return jsonBody<SyncStateBody>(await send(request("/sync-state")));
+}
+
 async function clearBucket(): Promise<void> {
   const listed = await env.BUCKET.list({ limit: 1000 });
   if (listed.objects.length > 0) {
@@ -70,22 +141,16 @@ describe("Workers Sync API", () => {
 
   describe("authentication", () => {
     it("rejects requests without Authorization header", async () => {
-      const req = new Request("http://localhost/sync-state");
-      const ctx = createExecutionContext();
-      const res = await worker.fetch(req, env, ctx);
-      await waitOnExecutionContext(ctx);
-
+      const res = await send(new Request("http://localhost/sync-state"));
       expect(res.status).toBe(401);
     });
 
     it("rejects invalid JWT", async () => {
-      const req = new Request("http://localhost/sync-state", {
-        headers: { Authorization: "Bearer invalid" },
-      });
-      const ctx = createExecutionContext();
-      const res = await worker.fetch(req, env, ctx);
-      await waitOnExecutionContext(ctx);
-
+      const res = await send(
+        new Request("http://localhost/sync-state", {
+          headers: { Authorization: "Bearer invalid" },
+        }),
+      );
       expect(res.status).toBe(401);
     });
 
@@ -95,398 +160,221 @@ describe("Workers Sync API", () => {
         email: "test@example.com",
         exp: Math.floor(Date.now() / 1000) - 100,
       });
-      const req = new Request("http://localhost/sync-state", {
-        headers: { Authorization: `Bearer ${expiredToken}` },
-      });
-      const ctx = createExecutionContext();
-      const res = await worker.fetch(req, env, ctx);
-      await waitOnExecutionContext(ctx);
-
+      const res = await send(
+        new Request("http://localhost/sync-state", {
+          headers: { Authorization: `Bearer ${expiredToken}` },
+        }),
+      );
       expect(res.status).toBe(401);
     });
   });
 
   describe("gET /sync-state", () => {
     it("returns empty state for new user", async () => {
-      const req = request("/sync-state");
-      const ctx = createExecutionContext();
-      const res = await worker.fetch(req, env, ctx);
-      await waitOnExecutionContext(ctx);
-
-      expect(res.status).toBe(200);
-      const body = await jsonBody<{
-        files: Record<string, unknown>;
-        last_sync: string | null;
-        etag: string | null;
-      }>(res);
+      const body = await currentState();
       expect(body.files).toEqual({});
       expect(body.last_sync).toBeNull();
       expect(body.etag).toBeNull();
     });
 
     it("returns saved state with etag", async () => {
-      // First, save some state via bulk
-      const bulkReq = request("/sync/bulk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          uploads: [
-            {
-              key: "notes/a.md",
-              content_base64: b64("hello"),
-              last_modified: "2026-05-12T10:00:00Z",
-            },
-          ],
-          downloads: [],
-          delete_remote: [],
-          conflicts: [],
-          new_state: {
-            files: { "notes/a.md": { hash: "h1", last_modified: "2026-05-12T10:00:00Z" } },
-            last_sync: "2026-05-12T10:00:00Z",
-          },
-          expected_etag: null,
-        }),
-      });
-      const ctx = createExecutionContext();
-      const res = await worker.fetch(bulkReq, env, ctx);
-      await waitOnExecutionContext(ctx);
-      expect(res.status).toBe(200);
+      const uploaded = await bulk({ uploads: [upload("notes/a.md", "hello", "b")] });
+      expect(uploaded.status).toBe(200);
 
-      // Now read state
-      const stateReq = request("/sync-state");
-      const ctx2 = createExecutionContext();
-      const stateRes = await worker.fetch(stateReq, env, ctx2);
-      await waitOnExecutionContext(ctx2);
-
-      expect(stateRes.status).toBe(200);
-      const state = await jsonBody<{
-        files: Record<string, { hash: string }>;
-        etag: string | null;
-      }>(stateRes);
-      expect(state.files["notes/a.md"].hash).toBe("h1");
-      expect(state.etag.length).toBeGreaterThan(0);
+      const state = await currentState();
+      expect(state.files["notes/a.md"].hash).toBe(hash("b"));
+      expect(state.etag?.length).toBeGreaterThan(0);
     });
   });
 
   describe("pOST /sync/bulk", () => {
     it("uploads files to R2", async () => {
-      const req = request("/sync/bulk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          uploads: [
-            {
-              key: "notes/up.md",
-              content_base64: b64("uploaded content"),
-              last_modified: "2026-05-12T10:00:00Z",
-            },
-          ],
-          downloads: [],
-          delete_remote: [],
-          conflicts: [],
-          new_state: {
-            files: { "notes/up.md": { hash: "h", last_modified: "2026-05-12T10:00:00Z" } },
-            last_sync: "2026-05-12T10:00:00Z",
-          },
-          expected_etag: null,
-        }),
-      });
-      const ctx = createExecutionContext();
-      const res = await worker.fetch(req, env, ctx);
-      await waitOnExecutionContext(ctx);
+      const res = await bulk({ uploads: [upload("notes/up.md", "uploaded content")] });
 
       expect(res.status).toBe(200);
-      const obj = await env.BUCKET.get("notes/up.md");
-      expect(obj).not.toBeNull();
-      expect(await objectText(obj)).toBe("uploaded content");
+      expect(await objectText(await env.BUCKET.get("notes/up.md"))).toBe("uploaded content");
+    });
+
+    it("records uploads in the server-owned state", async () => {
+      const res = await bulk({ uploads: [upload("notes/up.md", "content", "c")] });
+
+      const body = await jsonBody<BulkBody>(res);
+      expect(body.new_state.files["notes/up.md"].hash).toBe(hash("c"));
+      expect(body.new_state.last_sync).not.toBeNull();
     });
 
     it("downloads files from R2", async () => {
-      // Pre-populate
       await env.BUCKET.put("notes/down.md", "remote content", {
         customMetadata: { lastModified: "2026-05-12T11:00:00Z" },
       });
 
-      const req = request("/sync/bulk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          uploads: [],
-          downloads: ["notes/down.md"],
-          delete_remote: [],
-          conflicts: [],
-          new_state: { files: {}, last_sync: "2026-05-12T10:00:00Z" },
-          expected_etag: null,
-        }),
-      });
-      const ctx = createExecutionContext();
-      const res = await worker.fetch(req, env, ctx);
-      await waitOnExecutionContext(ctx);
+      const res = await bulk({ downloads: ["notes/down.md"] });
 
       expect(res.status).toBe(200);
-      const body = await jsonBody<{
-        downloads: { key: string; content_base64: string; last_modified: string }[];
-      }>(res);
+      const body = await jsonBody<BulkBody>(res);
       expect(body.downloads).toHaveLength(1);
       expect(body.downloads[0].key).toBe("notes/down.md");
       expect(b64Decode(body.downloads[0].content_base64)).toBe("remote content");
     });
 
-    it("deletes remote files", async () => {
-      await env.BUCKET.put("notes/del.md", "to delete");
+    // 2台目がダウンロードしただけで state からファイルが消えると、
+    // 次の同期で全端末が「リモートで削除された」と解釈してノートを消してしまう
+    it("keeps downloaded files in the state so a second device cannot wipe it", async () => {
+      await bulk({ uploads: [upload("notes/a.md", "from device A", "d")] });
+      const afterUpload = await currentState();
 
-      const req = request("/sync/bulk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          uploads: [],
-          downloads: [],
-          delete_remote: ["notes/del.md"],
-          conflicts: [],
-          new_state: { files: {}, last_sync: "2026-05-12T10:00:00Z" },
-          expected_etag: null,
-        }),
+      const res = await bulk({
+        downloads: ["notes/a.md"],
+        expected_etag: afterUpload.etag,
       });
-      const ctx = createExecutionContext();
-      const res = await worker.fetch(req, env, ctx);
-      await waitOnExecutionContext(ctx);
 
       expect(res.status).toBe(200);
-      const obj = await env.BUCKET.get("notes/del.md");
-      expect(obj).toBeNull();
+      const body = await jsonBody<BulkBody>(res);
+      expect(Object.keys(body.new_state.files)).toEqual(["notes/a.md"]);
+      expect(body.new_state.files["notes/a.md"].hash).toBe(hash("d"));
+      // ダウンロードは版を進めない。進めると同期済みの端末が再取得し続ける
+      expect(body.new_state.files["notes/a.md"].last_modified).toBe(
+        afterUpload.files["notes/a.md"].last_modified,
+      );
     });
 
-    it("handles conflict with keep_local: writes conflict copy + new content", async () => {
+    it("deletes remote files and drops them from the state", async () => {
+      await bulk({ uploads: [upload("notes/del.md", "to delete")] });
+      const afterUpload = await currentState();
+
+      const res = await bulk({
+        delete_remote: ["notes/del.md"],
+        expected_etag: afterUpload.etag,
+      });
+
+      expect(res.status).toBe(200);
+      expect(await env.BUCKET.get("notes/del.md")).toBeNull();
+      const body = await jsonBody<BulkBody>(res);
+      expect(body.new_state.files).toEqual({});
+    });
+
+    it("advances the version stamp when the same file is uploaded again", async () => {
+      await bulk({ uploads: [upload("notes/a.md", "v1", "a")] });
+      const first = await currentState();
+
+      await bulk({
+        uploads: [upload("notes/a.md", "v2", "b")],
+        expected_etag: first.etag,
+      });
+      const second = await currentState();
+
+      expect(second.files["notes/a.md"].last_modified).not.toBe(
+        first.files["notes/a.md"].last_modified,
+      );
+    });
+
+    it("resolves conflicts by keeping local and handing the remote copy back", async () => {
       await env.BUCKET.put("notes/c.md", "remote version", {
         customMetadata: { lastModified: "2026-05-12T10:00:00Z" },
       });
 
-      const req = request("/sync/bulk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          uploads: [],
-          downloads: [],
-          delete_remote: [],
-          conflicts: [
-            {
-              key: "notes/c.md",
-              conflict_key: "notes/c.sync-conflict-20260512-120000.md",
-              resolution: "keep_local",
-              content_base64: b64("local version"),
-            },
-          ],
-          new_state: { files: {}, last_sync: "2026-05-12T12:00:00Z" },
-          expected_etag: null,
-        }),
+      const res = await bulk({
+        conflicts: [
+          {
+            key: "notes/c.md",
+            conflict_key: "notes/c.sync-conflict-20260512-120000.md",
+            content_base64: b64("local version"),
+            hash: hash("e"),
+            last_modified: "2026-05-12T12:00:00Z",
+          },
+        ],
       });
-      const ctx = createExecutionContext();
-      const res = await worker.fetch(req, env, ctx);
-      await waitOnExecutionContext(ctx);
 
       expect(res.status).toBe(200);
+      const body = await jsonBody<BulkBody>(res);
 
-      const conflict = await env.BUCKET.get("notes/c.sync-conflict-20260512-120000.md");
-      expect(conflict).not.toBeNull();
-      expect(await objectText(conflict)).toBe("remote version");
-
-      const main = await env.BUCKET.get("notes/c.md");
-      expect(await objectText(main)).toBe("local version");
-    });
-
-    it("handles conflict with keep_remote: returns remote content for client to save", async () => {
-      await env.BUCKET.put("notes/c.md", "remote wins", {
-        customMetadata: { lastModified: "2026-05-12T10:00:00Z" },
-      });
-
-      const req = request("/sync/bulk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          uploads: [],
-          downloads: [],
-          delete_remote: [],
-          conflicts: [
-            {
-              key: "notes/c.md",
-              conflict_key: "notes/c.sync-conflict-x.md",
-              resolution: "keep_remote",
-            },
-          ],
-          new_state: { files: {}, last_sync: "2026-05-12T12:00:00Z" },
-          expected_etag: null,
-        }),
-      });
-      const ctx = createExecutionContext();
-      const res = await worker.fetch(req, env, ctx);
-      await waitOnExecutionContext(ctx);
-
-      expect(res.status).toBe(200);
-      const body = await jsonBody<{ downloads: { key: string; content_base64: string }[] }>(res);
-      expect(body.downloads).toHaveLength(1);
-      expect(body.downloads[0].key).toBe("notes/c.md");
-      expect(b64Decode(body.downloads[0].content_base64)).toBe("remote wins");
+      // ローカルが勝つ
+      expect(await objectText(await env.BUCKET.get("notes/c.md"))).toBe("local version");
+      // 上書きされたリモート側は R2 に退避され、クライアントにも返る
+      expect(
+        await objectText(await env.BUCKET.get("notes/c.sync-conflict-20260512-120000.md")),
+      ).toBe("remote version");
+      expect(body.conflict_downloads).toHaveLength(1);
+      expect(b64Decode(body.conflict_downloads[0].content_base64)).toBe("remote version");
+      // 競合コピーは同期対象外。state に載せると全端末が延々と取得し続ける
+      expect(Object.keys(body.new_state.files)).toEqual(["notes/c.md"]);
     });
 
     it("rejects unsafe keys (path traversal)", async () => {
-      const req = request("/sync/bulk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          uploads: [{ key: "../etc/passwd", content_base64: b64("evil"), last_modified: "x" }],
-          downloads: [],
-          delete_remote: [],
-          conflicts: [],
-          new_state: { files: {}, last_sync: "2026-05-12T12:00:00Z" },
-          expected_etag: null,
-        }),
-      });
-      const ctx = createExecutionContext();
-      const res = await worker.fetch(req, env, ctx);
-      await waitOnExecutionContext(ctx);
-
+      const res = await bulk({ uploads: [upload("../etc/passwd", "evil")] });
       expect(res.status).toBe(400);
     });
 
     it("rejects _sync-state/ prefix", async () => {
-      const req = request("/sync/bulk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          uploads: [{ key: "_sync-state/evil.json", content_base64: b64("x"), last_modified: "x" }],
-          downloads: [],
-          delete_remote: [],
-          conflicts: [],
-          new_state: { files: {}, last_sync: "2026-05-12T12:00:00Z" },
-          expected_etag: null,
-        }),
-      });
-      const ctx = createExecutionContext();
-      const res = await worker.fetch(req, env, ctx);
-      await waitOnExecutionContext(ctx);
-
+      const res = await bulk({ uploads: [upload("_sync-state/evil.json", "x")] });
       expect(res.status).toBe(400);
     });
 
     it("returns 409 on etag mismatch", async () => {
-      // First write
-      const req1 = request("/sync/bulk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          uploads: [],
-          downloads: [],
-          delete_remote: [],
-          conflicts: [],
-          new_state: { files: {}, last_sync: "2026-05-12T10:00:00Z" },
-          expected_etag: null,
-        }),
-      });
-      const ctx1 = createExecutionContext();
-      await worker.fetch(req1, env, ctx1);
-      await waitOnExecutionContext(ctx1);
+      await bulk({ uploads: [upload("notes/a.md", "first")] });
 
-      // Second write with stale etag (null when state exists)
-      const req2 = request("/sync/bulk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          uploads: [],
-          downloads: [],
-          delete_remote: [],
-          conflicts: [],
-          new_state: { files: {}, last_sync: "2026-05-12T11:00:00Z" },
-          expected_etag: null,
-        }),
-      });
-      const ctx2 = createExecutionContext();
-      const res2 = await worker.fetch(req2, env, ctx2);
-      await waitOnExecutionContext(ctx2);
+      // 2 回目が stale な etag (state があるのに null) を送る
+      const res = await bulk({ uploads: [upload("notes/b.md", "second")] });
 
-      expect(res2.status).toBe(409);
+      expect(res.status).toBe(409);
     });
 
     it("rejects invalid JSON", async () => {
-      const req = request("/sync/bulk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: "not json",
-      });
-      const ctx = createExecutionContext();
-      const res = await worker.fetch(req, env, ctx);
-      await waitOnExecutionContext(ctx);
-
+      const res = await send(
+        request("/sync/bulk", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "not json",
+        }),
+      );
       expect(res.status).toBe(400);
     });
 
     it("rejects missing required fields", async () => {
-      const req = request("/sync/bulk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ uploads: [] }),
-      });
-      const ctx = createExecutionContext();
-      const res = await worker.fetch(req, env, ctx);
-      await waitOnExecutionContext(ctx);
-
+      const res = await send(
+        request("/sync/bulk", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ uploads: [] }),
+        }),
+      );
       expect(res.status).toBe(400);
     });
 
     it("rejects an upload with an unparsable last_modified", async () => {
-      const req = request("/sync/bulk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          uploads: [
-            { key: "notes/bad.md", content_base64: b64("content"), last_modified: "not-a-date" },
-          ],
-          downloads: [],
-          delete_remote: [],
-          conflicts: [],
-          new_state: { files: {}, last_sync: "2026-05-12T10:00:00Z" },
-          expected_etag: null,
-        }),
+      const res = await bulk({
+        uploads: [{ ...upload("notes/bad.md", "content"), last_modified: "not-a-date" }],
       });
-      const ctx = createExecutionContext();
-      const res = await worker.fetch(req, env, ctx);
-      await waitOnExecutionContext(ctx);
-
-      // 保存すると、それを読んだ全クライアントでこのファイルが sync 対象から静かに消える
       expect(res.status).toBe(400);
     });
 
-    it("rejects new_state carrying an unparsable last_modified", async () => {
-      const req = request("/sync/bulk", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          uploads: [],
-          downloads: [],
-          delete_remote: [],
-          conflicts: [],
-          new_state: {
-            files: { "notes/bad.md": { hash: "abc", last_modified: "not-a-date" } },
-            last_sync: "2026-05-12T10:00:00Z",
-          },
-          expected_etag: null,
-        }),
+    // 壊れたハッシュを state に入れると、全端末で変更検出が壊れる
+    it("rejects an upload whose hash is not a sha256 hex digest", async () => {
+      const res = await bulk({
+        uploads: [{ ...upload("notes/bad.md", "content"), hash: "abc" }],
       });
-      const ctx = createExecutionContext();
-      const res = await worker.fetch(req, env, ctx);
-      await waitOnExecutionContext(ctx);
-
       expect(res.status).toBe(400);
     });
   });
 
   describe("unknown routes", () => {
     it("returns 404 for unknown paths", async () => {
-      const req = request("/unknown");
-      const ctx = createExecutionContext();
-      const res = await worker.fetch(req, env, ctx);
-      await waitOnExecutionContext(ctx);
-
+      const res = await send(request("/unknown"));
       expect(res.status).toBe(404);
     });
+  });
+});
+
+// Android Chrome はユーザー操作なしのカスタムスキーム遷移を捨てるため、
+// 自動遷移だけだとアプリに戻れない (#59)
+describe("deepLinkPage", () => {
+  it("offers a tappable link to the app, not only an automatic redirect", () => {
+    const html = deepLinkPage("magical-merchant://auth/callback?token=abc");
+    expect(html).toContain('href="magical-merchant://auth/callback?token=abc"');
+  });
+
+  it("escapes a redirect that tries to break out of the script tag", () => {
+    const html = deepLinkPage("magical-merchant://auth/callback?token=</script><script>evil()");
+    expect(html).not.toContain("<script>evil()");
   });
 });

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -1,6 +1,6 @@
 import { SignJWT, jwtVerify } from "jose";
-import { executeBulk, loadSyncState, saveSyncState } from "./sync";
-import type { BulkRequest } from "./sync";
+import { deriveState, executeBulk, isValidHash, loadSyncState, saveSyncState } from "./sync";
+import type { BulkRequest, BulkResponse } from "./sync";
 
 export interface Env {
   BUCKET: R2Bucket;
@@ -46,15 +46,50 @@ function isInvalidTimestamp(value: unknown): boolean {
   return typeof value !== "string" || Number.isNaN(Date.parse(value));
 }
 
-function hasInvalidTimestamp(body: BulkRequest): boolean {
-  if (body.uploads.some((u) => isInvalidTimestamp(u.last_modified))) {
-    return true;
+/// リクエストの形をここで弾いておかないと、壊れた値が新しい同期状態に
+/// そのまま焼き込まれ、全端末に伝播する
+function validateBulkRequest(body: BulkRequest): string | null {
+  if (
+    !Array.isArray(body.uploads) ||
+    !Array.isArray(body.downloads) ||
+    !Array.isArray(body.delete_remote) ||
+    !Array.isArray(body.conflicts)
+  ) {
+    return "Invalid request: missing or malformed fields";
   }
-  const { files } = body.new_state;
-  if (typeof files !== "object" || files === null) {
-    return true;
+  if (body.downloads.some((k) => typeof k !== "string")) {
+    return "Invalid download key";
   }
-  return Object.values(files).some((rec) => isInvalidTimestamp(rec?.last_modified));
+  if (body.delete_remote.some((k) => typeof k !== "string")) {
+    return "Invalid delete key";
+  }
+  for (const u of body.uploads) {
+    if (typeof u?.key !== "string" || typeof u.content_base64 !== "string") {
+      return "Invalid upload entry";
+    }
+    if (isInvalidTimestamp(u.last_modified)) {
+      return "Invalid last_modified timestamp";
+    }
+    if (!isValidHash(u.hash)) {
+      return `Invalid content hash for ${u.key}`;
+    }
+  }
+  for (const c of body.conflicts) {
+    if (
+      typeof c?.key !== "string" ||
+      typeof c.conflict_key !== "string" ||
+      typeof c.content_base64 !== "string"
+    ) {
+      return "Invalid conflict entry";
+    }
+    if (isInvalidTimestamp(c.last_modified)) {
+      return "Invalid last_modified timestamp";
+    }
+    if (!isValidHash(c.hash)) {
+      return `Invalid content hash for ${c.key}`;
+    }
+  }
+  return null;
 }
 
 async function handleSyncBulk(
@@ -68,41 +103,33 @@ async function handleSyncBulk(
   } catch {
     return errorResponse("Invalid JSON", 400);
   }
-  if (
-    !Array.isArray(body.uploads) ||
-    !Array.isArray(body.downloads) ||
-    !Array.isArray(body.delete_remote) ||
-    !Array.isArray(body.conflicts) ||
-    typeof body.new_state !== "object" ||
-    body.new_state === null
-  ) {
-    return errorResponse("Invalid request: missing or malformed fields", 400);
-  }
-  if (hasInvalidTimestamp(body)) {
-    return errorResponse("Invalid last_modified timestamp", 400);
+  const invalid = validateBulkRequest(body);
+  if (invalid) {
+    return errorResponse(invalid, 400);
   }
 
   // CAS check
-  const { etag: currentEtag } = await loadSyncState(bucket, userId);
+  const { state: currentState, etag: currentEtag } = await loadSyncState(bucket, userId);
   if (currentEtag !== body.expected_etag) {
     return errorResponse("Sync state changed concurrently, please retry", 409);
   }
 
-  let result;
+  let outcome;
   try {
-    result = await executeBulk(bucket, body);
+    outcome = await executeBulk(bucket, body);
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     return errorResponse(`Bulk execution failed: ${msg}`, 400);
   }
 
-  // Save new state with CAS
-  const saved = await saveSyncState(bucket, userId, body.new_state, body.expected_etag);
+  const newState = deriveState(currentState, body, Date.now());
+  const saved = await saveSyncState(bucket, userId, newState, body.expected_etag);
   if (!saved) {
     return errorResponse("Sync state changed concurrently, please retry", 409);
   }
 
-  return jsonResponse(result);
+  const response: BulkResponse = { ...outcome, new_state: newState };
+  return jsonResponse(response);
 }
 
 function signJwt(payload: JwtPayload, secret: string): Promise<string> {
@@ -146,6 +173,45 @@ function getCookie(request: Request, name: string): string | null {
 
 function isAllowedRedirect(redirect: string): boolean {
   return redirect.startsWith("magical-merchant://") || redirect.startsWith("http://127.0.0.1:");
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+/// Android Chrome はユーザー操作を伴わないカスタムスキームへの遷移を捨てる。
+/// 自動遷移だけだとアプリに戻れないので、必ずタップできるリンクを残す。
+export function deepLinkPage(redirectUrl: string): string {
+  const href = escapeHtml(redirectUrl);
+  return `<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Magical Merchant</title>
+<style>
+:root { color-scheme: light dark; }
+body { font-family: system-ui, sans-serif; display: grid; place-items: center;
+       min-height: 100dvh; margin: 0; gap: 1.5rem; text-align: center; padding: 1rem; }
+a.open { display: inline-block; padding: .9rem 1.6rem; border-radius: .6rem;
+         background: #4c6ef5; color: #fff; text-decoration: none; font-weight: 600; }
+p { margin: 0; opacity: .75; }
+</style>
+</head>
+<body>
+<p>ログインが完了しました。</p>
+<a id="open" class="open" href="${href}">アプリを開く</a>
+<script>
+  // 自動遷移が許可される環境（デスクトップ等）ではワンタップを省く。
+  // URL は href から読む。スクリプトに URL を埋め込むと閉じタグで抜け出される
+  location.href = document.getElementById("open").href;
+</script>
+</body>
+</html>`;
 }
 
 function getJwtExpiry(env: Env): number {
@@ -292,10 +358,7 @@ export default {
         return new Response(null, { status: 302, headers: clearCookies });
       }
 
-      return new Response(
-        `<html><body><p>Redirecting to app...</p><script>window.location.href="${redirectUrl}";</script></body></html>`,
-        { status: 200, headers: clearCookies },
-      );
+      return new Response(deepLinkPage(redirectUrl), { status: 200, headers: clearCookies });
     }
 
     // Bearer token authentication

--- a/workers/src/sync.test.ts
+++ b/workers/src/sync.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from "vitest";
-import { isUnsafeKey } from "./sync";
+import { deriveState, isUnsafeKey, isValidHash } from "./sync";
+import type { BulkRequest, SyncState } from "./sync";
+
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
+
+function req(overrides: Partial<BulkRequest> = {}): BulkRequest {
+  return {
+    uploads: [],
+    downloads: [],
+    delete_remote: [],
+    conflicts: [],
+    expected_etag: null,
+    ...overrides,
+  };
+}
+
+function stateWith(key: string, lastModified: string): SyncState {
+  return { files: { [key]: { hash: HASH_A, last_modified: lastModified } }, last_sync: null };
+}
 
 describe("isUnsafeKey", () => {
   it("rejects path traversal", () => {
@@ -23,5 +42,76 @@ describe("isUnsafeKey", () => {
     expect(isUnsafeKey("notes/a.md")).toBe(false);
     expect(isUnsafeKey("notes/archive/2026/note.md")).toBe(false);
     expect(isUnsafeKey("notes/file.sync-conflict-20260512-120000.md")).toBe(false);
+  });
+});
+
+describe("isValidHash", () => {
+  it("accepts a lowercase sha256 hex digest", () => {
+    expect(isValidHash(HASH_A)).toBe(true);
+  });
+
+  it("rejects anything that is not 64 lowercase hex chars", () => {
+    expect(isValidHash("ABC")).toBe(false);
+    expect(isValidHash(HASH_A.toUpperCase())).toBe(false);
+    expect(isValidHash(`${HASH_A}0`)).toBe(false);
+    expect(isValidHash(null)).toBe(false);
+    expect(isValidHash(123)).toBe(false);
+  });
+});
+
+describe("deriveState", () => {
+  const empty: SyncState = { files: {}, last_sync: null };
+  const now = Date.parse("2026-08-05T00:00:00Z");
+
+  it("adds uploaded files", () => {
+    const state = deriveState(
+      empty,
+      req({
+        uploads: [
+          {
+            key: "notes/a.md",
+            content_base64: "",
+            last_modified: "2026-08-04T00:00:00Z",
+            hash: HASH_B,
+          },
+        ],
+      }),
+      now,
+    );
+    expect(state.files["notes/a.md"].hash).toBe(HASH_B);
+  });
+
+  it("leaves downloaded files untouched", () => {
+    const old = stateWith("notes/a.md", "2026-08-01T00:00:00Z");
+    const state = deriveState(old, req({ downloads: ["notes/a.md"] }), now);
+    expect(state.files["notes/a.md"]).toEqual(old.files["notes/a.md"]);
+  });
+
+  it("removes deleted files", () => {
+    const old = stateWith("notes/a.md", "2026-08-01T00:00:00Z");
+    const state = deriveState(old, req({ delete_remote: ["notes/a.md"] }), now);
+    expect(state.files).toEqual({});
+  });
+
+  // 版が据え置かれると、他端末が「変更なし」と判断して更新を取りこぼす
+  it("keeps the version stamp strictly increasing even when the clock does not move", () => {
+    const old = stateWith("notes/a.md", "2026-08-05T00:00:00.000Z");
+    const state = deriveState(
+      old,
+      req({
+        uploads: [
+          {
+            key: "notes/a.md",
+            content_base64: "",
+            last_modified: "2026-08-04T00:00:00Z",
+            hash: HASH_B,
+          },
+        ],
+      }),
+      now,
+    );
+    expect(Date.parse(state.files["notes/a.md"].last_modified)).toBeGreaterThan(
+      Date.parse(old.files["notes/a.md"].last_modified),
+    );
   });
 });

--- a/workers/src/sync.ts
+++ b/workers/src/sync.ts
@@ -1,5 +1,7 @@
 interface FileSyncRecord {
   hash: string;
+  /// 同期状態のバージョン印。サーバーだけが発行するので、
+  /// 端末ごとの時計ずれやファイルシステムの mtime 精度に左右されない。
   last_modified: string;
 }
 
@@ -14,24 +16,34 @@ interface FileContent {
   last_modified: string;
 }
 
+interface UploadFile extends FileContent {
+  hash: string;
+}
+
 interface ConflictOp {
   key: string;
   conflict_key: string;
-  resolution: "keep_local" | "keep_remote";
-  content_base64?: string;
+  content_base64: string;
+  hash: string;
+  last_modified: string;
 }
 
 export interface BulkRequest {
-  uploads: FileContent[];
+  uploads: UploadFile[];
   downloads: string[];
   delete_remote: string[];
   conflicts: ConflictOp[];
-  new_state: SyncState;
   expected_etag: string | null;
 }
 
-export interface BulkResponse {
+export interface BulkOutcome {
   downloads: FileContent[];
+  /// 競合で退避したリモート側の中身。クライアントが競合コピーとして保存する。
+  conflict_downloads: FileContent[];
+}
+
+export interface BulkResponse extends BulkOutcome {
+  new_state: SyncState;
 }
 
 const SYNC_STATE_PREFIX = "_sync-state/";
@@ -96,10 +108,42 @@ export function isUnsafeKey(key: string): boolean {
   );
 }
 
-async function executeUpload(bucket: R2Bucket, f: FileContent): Promise<void> {
-  if (isUnsafeKey(f.key)) {
-    throw new Error(`unsafe key: ${f.key}`);
+const HASH_PATTERN = /^[0-9a-f]{64}$/;
+
+/// 壊れたハッシュを state に入れると、全クライアントで「常に変更あり」と
+/// 判定され続けるか、逆に変更が永久に検出されなくなる。
+export function isValidHash(hash: unknown): boolean {
+  return typeof hash === "string" && HASH_PATTERN.test(hash);
+}
+
+/// 同じキーの版が前回と同じ文字列になると、他端末が変更を取りこぼす。
+/// Workers の時計は I/O 単位でしか進まないので、明示的に単調化する。
+function nextStamp(previous: string | undefined, now: number): string {
+  const nowMs = previous === undefined ? now : Math.max(now, Date.parse(previous) + 1);
+  return new Date(nowMs).toISOString();
+}
+
+/// 新しい同期状態はサーバーだけが決める。
+/// クライアントが送ってきた一覧をそのまま採用すると、まだ手元に無いファイル
+/// （これからダウンロードするもの）が状態から消え、次の同期で全端末が
+/// 「リモートで削除された」と解釈してローカルのノートを消してしまう。
+export function deriveState(old: SyncState, req: BulkRequest, now: number): SyncState {
+  const files: Record<string, FileSyncRecord> = { ...old.files };
+
+  for (const u of req.uploads) {
+    files[u.key] = { hash: u.hash, last_modified: nextStamp(files[u.key]?.last_modified, now) };
   }
+  for (const key of req.delete_remote) {
+    delete files[key];
+  }
+  for (const c of req.conflicts) {
+    files[c.key] = { hash: c.hash, last_modified: nextStamp(files[c.key]?.last_modified, now) };
+  }
+
+  return { files, last_sync: new Date(now).toISOString() };
+}
+
+async function executeUpload(bucket: R2Bucket, f: UploadFile): Promise<void> {
   const body = base64Decode(f.content_base64);
   await bucket.put(f.key, body, {
     customMetadata: { lastModified: f.last_modified },
@@ -107,9 +151,6 @@ async function executeUpload(bucket: R2Bucket, f: FileContent): Promise<void> {
 }
 
 async function executeDownload(bucket: R2Bucket, key: string): Promise<FileContent> {
-  if (isUnsafeKey(key)) {
-    throw new Error(`unsafe key: ${key}`);
-  }
   const obj = await bucket.get(key);
   if (!obj) {
     throw new Error(`not found: ${key}`);
@@ -123,62 +164,49 @@ async function executeDownload(bucket: R2Bucket, key: string): Promise<FileConte
   };
 }
 
+/// 競合は常にローカル優先で上書きする。ただし上書きされるリモート側の中身は
+/// R2 に退避したうえでクライアントにも返し、どちらの編集も失わせない。
 async function executeConflict(bucket: R2Bucket, c: ConflictOp): Promise<FileContent | null> {
-  if (isUnsafeKey(c.key) || isUnsafeKey(c.conflict_key)) {
-    throw new Error(`unsafe key: ${c.key} or ${c.conflict_key}`);
+  const remote = await bucket.get(c.key);
+  let preserved: FileContent | null = null;
+
+  if (remote) {
+    const remoteLm = remote.customMetadata?.lastModified ?? remote.uploaded.toISOString();
+    const buf = await remote.arrayBuffer();
+    await bucket.put(c.conflict_key, buf, {
+      customMetadata: { lastModified: remoteLm },
+    });
+    preserved = {
+      key: c.conflict_key,
+      content_base64: base64Encode(buf),
+      last_modified: remoteLm,
+    };
   }
 
-  if (c.resolution === "keep_local") {
-    // Save current remote content under conflict_key, then overwrite with local
-    const remote = await bucket.get(c.key);
-    if (remote) {
-      const remoteLm = remote.customMetadata?.lastModified ?? remote.uploaded.toISOString();
-      await bucket.put(c.conflict_key, remote.body, {
-        customMetadata: { lastModified: remoteLm },
-      });
-    }
-    if (c.content_base64 !== undefined) {
-      const body = base64Decode(c.content_base64);
-      await bucket.put(c.key, body, {
-        customMetadata: { lastModified: new Date().toISOString() },
-      });
-    }
-    return null;
-  }
-  // keep_remote: client will save local as conflict copy locally,
-  // and downloads remote content. We just return remote content so client can write both.
-  const obj = await bucket.get(c.key);
-  if (!obj) {
-    throw new Error(`conflict download not found: ${c.key}`);
-  }
-  const lastModified = obj.customMetadata?.lastModified ?? obj.uploaded.toISOString();
-  const buf = await obj.arrayBuffer();
-  return {
-    key: c.key,
-    content_base64: base64Encode(buf),
-    last_modified: lastModified,
-  };
+  await bucket.put(c.key, base64Decode(c.content_base64), {
+    customMetadata: { lastModified: c.last_modified },
+  });
+
+  return preserved;
 }
 
-export async function executeBulk(bucket: R2Bucket, req: BulkRequest): Promise<BulkResponse> {
-  // Validate all keys upfront
-  for (const u of req.uploads) {
-    if (isUnsafeKey(u.key)) {
-      throw new Error(`unsafe upload key: ${u.key}`);
-    }
-  }
-  for (const d of req.downloads) {
-    if (isUnsafeKey(d)) {
-      throw new Error(`unsafe download key: ${d}`);
-    }
-  }
-  for (const d of req.delete_remote) {
-    if (isUnsafeKey(d)) {
-      throw new Error(`unsafe delete key: ${d}`);
+function collectKeys(req: BulkRequest): string[] {
+  return [
+    ...req.uploads.map((u) => u.key),
+    ...req.downloads,
+    ...req.delete_remote,
+    ...req.conflicts.flatMap((c) => [c.key, c.conflict_key]),
+  ];
+}
+
+export async function executeBulk(bucket: R2Bucket, req: BulkRequest): Promise<BulkOutcome> {
+  // Validate all keys upfront so a rejected key never leaves a half-applied batch
+  for (const key of collectKeys(req)) {
+    if (isUnsafeKey(key)) {
+      throw new Error(`unsafe key: ${key}`);
     }
   }
 
-  // Run all R2 operations concurrently
   const [, downloads, conflictDownloads] = await Promise.all([
     Promise.all(req.uploads.map((f) => executeUpload(bucket, f))),
     Promise.all(req.downloads.map((k) => executeDownload(bucket, k))),
@@ -186,10 +214,8 @@ export async function executeBulk(bucket: R2Bucket, req: BulkRequest): Promise<B
     req.delete_remote.length > 0 ? bucket.delete(req.delete_remote) : Promise.resolve(),
   ]);
 
-  const allDownloads: FileContent[] = [
-    ...downloads,
-    ...conflictDownloads.filter((d): d is FileContent => d !== null),
-  ];
-
-  return { downloads: allDownloads };
+  return {
+    downloads,
+    conflict_downloads: conflictDownloads.filter((d): d is FileContent => d !== null),
+  };
 }


### PR DESCRIPTION
## なぜ

R2 連携が失敗していた根本原因の修正と、実機で使うために足りていなかった配信経路の整備。

## R2 同期のデータ消失バグ

クライアントがローカルスキャンをそのまま `new_state` としてサーバーに送り返していたため、**まだ手元に無いファイル（これからダウンロードするもの）が同期状態から抜け落ちていた**。

2台目が初回同期でダウンロードすると R2 側の状態が空になり、次の同期で全端末が「リモートで削除された」と解釈してローカルのノートを消す、というデータ消失パスになっていた。

新しい状態は Worker だけが決めてレスポンスで返し、クライアントはそれをそのまま `.sync-state.json` に保存する。版はサーバー発行の単調増加スタンプにして、端末の時計や mtime の精度に依存しないようにした。

あわせて:

- 競合はローカル優先で確定し、上書きされるリモート側を R2 と手元の両方に競合コピーとして残す（従来は R2 に孤児として残るだけで、ユーザーからは見えなかった）
- CAS で負けた 409 は再取得して自動リトライ
- **1回の同期でローカルのファイルが全部消える結果は拒否する**。壊れた同期状態を読んだときの被害を止める安全弁（3件未満は素通し）

## Android で認証できなかった原因 (#59)

`keyring` クレートは Android にストアを持たず、既定でプロセス内 mock に落ちる。mock は `Entry` ごとに空の入れ物を作るので、保存したトークンは二度と読めない。アプリ専用ディレクトリ（mode 600）に保存するよう分岐した。

加えて Worker のコールバックがユーザー操作なしの `window.location.href` でカスタムスキームに飛ばしていて、Android Chrome がこれを捨てるためアプリに戻れなかった。タップできるリンクを併置した。

## 配信

- `nix build .#default` が mermaid 追加以降 `pnpmDeps.hash` の古さで壊れていた（macOS 配布経路そのものが死んでいた）。hash を取り直し、同じ腐り方を CI で検出できるよう `packages.pnpm-deps` を出して lockfile 変更時に検証する
- タグ push で署名済み Android release APK をビルドし GitHub Release に添付する workflow を追加。Play Store には出さないテスト配信
- `devShells.android` を追加（Playwright とブラウザ自動化を除いたリリース用）
- `darwinModules.default` がこのフレークのパッケージを既定値に差し込むようにした。nixpkgs に無いので従来の `mkPackageOption` 既定値では評価に失敗していた

## その他

- 「自動同期」トグルは保存されるだけで何も起きていなかったので実装（書き込み成功を `typedInvoke` で一箇所に集めて 5 秒 debounce）
- コードブロックの背景をアプリのトークンに揃えた (#75)

## 検証

- Rust 30 + 98 / フロント 114 / Workers 33 すべて green
- `nix fmt` / `just check` / `nix build .#default` 通過
- `aarch64-linux-android` ターゲットの clippy 通過

## 未検証・マージ後に必要なこと

- **`release.yml` は実地未検証**。CI 上での `tauri android init` → gradle ビルドまでは回せていない。初回タグは失敗しうる
- **Worker の再デプロイが必須**。プロトコルは破壊的変更で、古いクライアントは `hash` 無しのため 400 になる。Worker とアプリは同時に上げる
- Android 配信には secrets（`ANDROID_KEYSTORE_BASE64` / `ANDROID_KEYSTORE_PASSWORD` / `ANDROID_KEY_ALIAS` / `ANDROID_KEY_PASSWORD`）の登録が要る

Fixes #59
Fixes #75
