### PR TITLE
perf(search): debounce the palette's full-text search

### DIFF
--- a/tauri-app/src/components/CommandPalette.tsx
+++ b/tauri-app/src/components/CommandPalette.tsx
@@ -4,6 +4,7 @@ import Icon from "./Icon";
 import type { IconName } from "./Icon";
 import { typedInvoke } from "../lib/commands";
 import type { SearchHit } from "../lib/commands";
+import { createDebouncedAccessor } from "../lib/debounce";
 
 interface PaletteCommand {
   id: string;
@@ -31,10 +32,17 @@ function searchHits(query: string): Promise<SearchHit[]> {
   return typedInvoke("search_all", { query });
 }
 
+/**
+ * search_all は全タイムライン + 全ノートのファイル走査で、実機では 1 回
+ * 100ms を超えうる。打鍵ごとに発行せず、指が止まってからまとめて聞く。
+ * コマンドの絞り込みはメモリ内なので query を直に見て即時に効かせる。
+ */
+const SEARCH_DEBOUNCE_MS = 200;
+
 export default function CommandPalette(props: CommandPaletteProps): JSX.Element {
   const [query, setQuery] = createSignal("");
   const [cursor, setCursor] = createSignal(0);
-  const [hits] = createResource(query, searchHits);
+  const [hits] = createResource(createDebouncedAccessor(query, SEARCH_DEBOUNCE_MS), searchHits);
 
   let inputRef: HTMLInputElement | undefined;
   onMount(() => inputRef?.focus());

--- a/tauri-app/src/lib/debounce.test.ts
+++ b/tauri-app/src/lib/debounce.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createRoot, createSignal } from "solid-js";
+import type { Accessor } from "solid-js";
+import { createDebouncedAccessor } from "./debounce";
+
+const DELAY = 200;
+
+/**
+ * effect は createRoot のコールバックが返るまで走らない。値の更新は
+ * root の外から行わないと、購読前の変更として黙って落ちる。
+ */
+function setup(): {
+  setSource: (value: string) => void;
+  debounced: Accessor<string>;
+  dispose: () => void;
+} {
+  const [source, setSource] = createSignal("a");
+  let debounced!: Accessor<string>;
+  const dispose = createRoot((d) => {
+    debounced = createDebouncedAccessor(source, DELAY);
+    return d;
+  });
+  return { setSource, debounced, dispose };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createDebouncedAccessor", () => {
+  it("starts with the source's current value", () => {
+    const { debounced, dispose } = setup();
+
+    expect(debounced()).toBe("a");
+    dispose();
+  });
+
+  it("holds the old value until the delay passes", () => {
+    const { setSource, debounced, dispose } = setup();
+
+    setSource("ab");
+    vi.advanceTimersByTime(DELAY - 1);
+
+    expect(debounced()).toBe("a");
+    dispose();
+  });
+
+  it("applies the newest value once typing pauses", () => {
+    const { setSource, debounced, dispose } = setup();
+
+    setSource("ab");
+    vi.advanceTimersByTime(DELAY);
+
+    expect(debounced()).toBe("ab");
+    dispose();
+  });
+
+  // 1 打鍵ごとに発火しては debounce の意味がない。タイマーは打鍵で巻き戻る。
+  it("collapses a burst of changes into one update", () => {
+    const { setSource, debounced, dispose } = setup();
+
+    setSource("ab");
+    vi.advanceTimersByTime(DELAY - 50);
+    setSource("abc");
+    vi.advanceTimersByTime(DELAY - 50);
+    setSource("abcd");
+
+    expect(debounced()).toBe("a");
+    vi.advanceTimersByTime(DELAY);
+    expect(debounced()).toBe("abcd");
+    dispose();
+  });
+
+  it("stops pending updates when the owner is disposed", () => {
+    const { setSource, debounced, dispose } = setup();
+
+    setSource("ab");
+    dispose();
+    vi.advanceTimersByTime(DELAY);
+
+    expect(debounced()).toBe("a");
+  });
+});

--- a/tauri-app/src/lib/debounce.ts
+++ b/tauri-app/src/lib/debounce.ts
@@ -1,0 +1,28 @@
+import { createSignal, createEffect, onCleanup } from "solid-js";
+import type { Accessor } from "solid-js";
+
+/**
+ * source の変化が止まってから delayMs 後に追いつく Accessor を返す。
+ * 検索のように「1 打鍵ごとに発行してはコストが払えない」読み取りを、
+ * これを createResource の source にすることでまとめる。
+ */
+export function createDebouncedAccessor<T>(source: Accessor<T>, delayMs: number): Accessor<T> {
+  const [value, setValue] = createSignal(source());
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  createEffect(() => {
+    const next = source();
+    if (timer) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => setValue(() => next), delayMs);
+  });
+
+  onCleanup(() => {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  });
+
+  return value;
+}


### PR DESCRIPTION
## Summary

検索パレットは打鍵1回ごとに `search_all`（全タイムライン+全ノートのファイル走査）を発行していた。ベンチ実測で 17〜24ms/Mac（1年分データ）、実機では 100-200ms/打鍵と推定され、日本語 IME の変換中も走る。

打鍵が 200ms 止まってから発行するよう `createDebouncedAccessor` を新設して `createResource` の source に挟んだ。メモリ内で完結するコマンド絞り込みは生の query を見続けるので即時のまま。

#40 の第1段階。インデックス（SQLite FTS5 等）はデータが増えてフルスキャンが許容できなくなったら着手する。

## Test plan

- [x] `debounce.test.ts` 新規5件（fake timers。初期値 / 遅延中の保持 / 連打の集約 / dispose）
- [x] 全186件 green、oxlint / tsgo / knip clean

## 変更点の図解

### 変更前 — 打鍵ごとにフルスキャン

```mermaid
sequenceDiagram
    actor User
    participant P as CommandPalette
    participant S as search_all (全ファイル走査)

    User->>P: "め"
    P->>S: scan (~100ms on device)
    User->>P: "めも"
    P->>S: scan (~100ms on device)
    User->>P: "めもり"
    P->>S: scan (~100ms on device)
```

### 変更後 — 指が止まってから 1 回

```mermaid
sequenceDiagram
    actor User
    participant P as CommandPalette
    participant D as createDebouncedAccessor
    participant S as search_all (全ファイル走査)

    User->>P: "め"
    P->>D: query 更新 (タイマー再セット)
    User->>P: "めも"
    P->>D: query 更新 (タイマー再セット)
    User->>P: "めもり"
    P->>D: query 更新 (タイマー再セット)
    Note over D: 200ms 打鍵なし
    D->>S: scan 1 回だけ
    S-->>P: 結果表示
```

コマンドの絞り込み（メモリ内）は生の query を見続けるので即時のまま。
