### PR TITLE
fix(android): keep the layout inside the system bars, and shrink the APK to 11MB

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Collect the APK
         id: apk
         run: |
+          # --target aarch64 でも Tauri は出力名を universal のままにする
           src=tauri-app/src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release.apk
           out="magical-merchant-${{ steps.version.outputs.version }}.apk"
           cp "$src" "$out"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,14 @@ missing_panics_doc = "allow"
 # wins because it describes the crate's real API surface.
 redundant_pub_crate = "allow"
 
+# 配布物のサイズは Android で直に効く。既定のままだとシンボル付き・LTO なしで、
+# .so だけで 13MB あった。opt-level は下げない: ローカルスキャンと SHA-256 が
+# 同期処理でエディタの応答に乗るため、速度を落とす取引はしない。
+[profile.release]
+strip = true
+lto = "thin"
+codegen-units = 1
+
 # Flame graphs need symbols; this profile is bench-only so the shipped
 # release binary stays untouched.
 [profile.bench]

--- a/tauri-app/justfile
+++ b/tauri-app/justfile
@@ -41,15 +41,17 @@ android-install: android-build-debug
 android-sign-setup:
   go run android-signing/apply-signing.go
 
-# Build a signed release APK (universal). Requires keystore.properties.
+# Build a signed release APK. Requires keystore.properties.
+# arm64 のみ: x86 系はエミュレータ専用で実機には要らず、universal だと
+# 4 ABI ぶんの .so で APK が 52MB まで膨らむ。
 android-build-release: android-sign-setup
-  pnpm tauri android build --apk
+  pnpm tauri android build --apk --target aarch64
 
 # Same, but from a checkout with no gen/android yet (CI). keystore.properties
 # has to be written after android-init, so this recipe does not build on its own —
 # see .github/workflows/release.yml.
 android-release-build: setup
-  pnpm tauri android build --apk
+  pnpm tauri android build --apk --target aarch64
 
 # Build and install the signed release APK onto a connected device (-r updates in place).
 android-install-release: android-build-release

--- a/tauri-app/src/components/MarkdownToolbar.test.tsx
+++ b/tauri-app/src/components/MarkdownToolbar.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@solidjs/testing-library";
 import { createSignal } from "solid-js";
 import type { Editor } from "@milkdown/kit/core";
-import MarkdownToolbar from "./MarkdownToolbar";
+import MarkdownToolbar, { keyboardTop } from "./MarkdownToolbar";
 
 function createMockEditor(): Editor {
   return {
@@ -54,5 +54,27 @@ describe("MarkdownToolbar", () => {
 
     setEditor(undefined);
     expect(screen.queryByRole("toolbar")).toBeNull();
+  });
+});
+
+describe("keyboardTop", () => {
+  const WINDOW_HEIGHT = 900;
+
+  // Android では閉じていても visualViewport がナビゲーションバーぶんを含んだ
+  // 全高を返すので、その値で固定するとツールバーがバーの裏に潜り込む
+  it("returns nothing while the keyboard is closed", () => {
+    expect(keyboardTop({ offsetTop: 0, height: WINDOW_HEIGHT }, WINDOW_HEIGHT)).toBeUndefined();
+  });
+
+  it("ignores a shrink too small to be a keyboard", () => {
+    expect(keyboardTop({ offsetTop: 0, height: 860 }, WINDOW_HEIGHT)).toBeUndefined();
+  });
+
+  it("returns the keyboard top once it opens", () => {
+    expect(keyboardTop({ offsetTop: 0, height: 500 }, WINDOW_HEIGHT)).toBe(500);
+  });
+
+  it("follows the viewport while it is scrolled", () => {
+    expect(keyboardTop({ offsetTop: 120, height: 500 }, WINDOW_HEIGHT)).toBe(620);
   });
 });

--- a/tauri-app/src/components/MarkdownToolbar.tsx
+++ b/tauri-app/src/components/MarkdownToolbar.tsx
@@ -15,6 +15,26 @@ interface MarkdownToolbarProps {
   editor: Editor | undefined;
 }
 
+/** これ以下の縮みはスクロールバーや URL バーの誤差で、キーボードとは見なさない。 */
+const KEYBOARD_MIN_HEIGHT = 100;
+
+/**
+ * キーボードの上端。閉じているあいだは `undefined` を返し、CSS の
+ * `bottom: var(--safe-bottom)` に任せる。
+ *
+ * Android では閉じていても `visualViewport.height` がナビゲーションバーを含んだ
+ * 全高になるため、その値で `top` を固定するとツールバーがバーの裏に潜り込む。
+ */
+export function keyboardTop(
+  viewport: { offsetTop: number; height: number },
+  windowHeight: number,
+): number | undefined {
+  if (viewport.height >= windowHeight - KEYBOARD_MIN_HEIGHT) {
+    return undefined;
+  }
+  return viewport.offsetTop + viewport.height;
+}
+
 export default function MarkdownToolbar(props: MarkdownToolbarProps): JSX.Element {
   const [toolbarTop, setToolbarTop] = createSignal<number | undefined>();
 
@@ -25,7 +45,7 @@ export default function MarkdownToolbar(props: MarkdownToolbarProps): JSX.Elemen
     }
 
     const update = () => {
-      setToolbarTop(vv.offsetTop + vv.height);
+      setToolbarTop(keyboardTop(vv, window.innerHeight));
     };
 
     vv.addEventListener("resize", update);

