### PR TITLE
有線か無線かを記録し、macOS でも書いた場所を残す

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,6 +2425,8 @@ dependencies = [
  "jsonwebtoken",
  "keyring",
  "magical-merchant-core",
+ "objc2",
+ "objc2-core-location",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -2743,6 +2745,16 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]

--- a/core/src/utils/device.rs
+++ b/core/src/utils/device.rs
@@ -1,8 +1,13 @@
 use serde::{Deserialize, Serialize};
 
+/// どうやって外に繋がっていたか。
+///
+/// 回線の名前（SSID）は持たない。macOS 14 以降は位置情報の許可がないと
+/// 伏せられるうえ、どこで書いたかは位置情報のほうが正確に答える。
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum NetworkType {
     WiFi,
+    Ethernet,
     Mobile,
     Offline,
 }
@@ -21,8 +26,6 @@ pub struct Context {
     pub is_charging: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub network_type: Option<NetworkType>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub wifi_ssid: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub location: Option<Location>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -76,7 +79,6 @@ impl Context {
             battery: self.battery,
             is_charging: self.is_charging,
             network_type: self.network_type.clone(),
-            wifi_ssid: self.wifi_ssid.clone(),
             location: self.location.clone(),
             ..Self::default()
         }
@@ -103,7 +105,6 @@ mod tests {
             battery: Some(82),
             is_charging: Some(false),
             network_type: Some(NetworkType::WiFi),
-            wifi_ssid: Some("MyNetwork".to_string()),
             location: Some(Location {
                 latitude: 35.6762,
                 longitude: 139.6503,
@@ -163,7 +164,6 @@ mod tests {
         assert_eq!(ctx.battery, None);
         assert_eq!(ctx.is_charging, None);
         assert_eq!(ctx.network_type, None);
-        assert_eq!(ctx.wifi_ssid, None);
         assert_eq!(ctx.location, None);
     }
 
@@ -180,7 +180,6 @@ mod tests {
             battery: Some(82),
             is_charging: Some(false),
             network_type: Some(NetworkType::WiFi),
-            wifi_ssid: Some("MyNetwork".to_string()),
             location: Some(Location {
                 latitude: 35.6762,
                 longitude: 139.6503,
@@ -194,7 +193,6 @@ mod tests {
         let json = serde_json::to_string(&ctx).unwrap();
         assert!(json.contains("\"battery\":82"));
         assert!(json.contains("\"network_type\":\"WiFi\""));
-        assert!(json.contains("\"wifi_ssid\":\"MyNetwork\""));
         assert!(json.contains("\"latitude\":35.6762"));
         assert!(json.contains("\"os\":\"macos\""));
         assert!(json.contains("\"hostname\":\"MacBook\""));
@@ -207,7 +205,6 @@ mod tests {
         assert_eq!(ctx.battery, Some(82));
         assert_eq!(ctx.is_charging, Some(false));
         assert_eq!(ctx.network_type, None);
-        assert_eq!(ctx.wifi_ssid, None);
         assert_eq!(ctx.location, None);
     }
 

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -41,6 +41,15 @@ base64 = "0.22"
 [target.'cfg(not(target_os = "android"))'.dependencies]
 battery = "0.7"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+# 既定では全ヘッダと block2 / dispatch2 / contacts まで引き込む。使うのは
+# 測位だけなので、CLLocationManager と CLLocation の 2 つに絞る。
+objc2-core-location = { version = "0.3", default-features = false, features = [
+  "CLLocation",
+  "CLLocationManager",
+] }
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/tauri-app/src-tauri/Info.plist
+++ b/tauri-app/src-tauri/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- requestWhenInUseAuthorization はこのキーが無いと、許可を尋ねもせず
+       黙って何もしない。文言はそのまま許可ダイアログに出る。 -->
+  <key>NSLocationWhenInUseUsageDescription</key>
+  <string>記録した場所をメモと一緒に残すために使います。位置情報は端末の中だけに保存され、外には送りません。</string>
+  <!-- 古い macOS が見る旧キー。新しい API は参照しないが、あっても害はない。 -->
+  <key>NSLocationUsageDescription</key>
+  <string>記録した場所をメモと一緒に残すために使います。位置情報は端末の中だけに保存され、外には送りません。</string>
+</dict>
+</plist>

--- a/tauri-app/src-tauri/src/device.rs
+++ b/tauri-app/src-tauri/src/device.rs
@@ -21,13 +21,11 @@ pub(crate) struct ClientContext {
 /// ネイティブは OS に直接聞ける（macOS の battery クレートなど）ぶん確度が高い。
 pub(crate) fn get_context(client: ClientContext) -> DeviceContext {
     let (battery, is_charging) = get_battery();
-    let (network_type, wifi_ssid) = get_network();
 
     DeviceContext {
         battery: battery.or(client.battery),
         is_charging: is_charging.or(client.is_charging),
-        network_type: network_type.or(client.network_type),
-        wifi_ssid,
+        network_type: get_network().or(client.network_type),
         location: make_location(client.latitude, client.longitude),
         os: std::env::consts::OS.to_string(),
         os_version: get_os_version().or(client.os_version),
@@ -117,93 +115,143 @@ const fn get_battery() -> (Option<u8>, Option<bool>) {
     (None, None)
 }
 
+/// いま外に出ている経路が有線か無線かを、名前を聞かずに判定する。
+///
+/// 既定経路のインターフェース名を引き、それがどのハードウェアポートかを
+/// 名前で引き直す。SSID を読むのと違い、どちらのコマンドも位置情報の許可を
+/// 必要としない。
 #[cfg(target_os = "macos")]
-fn get_network() -> (Option<NetworkType>, Option<String>) {
-    let Ok(output) = std::process::Command::new("ipconfig")
-        .args(["getsummary", "en0"])
+fn get_network() -> Option<NetworkType> {
+    let route = std::process::Command::new("route")
+        .args(["-n", "get", "default"])
         .output()
-    else {
-        return (None, None);
+        .ok()?;
+    let Some(interface) = parse_default_interface(&String::from_utf8_lossy(&route.stdout)) else {
+        // 既定経路が無い = どこにも出られない。
+        return Some(NetworkType::Offline);
     };
 
-    parse_wifi_summary(&String::from_utf8_lossy(&output.stdout))
+    let ports = std::process::Command::new("networksetup")
+        .arg("-listallhardwareports")
+        .output()
+        .ok()?;
+    let port = parse_hardware_port(&String::from_utf8_lossy(&ports.stdout), &interface)?;
+
+    Some(classify_port(&port))
 }
 
-/// `ipconfig getsummary en0` の出力から Wi-Fi の状態を読む。
-///
-/// SSID 行があるだけで Wi-Fi 接続中だと分かるので、名前が読めなくても
-/// `NetworkType::WiFi` は返す。macOS 14 以降は位置情報の許可がないと
-/// SSID が `<redacted>` に伏せられ、これをそのまま保存すると
-/// 「SSID が取れている」ように見えるゴミが記録に残る。
+/// `route -n get default` の `interface:` 行。
 #[cfg(target_os = "macos")]
-fn parse_wifi_summary(stdout: &str) -> (Option<NetworkType>, Option<String>) {
+fn parse_default_interface(stdout: &str) -> Option<String> {
+    stdout.lines().find_map(|line| {
+        let name = line.trim().strip_prefix("interface: ")?.trim();
+        (!name.is_empty()).then(|| name.to_string())
+    })
+}
+
+/// `networksetup -listallhardwareports` から、その `Device` を持つ
+/// `Hardware Port` の名前を返す。ポート名と Device 行は必ずこの順で対になる。
+#[cfg(target_os = "macos")]
+fn parse_hardware_port(stdout: &str, interface: &str) -> Option<String> {
+    let mut port: Option<&str> = None;
     for line in stdout.lines() {
-        let Some(ssid) = line.trim().strip_prefix("SSID : ") else {
-            continue;
-        };
-        let ssid = ssid.trim();
-        if ssid.is_empty() {
-            continue;
+        let line = line.trim();
+        if let Some(name) = line.strip_prefix("Hardware Port: ") {
+            port = Some(name.trim());
+        } else if let Some(device) = line.strip_prefix("Device: ") {
+            if device.trim() == interface {
+                return port.map(str::to_string);
+            }
         }
-        let named = (!is_redacted(ssid)).then(|| ssid.to_string());
-        return (Some(NetworkType::WiFi), named);
     }
-
-    // SSID 行がない = Ethernet かテザリングか本当に圏外。切り分けられない以上、
-    // Offline と断定すると嘘になるので None のままにする。
-    (None, None)
+    None
 }
 
+/// ポート名から回線の種類を決める。
+///
+/// iPhone の USB テザリングは見た目こそ有線だが、出ていく先は携帯回線。
+/// 有線として記録すると、実際には電波の届く所でしか書けなかった記録が
+/// 机の上で書いたように見える。
 #[cfg(target_os = "macos")]
-fn is_redacted(value: &str) -> bool {
-    value.starts_with('<') && value.ends_with('>')
+fn classify_port(port: &str) -> NetworkType {
+    let lowered = port.to_lowercase();
+    if lowered.contains("wi-fi") || lowered.contains("airport") {
+        NetworkType::WiFi
+    } else if lowered.contains("iphone") || lowered.contains("ipad") {
+        NetworkType::Mobile
+    } else {
+        NetworkType::Ethernet
+    }
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "android")))]
-const fn get_network() -> (Option<NetworkType>, Option<String>) {
-    (None, None)
-}
-
-#[cfg(target_os = "android")]
-const fn get_network() -> (Option<NetworkType>, Option<String>) {
-    (None, None)
+#[cfg(not(target_os = "macos"))]
+const fn get_network() -> Option<NetworkType> {
+    None
 }
 
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
     use super::*;
 
-    const CONNECTED: &str = "  <dictionary> {\n  BSSID : 11:22:33:44:55:66\n  SSID : MyNetwork\n}";
+    /// 実機の `networksetup -listallhardwareports` の抜粋。
+    const PORTS: &str = "\n\
+        Hardware Port: Ethernet Adapter (en3)\n\
+        Device: en3\n\
+        Ethernet Address: 32:73:6f:a1:60:43\n\
+        \n\
+        Hardware Port: Thunderbolt Bridge\n\
+        Device: bridge0\n\
+        Ethernet Address: 36:c3:1a:6d:54:00\n\
+        \n\
+        Hardware Port: Wi-Fi\n\
+        Device: en0\n\
+        Ethernet Address: 10:9f:41:bf:3d:ff\n";
 
     #[test]
-    fn reads_the_ssid_when_macos_discloses_it() {
-        let (network, ssid) = parse_wifi_summary(CONNECTED);
+    fn reads_the_interface_the_default_route_uses() {
+        let stdout = "   route to: default\n    gateway: 192.168.3.1\n  interface: en0\n";
 
-        assert_eq!(network, Some(NetworkType::WiFi));
-        assert_eq!(ssid.as_deref(), Some("MyNetwork"));
+        assert_eq!(parse_default_interface(stdout).as_deref(), Some("en0"));
+    }
+
+    /// 既定経路が無いときの `route` はこの行を出さない。
+    #[test]
+    fn finds_no_interface_without_a_default_route() {
+        assert_eq!(
+            parse_default_interface("route: writing to routing socket: not in table"),
+            None
+        );
     }
 
     #[test]
-    fn keeps_wifi_but_drops_the_name_when_macos_redacts_it() {
-        let (network, ssid) = parse_wifi_summary("  BSSID : <redacted>\n  SSID : <redacted>");
-
-        assert_eq!(network, Some(NetworkType::WiFi));
-        assert_eq!(ssid, None);
+    fn matches_an_interface_to_its_hardware_port() {
+        assert_eq!(parse_hardware_port(PORTS, "en0").as_deref(), Some("Wi-Fi"));
+        assert_eq!(
+            parse_hardware_port(PORTS, "en3").as_deref(),
+            Some("Ethernet Adapter (en3)")
+        );
     }
 
     #[test]
-    fn reports_nothing_without_an_ssid_line() {
-        let (network, ssid) = parse_wifi_summary("  <dictionary> {\n  IPv4 : 192.168.0.2\n}");
-
-        assert_eq!(network, None);
-        assert_eq!(ssid, None);
+    fn finds_no_port_for_an_interface_that_is_not_listed() {
+        assert_eq!(parse_hardware_port(PORTS, "utun4"), None);
     }
 
     #[test]
-    fn skips_an_empty_ssid_line() {
-        let (network, ssid) = parse_wifi_summary("  SSID : \n");
+    fn tells_wireless_from_wired() {
+        assert_eq!(classify_port("Wi-Fi"), NetworkType::WiFi);
+        assert_eq!(classify_port("AirPort"), NetworkType::WiFi);
+        assert_eq!(
+            classify_port("Ethernet Adapter (en3)"),
+            NetworkType::Ethernet
+        );
+        assert_eq!(classify_port("Thunderbolt Bridge"), NetworkType::Ethernet);
+    }
 
-        assert_eq!(network, None);
-        assert_eq!(ssid, None);
+    /// USB で挿していても出ていく先は携帯回線。有線として記録すると、
+    /// 電波の届く所でしか書けなかった記録が机の上で書いたように見える。
+    #[test]
+    fn counts_a_tethered_phone_as_mobile() {
+        assert_eq!(classify_port("iPhone USB"), NetworkType::Mobile);
     }
 }

--- a/tauri-app/src-tauri/src/device.rs
+++ b/tauri-app/src-tauri/src/device.rs
@@ -26,13 +26,25 @@ pub(crate) fn get_context(client: ClientContext) -> DeviceContext {
         battery: battery.or(client.battery),
         is_charging: is_charging.or(client.is_charging),
         network_type: get_network().or(client.network_type),
-        location: make_location(client.latitude, client.longitude),
+        location: make_location(client.latitude, client.longitude).or_else(get_location),
         os: std::env::consts::OS.to_string(),
         os_version: get_os_version().or(client.os_version),
         arch: std::env::consts::ARCH.to_string(),
         hostname: get_hostname(),
         locale: get_locale().or(client.locale),
     }
+}
+
+/// `WebView` が座標を持たないときの取り直し。Android の geolocation プラグインは
+/// フロント側で答えを出しているので、こちらが要るのは macOS だけ。
+#[cfg(target_os = "macos")]
+fn get_location() -> Option<Location> {
+    crate::location::latest()
+}
+
+#[cfg(not(target_os = "macos"))]
+const fn get_location() -> Option<Location> {
+    None
 }
 
 const fn make_location(latitude: Option<f64>, longitude: Option<f64>) -> Option<Location> {

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -8,6 +8,8 @@
 
 mod auth;
 mod device;
+#[cfg(target_os = "macos")]
+mod location;
 mod sync;
 
 use device::ClientContext;
@@ -199,6 +201,12 @@ pub fn run() {
             let handle = app.handle().clone();
             app.deep_link()
                 .on_open_url(move |event| store_token_from_urls(&handle, &event.urls()));
+
+            // 測位は始めてから最初の 1 件が返るまでに間がある。保存のたびに
+            // 頼むのでは間に合わないので、起動と同時に受け取り始める。
+            #[cfg(target_os = "macos")]
+            location::start(app.handle());
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/tauri-app/src-tauri/src/location.rs
+++ b/tauri-app/src-tauri/src/location.rs
@@ -1,0 +1,98 @@
+//! macOS の位置情報。
+//!
+//! `tauri-plugin-geolocation` はデスクトップが実装スタブで、`Position::default()`
+//! をそのまま返す。許可を尋ねることすらしないので、Mac で書いた記録には座標が
+//! 一度も残っていなかった。CoreLocation を直に叩く。
+
+use std::cell::OnceCell;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use magical_merchant_core::utils::device::Location;
+use objc2::rc::Retained;
+use objc2_core_location::{CLLocationManager, kCLLocationAccuracyHundredMeters};
+use tauri::AppHandle;
+
+/// 直近に取れた座標。
+///
+/// `CLLocationManager` はメインスレッドに縛られていて `Send` でもないので、
+/// 記録する側とはこの箱越しにやり取りする。
+static LAST_FIX: Mutex<Option<Location>> = Mutex::new(None);
+
+/// 何メートル動いたら次の更新を受け取るか。
+///
+/// どこで書いたかが分かればよく、番地まで当てる必要はない。細かくするほど
+/// GPS を回す時間が延びるだけで、記録の読み返しには何も足さない。
+const DISTANCE_FILTER_METERS: f64 = 50.0;
+
+/// 座標を箱に写し直す間隔。
+///
+/// 更新そのものは OS 側が距離で間引くので、この間隔が変えるのは手元の写しが
+/// どれだけ古くなりうるかだけ。起動直後の 1 件目にも座標を載せたいので、
+/// 分単位まで空けない。
+const POLL_INTERVAL: Duration = Duration::from_secs(10);
+
+thread_local! {
+    /// メインスレッドだけが触る。落とすと更新も黙って止まるので握り続ける。
+    static MANAGER: OnceCell<Retained<CLLocationManager>> = const { OnceCell::new() };
+}
+
+/// メインスレッドで、いま分かっている座標を箱に写す。
+///
+/// # Panics
+///
+/// しない。許可がなければ `location` が `None` を返すだけで、そのまま戻る。
+fn refresh() {
+    MANAGER.with(|cell| {
+        let manager = cell.get_or_init(|| {
+            // SAFETY: run_on_main_thread の中でしか呼ばれない。CoreLocation は
+            // 初期化したスレッドの run loop に結果を返すので、Tauri のイベント
+            // ループが回っているメインスレッドで作る必要がある。
+            unsafe {
+                let manager = CLLocationManager::new();
+                manager.setDesiredAccuracy(kCLLocationAccuracyHundredMeters);
+                manager.setDistanceFilter(DISTANCE_FILTER_METERS);
+                manager.requestWhenInUseAuthorization();
+                manager.startUpdatingLocation();
+                manager
+            }
+        });
+
+        // SAFETY: 同上。まだ測位できていなければ None が返る。
+        let Some(fix) = (unsafe { manager.location() }) else {
+            return;
+        };
+        // SAFETY: 同上。
+        let coordinate = unsafe { fix.coordinate() };
+        // SAFETY: 同上。測位に失敗した座標は範囲外の値で返ってくる。
+        if !unsafe { coordinate.is_valid() } {
+            return;
+        }
+
+        if let Ok(mut last) = LAST_FIX.lock() {
+            *last = Some(Location {
+                latitude: coordinate.latitude,
+                longitude: coordinate.longitude,
+            });
+        }
+    });
+}
+
+/// 記録に載せる座標。まだ 1 度も測位できていなければ `None`。
+pub(crate) fn latest() -> Option<Location> {
+    LAST_FIX.lock().ok().and_then(|fix| fix.clone())
+}
+
+/// 位置情報の受け取りを始める。
+///
+/// 保存のたびにメインスレッドの応答を待つと、待つ側がメインスレッドだった場合に
+/// 固まる。裏で写し続けておいて、保存時は箱を読むだけにする。
+pub(crate) fn start(app: &AppHandle) {
+    let handle = app.clone();
+    std::thread::spawn(move || {
+        // 失敗するのはアプリが畳まれたとき。追いかける相手がいないので降りる。
+        while handle.run_on_main_thread(refresh).is_ok() {
+            std::thread::sleep(POLL_INTERVAL);
+        }
+    });
+}

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -37,6 +37,10 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png"]
+    "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png"],
+    "macOS": {
+      "signingIdentity": "-",
+      "hardenedRuntime": false
+    }
   }
 }

--- a/tauri-app/src/components/CalendarPopover.tsx
+++ b/tauri-app/src/components/CalendarPopover.tsx
@@ -10,6 +10,7 @@ import {
 } from "../lib/calendar";
 import type { DaySummary } from "../lib/calendar";
 import { toIsoDate } from "../lib/day-labels";
+import { getNetworkIcon } from "../lib/parse-timeline";
 import type { DeviceContext } from "../lib/parse-timeline";
 
 interface CalendarPopoverProps {
@@ -84,14 +85,24 @@ export default function CalendarPopover(props: CalendarPopoverProps): JSX.Elemen
         </span>
         <Show when={summary().count > 0}>
           <span class="calendar-summary-row">
-            <Show when={summary().places.length}>
+            <Show when={summary().located}>
               <span class="calendar-summary-item">
                 <Icon name="map-pin" size={13} />
-                {summary()
-                  .places.map((p) => `${p.label} ${p.count}`)
-                  .join(" · ")}
+                {summary().located}
               </span>
             </Show>
+            <For each={summary().networks}>
+              {(network) => (
+                <Show when={getNetworkIcon({ network_type: network.label } as DeviceContext)}>
+                  {(icon) => (
+                    <span class="calendar-summary-item">
+                      <Icon name={icon()} size={13} />
+                      {network.count}
+                    </span>
+                  )}
+                </Show>
+              )}
+            </For>
             <For each={summary().devices}>
               {(device) => (
                 <span class="calendar-summary-item">

--- a/tauri-app/src/components/Icon.tsx
+++ b/tauri-app/src/components/Icon.tsx
@@ -32,6 +32,7 @@ const ICONS = {
   "wifi-high": () => import("@phosphor-icons/core/assets/regular/wifi-high.svg?raw"),
   "wifi-slash": () => import("@phosphor-icons/core/assets/regular/wifi-slash.svg?raw"),
   "cell-signal-full": () => import("@phosphor-icons/core/assets/regular/cell-signal-full.svg?raw"),
+  network: () => import("@phosphor-icons/core/assets/regular/network.svg?raw"),
   "map-pin": () => import("@phosphor-icons/core/assets/regular/map-pin.svg?raw"),
   laptop: () => import("@phosphor-icons/core/assets/regular/laptop.svg?raw"),
   "device-mobile": () => import("@phosphor-icons/core/assets/regular/device-mobile.svg?raw"),

--- a/tauri-app/src/lib/calendar.test.ts
+++ b/tauri-app/src/lib/calendar.test.ts
@@ -53,25 +53,30 @@ describe("summarizeDay", () => {
     expect(summarizeDay([ctx(), null, ctx()]).count).toBe(3);
   });
 
-  it("names places by Wi-Fi SSID", () => {
+  it("counts how the day got online, most used first", () => {
     const summary = summarizeDay([
-      ctx({ wifi_ssid: "home" }),
-      ctx({ wifi_ssid: "office" }),
-      ctx({ wifi_ssid: "home" }),
+      ctx({ network_type: "WiFi" }),
+      ctx({ network_type: "Ethernet" }),
+      ctx({ network_type: "WiFi" }),
     ]);
-    expect(summary.places).toStrictEqual([
-      { label: "home", count: 2 },
-      { label: "office", count: 1 },
+    expect(summary.networks).toStrictEqual([
+      { label: "WiFi", count: 2 },
+      { label: "Ethernet", count: 1 },
     ]);
   });
 
-  it("falls back to a placeholder when only coordinates are known", () => {
-    const summary = summarizeDay([ctx({ location: { latitude: 35, longitude: 139 } })]);
-    expect(summary.places).toStrictEqual([{ label: "場所不明", count: 1 }]);
+  it("leaves the networks empty when the line was never recorded", () => {
+    expect(summarizeDay([ctx(), null]).networks).toStrictEqual([]);
   });
 
-  it("leaves places empty when nothing about location was recorded", () => {
-    expect(summarizeDay([ctx(), null]).places).toStrictEqual([]);
+  // 緯度経度を並べても地名にはならない。数えて意味が出るのは件数のほう。
+  it("counts the entries that kept their coordinates", () => {
+    const summary = summarizeDay([
+      ctx({ location: { latitude: 35, longitude: 139 } }),
+      ctx(),
+      ctx({ location: { latitude: 36, longitude: 140 } }),
+    ]);
+    expect(summary.located).toBe(2);
   });
 
   it("counts devices by os", () => {

--- a/tauri-app/src/lib/calendar.ts
+++ b/tauri-app/src/lib/calendar.ts
@@ -53,23 +53,11 @@ interface Tally {
 
 export interface DaySummary {
   count: number;
-  places: Tally[];
+  /** 座標が残っているエントリの数。 */
+  located: number;
+  /** ラベルは `NetworkType` そのもの。アイコンに直すのは表示側の仕事。 */
+  networks: Tally[];
   devices: Tally[];
-}
-
-const UNKNOWN_PLACE = "場所不明";
-
-function placeOf(context: DeviceContext | null): string | null {
-  if (!context) {
-    return null;
-  }
-  if (context.wifi_ssid) {
-    return context.wifi_ssid;
-  }
-  if (context.location) {
-    return UNKNOWN_PLACE;
-  }
-  return null;
 }
 
 function tally(values: (string | null)[]): Tally[] {
@@ -85,13 +73,16 @@ function tally(values: (string | null)[]): Tally[] {
 }
 
 /**
- * その日のエントリを場所と端末で数える。場所の名前は Wi-Fi SSID を使う:
- * 記録に含まれる中で人が地名として読める唯一の値がこれしかない。
+ * その日のエントリを回線と端末で数える。
+ *
+ * 場所は座標があるかどうかだけを数える。緯度経度をそのまま並べても地名には
+ * ならず、数えて意味が出るのは「その日どれだけ外で書いたか」のほう。
  */
 export function summarizeDay(contexts: (DeviceContext | null)[]): DaySummary {
   return {
     count: contexts.length,
-    places: tally(contexts.map((c) => placeOf(c))),
+    located: contexts.filter((c) => c?.location).length,
+    networks: tally(contexts.map((c) => c?.network_type ?? null)),
     devices: tally(contexts.map((c) => c?.os || null)),
   };
 }

--- a/tauri-app/src/lib/client-context.test.ts
+++ b/tauri-app/src/lib/client-context.test.ts
@@ -26,6 +26,7 @@ describe("toNetworkType", () => {
 
   it("maps the Network Information API values", () => {
     expect(toNetworkType(true, "wifi")).toBe("WiFi");
+    expect(toNetworkType(true, "ethernet")).toBe("Ethernet");
     expect(toNetworkType(true, "cellular")).toBe("Mobile");
   });
 
@@ -36,7 +37,7 @@ describe("toNetworkType", () => {
   // 種別が分からないまま WiFi と決め打つと記録が嘘になる。
   it("returns null when the connection type is unknown or absent", () => {
     expect(toNetworkType(true)).toBeNull();
-    expect(toNetworkType(true, "ethernet")).toBeNull();
+    expect(toNetworkType(true, "bluetooth")).toBeNull();
   });
 });
 

--- a/tauri-app/src/lib/client-context.ts
+++ b/tauri-app/src/lib/client-context.ts
@@ -4,7 +4,7 @@ import {
   getCurrentPosition,
 } from "@tauri-apps/plugin-geolocation";
 
-export type NetworkType = "WiFi" | "Mobile" | "Offline";
+export type NetworkType = "WiFi" | "Ethernet" | "Mobile" | "Offline";
 
 /**
  * ネイティブ側では取れない実行環境の情報。Android には `battery` クレートも
@@ -48,13 +48,16 @@ export function toNetworkType(online: boolean, connectionType?: string): Network
     case "wifi": {
       return "WiFi";
     }
+    case "ethernet": {
+      return "Ethernet";
+    }
     case "cellular": {
       return "Mobile";
     }
     case "none": {
       return "Offline";
     }
-    // ethernet / bluetooth / unknown、あるいは API 自体が無いブラウザ。
+    // bluetooth / wimax / unknown、あるいは API 自体が無いブラウザ。
     // 分からないものを WiFi に丸めると記録が嘘になるので黙って諦める。
     default: {
       return null;

--- a/tauri-app/src/lib/parse-timeline.ts
+++ b/tauri-app/src/lib/parse-timeline.ts
@@ -3,8 +3,7 @@ import type { IconName } from "../components/Icon";
 export interface DeviceContext {
   battery?: number;
   is_charging?: boolean;
-  network_type?: "WiFi" | "Mobile" | "Offline";
-  wifi_ssid?: string;
+  network_type?: "WiFi" | "Ethernet" | "Mobile" | "Offline";
   location?: { latitude: number; longitude: number };
   os: string;
   os_version?: string;
@@ -76,6 +75,9 @@ export function getNetworkIcon(ctx: DeviceContext): IconName | null {
   switch (ctx.network_type) {
     case "WiFi": {
       return "wifi-high";
+    }
+    case "Ethernet": {
+      return "network";
     }
     case "Mobile": {
       return "cell-signal-full";

--- a/tauri-app/src/lib/timeline-meta.test.ts
+++ b/tauri-app/src/lib/timeline-meta.test.ts
@@ -19,17 +19,14 @@ describe("entryMeta", () => {
     expect(entryMeta(context({ os_version: "15.5" }))[0].label).toBe("macos 15.5");
   });
 
-  it("prefers the network name over its type", () => {
-    const meta = entryMeta(context({ network_type: "WiFi", wifi_ssid: "オフィスWi-Fi" }));
-
-    expect(meta[1]).toEqual({ icon: "wifi-high", label: "オフィスWi-Fi" });
-  });
-
-  // SSID は macOS の伏字対策で落ちることがある。Wi-Fi だと分かる以上は出す。
-  it("falls back to the network type when the name is unavailable", () => {
+  it("tells wired from wireless", () => {
     expect(entryMeta(context({ network_type: "WiFi" }))[1]).toEqual({
       icon: "wifi-high",
       label: "Wi-Fi",
+    });
+    expect(entryMeta(context({ network_type: "Ethernet" }))[1]).toEqual({
+      icon: "network",
+      label: "有線",
     });
     expect(entryMeta(context({ network_type: "Mobile" }))[1]).toEqual({
       icon: "cell-signal-full",

--- a/tauri-app/src/lib/timeline-meta.ts
+++ b/tauri-app/src/lib/timeline-meta.ts
@@ -10,6 +10,7 @@ export interface MetaSegment {
 
 const NETWORK_LABELS = {
   WiFi: "Wi-Fi",
+  Ethernet: "有線",
   Mobile: "モバイル回線",
   Offline: "オフライン",
 } as const;
@@ -29,9 +30,7 @@ function networkSegment(ctx: DeviceContext): MetaSegment | null {
   if (!icon || !ctx.network_type) {
     return null;
   }
-  // SSID が分かるならそちらを出す。「Wi-Fi」より「自宅」のほうが、
-  // どこで書いたのかを思い出す手がかりになる。
-  return { icon, label: ctx.wifi_ssid ?? NETWORK_LABELS[ctx.network_type] };
+  return { icon, label: NETWORK_LABELS[ctx.network_type] };
 }
 
 function batterySegment(ctx: DeviceContext): MetaSegment | null {


### PR DESCRIPTION
## 背景

前の PR で「電源・Wi-Fi・位置情報がちゃんと取れているか」を実データで確かめたところ、macOS の SSID は `"<redacted>"` というゴミしか残らず、有線接続では回線の情報が何ひとつ残っていなかった。macOS の位置情報にいたっては一度も記録されたことがなかった。

回線の名前は要らない。知りたいのは有線か無線か、そしてどこで書いたか。

## 変更

### 1. 有線／無線を記録し、SSID をやめる (b6685f9)

macOS の判定を「SSID 行があるか」から「既定経路のインターフェース名 → ハードウェアポート名」に変えた。`route -n get default` と `networksetup -listallhardwareports` のどちらも位置情報の許可を必要としない。

**これまで有線接続は「SSID 行が無い」として一律に記録なしへ落ちていた**ので、机で有線に挿して書いた記録には回線の情報が何も残らなかった。

- `NetworkType` に `Ethernet` を追加、`Context` から `wifi_ssid` を削除
- 既存の記録に残る `wifi_ssid` は読み飛ばされる。値はどれも `"<redacted>"` で、失って困るものは無い
- iPhone の USB テザリングは `Mobile` として数える。有線として記録すると、実際には電波の届く所でしか書けなかった記録が机の上で書いたように見える

カレンダーの日別サマリは SSID を場所の名前として使っていたので、回線の内訳と座標の残っている件数に置き換えた。緯度経度を並べても地名にはならず、数えて意味が出るのは「その日どれだけ外で書いたか」のほう。

### 2. macOS で書いた場所を残す (c5c94e2)

`tauri-plugin-geolocation` はデスクトップが実装スタブで、許可を尋ねもせず `Position::default()` を返す。CoreLocation を直に叩く。

- **保存時にメインスレッドの応答を待たない。** 待つ側がメインスレッドだった場合に固まる。起動と同時に受け取りを始めて箱に写しておき、保存時は箱を読むだけにした。測位は始めてから最初の 1 件が返るまでに間があるので、どのみち保存時に頼むのでは間に合わない
- 精度は 100m、距離フィルタは 50m。どこで書いたかが分かればよく、細かくするほど GPS を回す時間が延びるだけ
- `Info.plist` に `NSLocationWhenInUseUsageDescription` を置いた。このキーが無いと `requestWhenInUseAuthorization` は許可を尋ねもせず黙って何もしない

**署名を ad-hoc で明示した。** これまではリンカが付けた署名しかなく、TCC が plist の文言を信用できず許可の対象にならなかった:

| | 変更前 | 変更後 |
|---|---|---|
| Identifier | `magical_merchant_app-c6a3144a...` | `com.magical-merchant.app` |
| Info.plist | not bound | entries=17 |
| Sealed Resources | none | version=2 |

再ビルドのたびに cdhash が変わるので位置情報の許可は出し直しになる。更新頻度を考えれば、そのために署名 ID を買うほうが割に合わない。

## 確認

実機で記録された 1 件:

```
[04:24:23] テスト {"battery":100,"is_charging":true,"network_type":"WiFi",
                   "location":{"latitude":43.179...,"longitude":141.027...},"d":1}
```

`.app` をビルドして起動し、位置情報の許可を通してから実際に記録した結果。新しい回線判定と CoreLocation の両方が実アプリで動いている。

回線判定は実機で `en0 → Wi-Fi` に一致することを確認。agent-browser で有線／Wi-Fi／モバイル／オフラインの 4 種が混ざる日を表示させ、メタ行とカレンダーのサマリが正しく出ることも確認した。

`just check` / `just test` / `cargo clippy --workspace --all-targets -- -D warnings` すべて通過（Rust 152 / フロント 142 / workers 33）。

## 注意点

**hardenedRuntime は切ってある。** 有効にすると nix の `libiconv.2.dylib` が Team ID 違いで読み込めず、dyld が起動時にアプリを落とす:

```
Library not loaded: /nix/store/...-libiconv-109.100.2/lib/libiconv.2.dylib
Reason: mapping process and mapped file (non-platform) have different Team IDs
```

hardened runtime は notarization 用で TCC には要らない。将来 notarization をやる段になったら `libiconv` を nix 以外から取る必要がある。

## 残っている範囲

- **Android の SSID**: JS からは取れず JNI が要る。今回の方針（名前は要らない）により優先度は下がった
- **デザイン**: Notes (5a) / Settings (3a) / コマンドパレット (3a) / タグ (7a) / 同期ポップオーバー (6a) / 初回起動 (6a) / テーマのサイクル切替 (4a)