### PR TITLE
perf: mobile performance tuning

### DIFF
--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -2,14 +2,28 @@ import { lazy } from "solid-js";
 import { Router, Route } from "@solidjs/router";
 import AppLayout from "./layouts/AppLayout";
 import Timeline from "./views/Timeline";
-import Workspace from "./views/Workspace";
 import { ROUTES } from "./lib/routes";
 import type { JSX } from "solid-js";
 
-// 起動時に表示しない view は遅延読み込みして初期バンドルを軽くする
+// 起動時に表示しない view は遅延読み込みして初期バンドルを軽くする。
+// Workspace は Milkdown + ProseMirror + Shiki を引き連れており、
+// これを外すだけで起動時に parse する JS が大きく減る。
+const Workspace = lazy(() => import("./views/Workspace"));
 const Settings = lazy(() => import("./views/Settings"));
 
+// 遅延にした代わりに、起動が落ち着いてから裏で読んでおく。
+// これが無いと Notes タブを初めて開いた瞬間に読み込み待ちが挟まる
+function prefetchLazyViews(): void {
+  const idle: (cb: () => void) => unknown =
+    typeof requestIdleCallback === "function" ? requestIdleCallback : (cb) => setTimeout(cb, 2000);
+  idle(() => {
+    void import("./views/Workspace");
+    void import("./views/Settings");
+  });
+}
+
 export default function App(): JSX.Element {
+  prefetchLazyViews();
   return (
     <Router root={AppLayout}>
       <Route path={ROUTES.TIMELINE} component={Timeline} />

--- a/tauri-app/src/App.tsx
+++ b/tauri-app/src/App.tsx
@@ -14,8 +14,10 @@ const Settings = lazy(() => import("./views/Settings"));
 // 遅延にした代わりに、起動が落ち着いてから裏で読んでおく。
 // これが無いと Notes タブを初めて開いた瞬間に読み込み待ちが挟まる
 function prefetchLazyViews(): void {
-  const idle: (cb: () => void) => unknown =
-    typeof requestIdleCallback === "function" ? requestIdleCallback : (cb) => setTimeout(cb, 2000);
+  const idle: (task: () => void) => unknown =
+    typeof requestIdleCallback === "function"
+      ? requestIdleCallback
+      : (task) => setTimeout(task, 2000);
   idle(() => {
     void import("./views/Workspace");
     void import("./views/Settings");

--- a/tauri-app/src/layouts/AppLayout.tsx
+++ b/tauri-app/src/layouts/AppLayout.tsx
@@ -13,7 +13,7 @@ import type { Theme } from "../lib/theme";
 import { MODE_ICONS, MODE_LABELS, ROUTES } from "../lib/routes";
 import type { RoutePath } from "../lib/routes";
 import { typedInvoke } from "../lib/commands";
-import { getDeviceSignals } from "../lib/client-context";
+import { getDeviceSignals, warmLocation } from "../lib/client-context";
 
 const TABS: RoutePath[] = [ROUTES.TIMELINE, ROUTES.NOTES];
 const BOTTOM_TABS: RoutePath[] = [ROUTES.TIMELINE, ROUTES.NOTES, ROUTES.SETTINGS];
@@ -67,6 +67,9 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
   };
 
   onMount(() => {
+    // 最初の記録が測位を待たされないよう、許可済みなら今のうちに測り始める
+    warmLocation();
+
     const onKeyDown = (e: KeyboardEvent): void => {
       if (isMetaK(e)) {
         e.preventDefault();

--- a/tauri-app/src/lib/client-context.ts
+++ b/tauri-app/src/lib/client-context.ts
@@ -3,6 +3,7 @@ import {
   requestPermissions,
   getCurrentPosition,
 } from "@tauri-apps/plugin-geolocation";
+import { createLocationTracker } from "./location-tracker";
 
 export type NetworkType = "WiFi" | "Ethernet" | "Mobile" | "Offline";
 
@@ -82,22 +83,33 @@ async function readBattery(): Promise<Pick<ClientContext, "battery" | "isChargin
   }
 }
 
-async function readLocation(): Promise<Pick<ClientContext, "latitude" | "longitude">> {
-  try {
-    let permissions = await checkPermissions();
-    if (permissions.location === "prompt" || permissions.location === "prompt-with-rationale") {
-      permissions = await requestPermissions(["location"]);
-    }
+async function locationPermitted(request: boolean): Promise<boolean> {
+  let permissions = await checkPermissions();
+  if (
+    request &&
+    (permissions.location === "prompt" || permissions.location === "prompt-with-rationale")
+  ) {
+    permissions = await requestPermissions(["location"]);
+  }
+  return permissions.location === "granted";
+}
 
-    if (permissions.location !== "granted") {
-      return { latitude: null, longitude: null };
-    }
-
+/**
+ * Android の GPS はコールドスタートで数秒かかるので、保存のたびに測り直すと
+ * 送信がそのぶん止まる。手元の座標を使い回し、測位は裏で回して次に備える。
+ * macOS がネイティブ側で「起動と同時に受け取り始める」のと同じ理屈。
+ */
+const locationTracker = createLocationTracker({
+  permitted: locationPermitted,
+  position: async () => {
     const pos = await getCurrentPosition();
     return { latitude: pos.coords.latitude, longitude: pos.coords.longitude };
-  } catch {
-    return { latitude: null, longitude: null };
-  }
+  },
+});
+
+/** 許可ダイアログを出さずに測位を始めておく。起動時に呼ぶ。 */
+export function warmLocation(): void {
+  locationTracker.warmUp();
 }
 
 /**
@@ -121,6 +133,6 @@ export async function getDeviceSignals(): Promise<ClientContext> {
 
 /** 端末情報に位置情報を足したもの。ユーザーが明示的に記録した瞬間だけ使う。 */
 export async function getClientContext(): Promise<ClientContext> {
-  const [signals, location] = await Promise.all([getDeviceSignals(), readLocation()]);
+  const [signals, location] = await Promise.all([getDeviceSignals(), locationTracker.read()]);
   return { ...signals, ...location };
 }

--- a/tauri-app/src/lib/items.test.ts
+++ b/tauri-app/src/lib/items.test.ts
@@ -6,6 +6,7 @@ import {
   groupNotes,
   itemMeta,
   itemTitle,
+  replaceDayItems,
 } from "./items";
 import type { Note } from "./commands";
 
@@ -118,5 +119,45 @@ describe("itemTitle", () => {
   it("labels an entry with no text", () => {
     const [item] = toTimelineItems("2026-08-04", ["- [09:00:00] "]);
     expect(itemTitle(item)).toBe("(空のメモ)");
+  });
+});
+
+describe("replaceDayItems", () => {
+  const day = (date: string, texts: string[]) =>
+    toTimelineItems(
+      date,
+      texts.map((t, i) => `- [${String(i + 9).padStart(2, "0")}:00:00] ${t}`),
+    );
+
+  it("swaps in the fresh entries for a day already on screen", () => {
+    const items = [...day("2026-08-04", ["today"]), ...day("2026-08-03", ["yesterday"])];
+
+    const updated = replaceDayItems(items, "2026-08-04", day("2026-08-04", ["today", "more"]));
+
+    expect(updated.map((i) => i.text)).toStrictEqual(["today", "more", "yesterday"]);
+  });
+
+  it("puts the first entry of a new day at the top", () => {
+    const items = day("2026-08-03", ["yesterday"]);
+
+    const updated = replaceDayItems(items, "2026-08-04", day("2026-08-04", ["first"]));
+
+    expect(updated.map((i) => i.date)).toStrictEqual(["2026-08-04", "2026-08-03"]);
+  });
+
+  it("slots an older day between its neighbours", () => {
+    const items = [...day("2026-08-04", ["a"]), ...day("2026-08-01", ["c"])];
+
+    const updated = replaceDayItems(items, "2026-08-02", day("2026-08-02", ["b"]));
+
+    expect(updated.map((i) => i.date)).toStrictEqual(["2026-08-04", "2026-08-02", "2026-08-01"]);
+  });
+
+  it("drops the day entirely when no entries remain", () => {
+    const items = [...day("2026-08-04", ["a"]), ...day("2026-08-03", ["b"])];
+
+    const updated = replaceDayItems(items, "2026-08-04", []);
+
+    expect(updated.map((i) => i.date)).toStrictEqual(["2026-08-03"]);
   });
 });

--- a/tauri-app/src/lib/items.ts
+++ b/tauri-app/src/lib/items.ts
@@ -85,6 +85,22 @@ function groupBy(items: Item[], labelOf: (item: Item) => string): ItemGroup[] {
   return groups;
 }
 
+/**
+ * 新しい順に並んだタイムラインの、1 日ぶんだけを差し替える。
+ * 記録のたびに全日を読み直すと保存 1 回に日数ぶんの IPC がかかるので、
+ * 書いた日だけ読み直してここで継ぎ合わせる。
+ */
+export function replaceDayItems(
+  items: TimelineItem[],
+  date: string,
+  dayItems: TimelineItem[],
+): TimelineItem[] {
+  const kept = items.filter((item) => item.date !== date);
+  const at = kept.findIndex((item) => item.date < date);
+  const insertAt = at === -1 ? kept.length : at;
+  return [...kept.slice(0, insertAt), ...dayItems, ...kept.slice(insertAt)];
+}
+
 export interface TimelineDay {
   /** `YYYY-MM-DD`。見出しの文字は表示側で作る。 */
   date: string;

--- a/tauri-app/src/lib/location-tracker.test.ts
+++ b/tauri-app/src/lib/location-tracker.test.ts
@@ -6,7 +6,11 @@ const SHIBUYA: Coordinates = { latitude: 35.658, longitude: 139.7 };
 const NONE: Coordinates = { latitude: null, longitude: null };
 
 /** 解決タイミングを手で握る測位。GPS のフィックス遅延を再現する。 */
-function manualPosition(): { position: () => Promise<Coordinates>; resolve: (c: Coordinates) => void; calls: () => number } {
+function manualPosition(): {
+  position: () => Promise<Coordinates>;
+  resolve: (c: Coordinates) => void;
+  calls: () => number;
+} {
   let resolvers: ((c: Coordinates) => void)[] = [];
   let calls = 0;
   return {
@@ -39,7 +43,10 @@ afterEach(() => {
 describe("createLocationTracker", () => {
   it("uses the fix when it arrives within the budget", async () => {
     const gps = manualPosition();
-    const tracker = createLocationTracker({ permitted: () => Promise.resolve(true), position: gps.position });
+    const tracker = createLocationTracker({
+      permitted: () => Promise.resolve(true),
+      position: gps.position,
+    });
 
     const reading = tracker.read();
     await vi.advanceTimersByTimeAsync(0);
@@ -51,7 +58,10 @@ describe("createLocationTracker", () => {
   // 保存が測位を待ち続けると「即座に保存される」が壊れる。位置は諦めてよい。
   it("saves without a location once the budget runs out", async () => {
     const gps = manualPosition();
-    const tracker = createLocationTracker({ permitted: () => Promise.resolve(true), position: gps.position });
+    const tracker = createLocationTracker({
+      permitted: () => Promise.resolve(true),
+      position: gps.position,
+    });
 
     const reading = tracker.read();
     await vi.advanceTimersByTimeAsync(LOCATION_BUDGET_MS);
@@ -61,7 +71,10 @@ describe("createLocationTracker", () => {
 
   it("uses a fix that arrived late for the next capture", async () => {
     const gps = manualPosition();
-    const tracker = createLocationTracker({ permitted: () => Promise.resolve(true), position: gps.position });
+    const tracker = createLocationTracker({
+      permitted: () => Promise.resolve(true),
+      position: gps.position,
+    });
 
     const first = tracker.read();
     await vi.advanceTimersByTimeAsync(LOCATION_BUDGET_MS);
@@ -75,7 +88,10 @@ describe("createLocationTracker", () => {
 
   it("never asks the GPS when permission is denied", async () => {
     const gps = manualPosition();
-    const tracker = createLocationTracker({ permitted: () => Promise.resolve(false), position: gps.position });
+    const tracker = createLocationTracker({
+      permitted: () => Promise.resolve(false),
+      position: gps.position,
+    });
 
     await expect(tracker.read()).resolves.toEqual(NONE);
     expect(gps.calls()).toBe(0);
@@ -100,7 +116,10 @@ describe("createLocationTracker", () => {
 
   it("lets the first capture use the coordinates the warm-up fetched", async () => {
     const gps = manualPosition();
-    const tracker = createLocationTracker({ permitted: () => Promise.resolve(true), position: gps.position });
+    const tracker = createLocationTracker({
+      permitted: () => Promise.resolve(true),
+      position: gps.position,
+    });
 
     tracker.warmUp();
     await vi.advanceTimersByTimeAsync(0);
@@ -112,7 +131,10 @@ describe("createLocationTracker", () => {
 
   it("shares one in-flight fix between overlapping reads", async () => {
     const gps = manualPosition();
-    const tracker = createLocationTracker({ permitted: () => Promise.resolve(true), position: gps.position });
+    const tracker = createLocationTracker({
+      permitted: () => Promise.resolve(true),
+      position: gps.position,
+    });
 
     const first = tracker.read();
     const second = tracker.read();

--- a/tauri-app/src/lib/location-tracker.test.ts
+++ b/tauri-app/src/lib/location-tracker.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createLocationTracker, LOCATION_BUDGET_MS } from "./location-tracker";
+import type { Coordinates } from "./location-tracker";
+
+const SHIBUYA: Coordinates = { latitude: 35.658, longitude: 139.7 };
+const NONE: Coordinates = { latitude: null, longitude: null };
+
+/** 解決タイミングを手で握る測位。GPS のフィックス遅延を再現する。 */
+function manualPosition(): { position: () => Promise<Coordinates>; resolve: (c: Coordinates) => void; calls: () => number } {
+  let resolvers: ((c: Coordinates) => void)[] = [];
+  let calls = 0;
+  return {
+    position: () => {
+      calls += 1;
+      // 解決を外から握るには executor を書くしかない
+      // oxlint-disable-next-line promise/avoid-new
+      return new Promise((resolve) => {
+        resolvers.push(resolve);
+      });
+    },
+    resolve: (c: Coordinates) => {
+      for (const res of resolvers) {
+        res(c);
+      }
+      resolvers = [];
+    },
+    calls: () => calls,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createLocationTracker", () => {
+  it("uses the fix when it arrives within the budget", async () => {
+    const gps = manualPosition();
+    const tracker = createLocationTracker({ permitted: () => Promise.resolve(true), position: gps.position });
+
+    const reading = tracker.read();
+    await vi.advanceTimersByTimeAsync(0);
+    gps.resolve(SHIBUYA);
+
+    await expect(reading).resolves.toEqual(SHIBUYA);
+  });
+
+  // 保存が測位を待ち続けると「即座に保存される」が壊れる。位置は諦めてよい。
+  it("saves without a location once the budget runs out", async () => {
+    const gps = manualPosition();
+    const tracker = createLocationTracker({ permitted: () => Promise.resolve(true), position: gps.position });
+
+    const reading = tracker.read();
+    await vi.advanceTimersByTimeAsync(LOCATION_BUDGET_MS);
+
+    await expect(reading).resolves.toEqual(NONE);
+  });
+
+  it("uses a fix that arrived late for the next capture", async () => {
+    const gps = manualPosition();
+    const tracker = createLocationTracker({ permitted: () => Promise.resolve(true), position: gps.position });
+
+    const first = tracker.read();
+    await vi.advanceTimersByTimeAsync(LOCATION_BUDGET_MS);
+    await first;
+    gps.resolve(SHIBUYA);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // 2 回目は新しいフィックスを待たされず、手元にある前回の座標で即返る
+    await expect(tracker.read()).resolves.toEqual(SHIBUYA);
+  });
+
+  it("never asks the GPS when permission is denied", async () => {
+    const gps = manualPosition();
+    const tracker = createLocationTracker({ permitted: () => Promise.resolve(false), position: gps.position });
+
+    await expect(tracker.read()).resolves.toEqual(NONE);
+    expect(gps.calls()).toBe(0);
+  });
+
+  it("warms up without showing a permission dialog", async () => {
+    const gps = manualPosition();
+    const requests: boolean[] = [];
+    const tracker = createLocationTracker({
+      permitted: (request) => {
+        requests.push(request);
+        return Promise.resolve(true);
+      },
+      position: gps.position,
+    });
+
+    tracker.warmUp();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(requests).toEqual([false]);
+  });
+
+  it("lets the first capture use the coordinates the warm-up fetched", async () => {
+    const gps = manualPosition();
+    const tracker = createLocationTracker({ permitted: () => Promise.resolve(true), position: gps.position });
+
+    tracker.warmUp();
+    await vi.advanceTimersByTimeAsync(0);
+    gps.resolve(SHIBUYA);
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(tracker.read()).resolves.toEqual(SHIBUYA);
+  });
+
+  it("shares one in-flight fix between overlapping reads", async () => {
+    const gps = manualPosition();
+    const tracker = createLocationTracker({ permitted: () => Promise.resolve(true), position: gps.position });
+
+    const first = tracker.read();
+    const second = tracker.read();
+    await vi.advanceTimersByTimeAsync(0);
+    gps.resolve(SHIBUYA);
+
+    await expect(first).resolves.toEqual(SHIBUYA);
+    await expect(second).resolves.toEqual(SHIBUYA);
+    expect(gps.calls()).toBe(1);
+  });
+
+  it("falls back to no location when the permission check itself blows up", async () => {
+    const gps = manualPosition();
+    const tracker = createLocationTracker({
+      permitted: () => Promise.reject(new Error("plugin missing on this platform")),
+      position: gps.position,
+    });
+
+    await expect(tracker.read()).resolves.toEqual(NONE);
+  });
+});

--- a/tauri-app/src/lib/location-tracker.ts
+++ b/tauri-app/src/lib/location-tracker.ts
@@ -1,0 +1,90 @@
+export interface Coordinates {
+  latitude: number | null;
+  longitude: number | null;
+}
+
+const NO_LOCATION: Coordinates = { latitude: null, longitude: null };
+
+/**
+ * 保存が測位を待つ時間の上限。Android の GPS はコールドスタートで数秒かかる
+ * ことがあり、そのあいだ送信を止めると「即座に保存される」が壊れる。
+ * ここを過ぎたら位置なしで保存を進め、遅れて届いたフィックスは次の保存が使う。
+ */
+export const LOCATION_BUDGET_MS = 1500;
+
+interface TrackerDeps {
+  /** 位置情報の許可を確かめる。request が true のときだけダイアログを出してよい。 */
+  permitted: (request: boolean) => Promise<boolean>;
+  position: () => Promise<Coordinates>;
+  budgetMs?: number;
+}
+
+export interface LocationTracker {
+  /** ダイアログを出さずにキャッシュを温める。起動時に呼ぶ。 */
+  warmUp: () => void;
+  read: () => Promise<Coordinates>;
+}
+
+interface Flight {
+  id: number;
+  request: boolean;
+  promise: Promise<Coordinates>;
+}
+
+export function createLocationTracker(deps: TrackerDeps): LocationTracker {
+  const budget = deps.budgetMs ?? LOCATION_BUDGET_MS;
+  let lastKnown: Coordinates | null = null;
+  let inflight: Flight | null = null;
+  let flightCount = 0;
+
+  const locate = async (request: boolean): Promise<Coordinates> => {
+    try {
+      if (!(await deps.permitted(request))) {
+        return lastKnown ?? NO_LOCATION;
+      }
+      lastKnown = await deps.position();
+      return lastKnown;
+    } catch {
+      return lastKnown ?? NO_LOCATION;
+    }
+  };
+
+  const launch = async (id: number, request: boolean): Promise<Coordinates> => {
+    const result = await locate(request);
+    // 追い越されていたら後発の飛行が inflight を持っている。触らない。
+    if (inflight?.id === id) {
+      inflight = null;
+    }
+    return result;
+  };
+
+  const refresh = (request: boolean): Promise<Coordinates> => {
+    // 進行中の測位に相乗りする。ただし許可を求めない飛行中に「求めてよい」
+    // 呼び出しが来たら、乗らずに新しく飛ばす。乗ると初回の許可ダイアログが
+    // いつまでも出ない。
+    if (inflight && (inflight.request || !request)) {
+      return inflight.promise;
+    }
+    flightCount += 1;
+    const id = flightCount;
+    inflight = { id, request, promise: launch(id, request) };
+    return inflight.promise;
+  };
+
+  const read = (): Promise<Coordinates> => {
+    const fix = refresh(true);
+    // 手元に座標があるなら待たずに使う。記録したいのは「どのあたりで書いたか」
+    // であって、いま始めた測位の結果は次の保存に間に合えばよい。
+    if (lastKnown) {
+      return Promise.resolve(lastKnown);
+    }
+    // タイムアウトを Promise にする手段は executor を書く以外に無い
+    // oxlint-disable-next-line promise/avoid-new
+    const giveUp = new Promise<Coordinates>((resolve) => {
+      setTimeout(() => resolve(lastKnown ?? NO_LOCATION), budget);
+    });
+    return Promise.race([fix, giveUp]);
+  };
+
+  return { warmUp: () => void refresh(false), read };
+}

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -3,6 +3,7 @@ import {
   createResource,
   createMemo,
   createEffect,
+  on,
   For,
   Show,
   onCleanup,
@@ -167,10 +168,9 @@ export default function Timeline(): JSX.Element {
 
   const [timeline, { refetch }] = createResource(extraDates, loadTimeline);
 
-  createEffect(() => {
-    shell.dataVersion();
-    void refetch();
-  });
+  // 初回は createResource が読む。defer しないとマウント直後に同じ全読みを
+  // もう一度走らせ、起動時の IPC がまるごと倍になる
+  createEffect(on(shell.dataVersion, () => void refetch(), { defer: true }));
 
   const entries = createMemo(() => timeline() ?? []);
   const knownTags = createMemo(() => countTags(entries().map((item) => item.text)));

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -17,8 +17,8 @@ import TagText from "../components/TagText";
 import { typedInvoke } from "../lib/commands";
 import { getClientContext } from "../lib/client-context";
 import { useShell } from "../lib/shell";
-import { formatDayHeading } from "../lib/day-labels";
-import { groupTimelineByDay, toTimelineItems } from "../lib/items";
+import { formatDayHeading, toIsoDate } from "../lib/day-labels";
+import { groupTimelineByDay, replaceDayItems, toTimelineItems } from "../lib/items";
 import type { TimelineItem } from "../lib/items";
 import { entryMeta } from "../lib/timeline-meta";
 import { countTags, parseTags } from "../lib/tags";
@@ -166,7 +166,7 @@ export default function Timeline(): JSX.Element {
   /** 削除の取り消し待ち。5 秒経つまで本削除しないので、消えた跡だけ残す。 */
   const [pendingDelete, setPendingDelete] = createSignal<string[]>([]);
 
-  const [timeline, { refetch }] = createResource(extraDates, loadTimeline);
+  const [timeline, { refetch, mutate }] = createResource(extraDates, loadTimeline);
 
   // 初回は createResource が読む。defer しないとマウント直後に同じ全読みを
   // もう一度走らせ、起動時の IPC がまるごと倍になる
@@ -204,9 +204,15 @@ export default function Timeline(): JSX.Element {
 
   const isDeleting = (id: string): boolean => pendingDelete().includes(id);
 
+  /** 書いた日だけ読み直す。全日の読み直しは保存 1 回に日数ぶんの IPC を払う。 */
+  const reloadDay = async (date: string): Promise<void> => {
+    const items = toTimelineItems(date, await typedInvoke("read_timeline_by_date", { date }));
+    mutate((prev) => replaceDayItems(prev ?? [], date, items));
+  };
+
   const capture = async (text: string): Promise<void> => {
     await typedInvoke("save_quick_capture", { text, client: await getClientContext() });
-    await refetch();
+    await reloadDay(toIsoDate(new Date()));
   };
 
   // ---- その場編集（Esc / フォーカスを外すと確定）----
@@ -228,7 +234,7 @@ export default function Timeline(): JSX.Element {
     }
     await typedInvoke("update_timeline_entry", { date: item.date, index: item.index, text });
     setSaved(true);
-    await refetch();
+    await reloadDay(item.date);
   };
 
   // タブを切り替えても書きかけを捨てない。blur はアンマウントでは飛ばない。
@@ -241,7 +247,7 @@ export default function Timeline(): JSX.Element {
     const commit = setTimeout(() => {
       void (async () => {
         await typedInvoke("delete_timeline_entry", { date: item.date, index: item.index });
-        await refetch();
+        await reloadDay(item.date);
         setPendingDelete((ids) => ids.filter((id) => id !== item.id));
       })();
     }, UNDO_MS);

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -13,16 +13,16 @@ import type { JSX } from "solid-js";
 import type { Editor } from "@milkdown/kit/core";
 import Icon from "../components/Icon";
 import MarkdownPreview from "../components/MarkdownPreview";
-
-// Milkdown + ProseMirror は編集を始めるまで要らない。一覧とプレビューだけの
-// 表示をこの重さから切り離す
-const MilkdownEditor = lazy(() => import("../components/MilkdownEditor"));
-const MarkdownToolbar = lazy(() => import("../components/MarkdownToolbar"));
 import { typedInvoke } from "../lib/commands";
 import { getDeviceSignals } from "../lib/client-context";
 import { useShell } from "../lib/shell";
 import { groupNotes, itemTitle, toNoteItems } from "../lib/items";
 import type { ItemGroup, NoteItem } from "../lib/items";
+
+// Milkdown + ProseMirror は編集を始めるまで要らない。一覧とプレビューだけの
+// 表示をこの重さから切り離す
+const MilkdownEditor = lazy(() => import("../components/MilkdownEditor"));
+const MarkdownToolbar = lazy(() => import("../components/MarkdownToolbar"));
 
 const UNDO_MS = 5000;
 const SAVE_DEBOUNCE_MS = 1000;

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -5,14 +5,18 @@ import {
   createEffect,
   For,
   Show,
+  lazy,
   onCleanup,
 } from "solid-js";
 import type { JSX } from "solid-js";
 import type { Editor } from "@milkdown/kit/core";
 import Icon from "../components/Icon";
 import MarkdownPreview from "../components/MarkdownPreview";
-import MilkdownEditor from "../components/MilkdownEditor";
-import MarkdownToolbar from "../components/MarkdownToolbar";
+
+// Milkdown + ProseMirror は編集を始めるまで要らない。一覧とプレビューだけの
+// 表示をこの重さから切り離す
+const MilkdownEditor = lazy(() => import("../components/MilkdownEditor"));
+const MarkdownToolbar = lazy(() => import("../components/MarkdownToolbar"));
 import { typedInvoke } from "../lib/commands";
 import { getDeviceSignals } from "../lib/client-context";
 import { useShell } from "../lib/shell";
@@ -305,8 +309,10 @@ export default function Workspace(): JSX.Element {
         </Show>
       </div>
 
-      {/* キーボードでは打ちにくい記法のための入り口。タッチ端末にだけ出る */}
-      <MarkdownToolbar editor={markdownEditor()} />
+      {/* キーボードでは打ちにくい記法のための入り口。タッチ端末にだけ出る。
+          lazy なので、無条件に描くと一覧を見ただけでエディタ一式を読み込んで
+          しまう。エディタが立ち上がってから初めて描く */}
+      <Show when={markdownEditor()}>{(editor) => <MarkdownToolbar editor={editor()} />}</Show>
     </div>
   );
 }

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -3,6 +3,7 @@ import {
   createResource,
   createMemo,
   createEffect,
+  on,
   For,
   Show,
   lazy,
@@ -61,11 +62,9 @@ export default function Workspace(): JSX.Element {
 
   const [notes, { refetch: refetchNotes }] = createResource(loadNotes);
 
-  // 同期やパレット操作の後にデータを取り直す
-  createEffect(() => {
-    shell.dataVersion();
-    void refetchNotes();
-  });
+  // 同期やパレット操作の後にデータを取り直す。初回は createResource が読むので
+  // defer しないと全ノートの読み直しがマウント直後に二重で走る
+  createEffect(on(shell.dataVersion, () => void refetchNotes(), { defer: true }));
 
   const visibleItems = createMemo<NoteItem[]>(() => {
     const dropped = new Set(hidden());

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -117,7 +117,9 @@ export default function Workspace(): JSX.Element {
           body,
           client: await getDeviceSignals(),
         });
-        await refetchNotes();
+        // 一覧はここでは読み直さない。1 秒おきの保存のたびに全ノートを
+        // 読み直すのは低スペック端末に重く、編集中は一覧が見えてもいない。
+        // 編集を終えるときに 1 回だけ読み直す。
         setSaveStatus("saved");
       } catch {
         setSaveStatus("idle");
@@ -155,7 +157,11 @@ export default function Workspace(): JSX.Element {
       saveTimer = undefined;
     }
     await flushSave();
+    // 書き終えた本文が真実。読み直しを待ってからプレビューを出すと
+    // 一瞬だけ編集前の本文が見える
+    setNoteBody(draft());
     setEditing(false);
+    await refetchNotes();
   };
 
   const createNote = async (): Promise<void> => {


### PR DESCRIPTION
## Summary

スマホ（低スペック端末）を主眼にしたパフォーマンスチューニング。調査 → Criterion ベンチ / バンドル実測で定量化 → 改善 → moto g52j 5G 実機検証まで実施した。

前提の確認として、タイムラインの保存フォーマット（1日1mdファイル）はボトルネックではない。コア側は起動時14日分の読込が 0.32ms（1年分・365日×20件+500ノートのベンチ fixture）。遅延の原因は IPC の回数とフロントエンドの構造だった。

## Changes

| Commit | 内容 | 効果 |
|---|---|---|
| `perf(app)` | エディタ一式（Milkdown+ProseMirror+Shiki）を起動バンドルから分離、アイドル時プリフェッチ | 起動時 JS **777KB → 77KB**（gzip 262KB → 28KB） |
| `perf(views)` | マウント直後の dataVersion エフェクトを defer | 起動時の全データ二重フェッチを解消 |
| `perf(capture)` | `location-tracker.ts` 新設: 前回座標の即時利用+裏で更新、コールド時 1.5s バジェット、起動時ウォームアップ | **保存が GPS フィックス（Android コールドで数秒）をブロックしなくなった** |
| `perf(timeline)` | `replaceDayItems` で変異のあった日だけ再読込 | 記録/編集/削除ごとの 15 IPC → 1 IPC |
| `perf(notes)` | 自動保存ごとの全ノート一覧再読込を廃止、編集終了時に1回 | 1秒ごとの全 md ファイル読込（500件で 9ms/Mac、スマホは数倍）を解消 |

## Test plan

- [x] 新規テスト: `location-tracker.test.ts`（8件、fake timers で GPS 遅延を再現）、`replaceDayItems`（4件）
- [x] 既存テスト含め 181件 green、oxlint / tsgo / knip clean
- [x] moto g52j 5G（release APK）で実機検証: キャプチャ保存が send タップから 400ms 以内に表示、Notes 一覧 / エディタ / ツールバー / 自動保存 / 削除の全フロー正常

## Future work

同期の `scan_local_files` は毎回全ファイルを SHA-256 する（14ms/Mac、実機では同期のたび ~100ms+全ファイル読込）。mtime+size キャッシュで削れるが racily-clean 問題（git index と同種）の処理が必要なため本PRでは見送り。