--- a/tauri-app/src/styles/base.css
+++ b/tauri-app/src/styles/base.css
@@ -36,9 +36,16 @@
   --app-toast-text: var(--gray-0);
 }
 
+/* システムバーの実寸。env() を直に散らすとテストから固定できず、Android の
+   はみ出しが実機を触るまで分からない。ここ一箇所で受けて変数に流す */
+:root {
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+}
+
 html {
-  padding-top: env(safe-area-inset-top, 0px);
-  padding-bottom: env(safe-area-inset-bottom, 0px);
+  padding-top: var(--safe-top);
+  padding-bottom: var(--safe-bottom);
 }
 
 body {

--- a/tauri-app/src/styles/layout.css
+++ b/tauri-app/src/styles/layout.css
@@ -1,7 +1,10 @@
 .app {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  /* html が safe-area ぶんの padding を持つので、100dvh のままだとその合計だけ
+     画面下にはみ出し、下タブと入力バーが Android のナビゲーションバーの
+     向こう側へ消える。dvh は端末側のバーの出入りにも追従する */
+  height: calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px));
   position: relative;
   overflow: hidden;
 }

--- a/tauri-app/src/styles/layout.css
+++ b/tauri-app/src/styles/layout.css
@@ -4,7 +4,7 @@
   /* html が safe-area ぶんの padding を持つので、100dvh のままだとその合計だけ
      画面下にはみ出し、下タブと入力バーが Android のナビゲーションバーの
      向こう側へ消える。dvh は端末側のバーの出入りにも追従する */
-  height: calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px));
+  height: calc(100dvh - var(--safe-top) - var(--safe-bottom));
   position: relative;
   overflow: hidden;
 }

--- a/tauri-app/src/styles/layout.test.ts
+++ b/tauri-app/src/styles/layout.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+
+/**
+ * Android のシステムバーとの重なりは実機を触るまで分からなかった。
+ * `--safe-top` / `--safe-bottom` に実寸を集約してあるので、ここで値を差し込んで
+ * レイアウトが画面内に収まるかを検証できる。
+ */
+const ANDROID_SAFE_TOP = "42px";
+const ANDROID_SAFE_BOTTOM = "24px";
+
+function setInsets(top: string, bottom: string): void {
+  document.documentElement.style.setProperty("--safe-top", top);
+  document.documentElement.style.setProperty("--safe-bottom", bottom);
+}
+
+function mountApp(): HTMLElement {
+  document.body.innerHTML = `
+    <div class="app">
+      <header class="header">header</header>
+      <main class="app-main"><div class="view"></div></main>
+      <nav class="bottom-tabs"><a class="bottom-tab">Notes</a></nav>
+    </div>`;
+  const app = document.querySelector<HTMLElement>(".app");
+  if (!app) {
+    throw new Error("expected .app to be mounted");
+  }
+  return app;
+}
+
+describe("app shell inside the system bars", () => {
+  beforeAll(async () => {
+    await import("../index.css");
+  });
+
+  afterEach(() => {
+    document.documentElement.style.removeProperty("--safe-top");
+    document.documentElement.style.removeProperty("--safe-bottom");
+    document.body.innerHTML = "";
+  });
+
+  // html が safe-area ぶんの padding を持つので、.app が 100dvh のままだと
+  // 下端が画面外へ出て、下タブと入力バーがナビゲーションバーの裏に回り込む
+  it("does not overflow the viewport when the system bars take space", () => {
+    setInsets(ANDROID_SAFE_TOP, ANDROID_SAFE_BOTTOM);
+    const app = mountApp();
+
+    const { bottom } = app.getBoundingClientRect();
+
+    expect(bottom).toBeLessThanOrEqual(globalThis.innerHeight + 0.5);
+  });
+
+  it("keeps the bottom tabs reachable above the navigation bar", () => {
+    setInsets(ANDROID_SAFE_TOP, ANDROID_SAFE_BOTTOM);
+    mountApp();
+    const tabs = document.querySelector<HTMLElement>(".bottom-tabs");
+    if (!tabs) {
+      throw new Error("expected .bottom-tabs to be mounted");
+    }
+    // 下タブはモバイル幅でしか出ない。テストの実行幅に依らず位置だけを見る
+    tabs.style.display = "flex";
+
+    const { bottom } = tabs.getBoundingClientRect();
+    const navigationBarTop = globalThis.innerHeight - Number.parseInt(ANDROID_SAFE_BOTTOM, 10);
+
+    expect(bottom).toBeLessThanOrEqual(navigationBarTop + 0.5);
+  });
+
+  it("uses the whole viewport when there are no system bars", () => {
+    setInsets("0px", "0px");
+    const app = mountApp();
+
+    expect(app.getBoundingClientRect().height).toBeCloseTo(globalThis.innerHeight, 0);
+  });
+});

