### PR TITLE
スマホでコードブロックが打てなくなっていたのを直す

### DIFF
--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -8,9 +8,11 @@ import {
   onCleanup,
 } from "solid-js";
 import type { JSX } from "solid-js";
+import type { Editor } from "@milkdown/kit/core";
 import Icon from "../components/Icon";
 import MarkdownPreview from "../components/MarkdownPreview";
 import MilkdownEditor from "../components/MilkdownEditor";
+import MarkdownToolbar from "../components/MarkdownToolbar";
 import { typedInvoke } from "../lib/commands";
 import { getDeviceSignals } from "../lib/client-context";
 import { useShell } from "../lib/shell";
@@ -50,6 +52,8 @@ export default function Workspace(): JSX.Element {
   const [saveStatus, setSaveStatus] = createSignal<"idle" | "saving" | "saved">("idle");
   const [hidden, setHidden] = createSignal<string[]>([]);
   const [noteBody, setNoteBody] = createSignal("");
+  /** タッチ端末のツールバーが叩く先。編集をやめると undefined に戻る。 */
+  const [markdownEditor, setMarkdownEditor] = createSignal<Editor | undefined>();
 
   const [notes, { refetch: refetchNotes }] = createResource(loadNotes);
 
@@ -228,7 +232,12 @@ export default function Workspace(): JSX.Element {
                   type="button"
                   class="icon-button detail-back"
                   aria-label="一覧に戻る"
-                  onClick={() => setDetailOpen(false)}
+                  onClick={() => {
+                    // 編集したまま戻ると、一覧の上にツールバーだけが残る。
+                    // 見えなくなった編集対象に効くボタンが浮いていることになる。
+                    void stopEditing();
+                    setDetailOpen(false);
+                  }}
                 >
                   <Icon name="arrow-left" size={18} />
                 </button>
@@ -287,6 +296,7 @@ export default function Workspace(): JSX.Element {
                       setDraft(markdown);
                       scheduleSave();
                     }}
+                    onEditorReady={setMarkdownEditor}
                   />
                 </Show>
               </div>
@@ -294,6 +304,9 @@ export default function Workspace(): JSX.Element {
           )}
         </Show>
       </div>
+
+      {/* キーボードでは打ちにくい記法のための入り口。タッチ端末にだけ出る */}
+      <MarkdownToolbar editor={markdownEditor()} />
     </div>
   );
 }


### PR DESCRIPTION
## 背景

スマホでコードブロック（＝mermaid）が書けない、という指摘から調べた。

`MarkdownToolbar.tsx` はコードブロックボタンを含めて実装が残っていたのに、**画面に出す側の呼び出しが消えていた**。2026-08-04 の `05974ea feat(ui): rebuild the app around two panes and drop the hidden chrome` で `Workspace.tsx` から 3 行が落ち、そのまま復活していない。

```diff
-import MarkdownToolbar from "../components/MarkdownToolbar";
-              onEditorReady={setEditorInstance}
-          <MarkdownToolbar editor={editorInstance()} />
```

ツールバーは `@media (hover: none)` でしか出ないので、開発機では気づけない。そのうえ `knip` も未使用と判定しなかった。`MarkdownToolbar.test.tsx` が参照しているぶん「使われている」ことになるため。**テストは通るのに画面には無い**という、静的解析の死角に落ちていた。

## 変更

### ツールバーを画面に戻す

`Workspace.tsx` から `onEditorReady` を渡し、`<MarkdownToolbar>` を描く。戻るのはアウトデント / インデント / **コードブロック** / 水平線 の 4 つ。

### 一覧に戻るときは編集も終える

編集したまま一覧に戻ると、一覧の上にツールバーだけが残る。見えなくなった編集対象に効くボタンが浮いていることになるので、戻る操作で編集を確定させる。

## 確認

agent-browser で、編集を開いたときにツールバーが `Outdent / Indent / Code block / Horizontal rule` の 4 ボタンで描かれること、Code block を押すと `.ProseMirror` に `<pre><code>` が実際に挿入されることを確認した。

`@media (hover: none)` は CDP のデバイス emulation では切り替わらないため、CSS を一時的に上書きしてモバイル幅での見た目も確認した。

`just check` / `just test` 通過（フロント 169）。

## 残っている話

- **mermaid には言語名の入力が要る。** このボタンが作るのは素のコードブロックなので、` ```mermaid ` にするには結局 `mermaid` と打つ必要がある。スマホで図を描くなら mermaid 専用ボタンがあったほうが実用的だが、今回は範囲外にした
- **ツールバーは下タブバーに重なる。** `bottom: var(--safe-bottom)` に固定されているので、キーボードを閉じた編集中は Timeline/Notes/Settings のタブが隠れる。元の実装からの挙動なので変えていない