--- a/tauri-app/src/styles/markdown-toolbar.css
+++ b/tauri-app/src/styles/markdown-toolbar.css
@@ -5,7 +5,10 @@
   .markdown-toolbar {
     display: flex;
     position: fixed;
-    bottom: 0;
+    /* position: fixed は html の padding を無視するので、0 だと Android の
+       ナビゲーションバーの裏に入る。キーボードが開いている間は JS が top を
+       打つので、この値は使われない */
+    bottom: var(--safe-bottom, 0px);
     left: 0;
     right: 0;
     z-index: 150;


### PR DESCRIPTION
## なぜ

Android の実機で、下タブ（Timeline / Notes / Settings）と入力バーがシステムのナビゲーションバーの裏に回り込み、**Notes が押せない**状態だった。あわせて APK が 52MB あり、CLAUDE.md の優先度2「Lightweight」から外れていた。

## レイアウトのはみ出し

`html` に safe-area ぶんの padding を入れているのに `.app` が `100vh` のままだったため、アプリ全体が上下インセットの合計だけ画面外に押し出されていた。「縦長すぎる」「下タブが押せない」「入力バーが隠れる」は全て同じ原因。

```css
height: calc(100dvh - var(--safe-top) - var(--safe-bottom));
```

`.markdown-toolbar` も同じ穴に落ちていた。`position: fixed` は `html` の padding を無視するので `bottom: 0` はナビバーの裏になる。さらに JS が `visualViewport.height` で `top` を固定しており、**Android ではキーボードが閉じていてもその高さがナビバーを含んだ全高になる**ため、CSS だけでは直らなかった。キーボード開閉の判定を `keyboardTop` という純関数に切り出し、閉じている間は CSS に任せるようにした。

## 実機で見つからないと分からなかった問題を CI で捕まえる

`env()` を直に散らしているとテストから値を差し込めない。`--safe-top` / `--safe-bottom` に集約し、Android 相当のインセット（上42px / 下24px）を与えるブラウザテストを追加した。旧 CSS で落ちることを確認したうえで通している。

```
× does not overflow the viewport   : expected 938 <= 896.5   → 42px はみ出し
× keeps the bottom tabs reachable  : expected 938 <= 872.5   → 66px 潜り込み
```

この 66px が「Notes が押せない」の正体。

## APK サイズ (/profile)

計測したところ 52MB のうち 48.4MB が native ライブラリで、そのうち 26MB はエミュレータ専用の x86 / x86_64 だった。残る arm64 の `.so` も 13.3MB あり、`[profile.release]` が未定義のままシンボル付き・LTO なしでビルドされていた。

| | 変更前 | 変更後 |
| --- | --- | --- |
| APK | 52 MB | **11 MB** |
| native lib | 48.4 MB / 4 ABI | 8.24 MB / arm64 のみ |
| `.so` | 13.3 MB (not stripped) | 8.24 MB (**stripped**) |

`opt-level` は既定の 3 のまま。ローカルスキャンと SHA-256 は同期処理でエディタの応答時間に乗るため、サイズのために速度を落とす取引はしない。

## 実機検証

端末がロック状態でスクリーンショットが撮れなかったため（ロック画面の背後では Activity が resume されず `Total frames rendered: 0`）、`showWhenLocked` を持つ別パッケージの検証専用ビルドを一時的に入れて計測し、その後削除した。端末のセキュリティ設定と既存アプリのデータには触れていない。

- 下タブがラベルごとナビバーの上に完全表示されることを確認
- 入力バーが隠れないことを確認
- **Notes タブを実際にタップし、Timeline → Notes の遷移を確認**

| 項目 | 実測値 |
| --- | --- |
| コールドスタート | 308ms → 214ms → 212ms |
| フレーム 50th / 90th / 95th | 8ms / 22ms / 42ms |
| Janky frames | 9 / 61 (14.8%) |
| TOTAL PSS | 123.5 MB |

## 検証

- フロント 121 件 green（回帰テスト 7 件を追加）
- Rust 128 件 green / `nix fmt` / `just check`

## 未確認

`fix(android): keep the markdown toolbar above the navigation bar` は、検証用ビルドがノート 0 件で編集画面を開けなかったため実機で動かせていない。判定ロジックは純関数として単体テスト済みだが、キーボード追従は #54 の残像問題を抱える領域なので、挙動がおかしければこのコミットだけ切り戻せる。
