### PR TITLE
fix(core): replace files atomically instead of overwriting in place

### DIFF
--- a/core/src/note/repository.rs
+++ b/core/src/note/repository.rs
@@ -6,7 +6,7 @@ use chrono::Local;
 use crate::error::CoreError;
 use crate::utils::device::Context;
 use crate::utils::frontmatter::{self, NoteFrontmatter};
-use crate::utils::fs::{ensure_dir, list_md_files};
+use crate::utils::fs::{ensure_dir, list_md_files, write_atomic};
 use crate::utils::markdown::format_note_markdown;
 use crate::utils::paths::{note_file_path, notes_dir};
 use crate::utils::validated::NoteFilename;
@@ -37,7 +37,7 @@ impl Notes {
         ensure_dir(&file_path)?;
 
         let markdown = format_note_markdown(body, tags, now, context)?;
-        fs::write(&file_path, markdown)?;
+        write_atomic(&file_path, markdown)?;
         Ok(file_path)
     }
 
@@ -90,7 +90,7 @@ impl Notes {
 
         let now = Local::now();
         let markdown = format_note_markdown(body, &tags, now, context)?;
-        fs::write(path, markdown)?;
+        write_atomic(path, markdown)?;
         Ok(())
     }
 

--- a/core/src/sync/state.rs
+++ b/core/src/sync/state.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::CoreError;
+use crate::utils::fs::write_atomic;
 
 const STATE_FILENAME: &str = ".sync-state.json";
 
@@ -35,7 +36,7 @@ impl SyncState {
         let path = base_dir.join(STATE_FILENAME);
         let content =
             serde_json::to_string_pretty(self).map_err(|e| CoreError::Sync(e.to_string()))?;
-        fs::write(&path, content)?;
+        write_atomic(&path, content)?;
         Ok(())
     }
 }

--- a/core/src/timeline/repository.rs
+++ b/core/src/timeline/repository.rs
@@ -7,7 +7,7 @@ use chrono::{Local, NaiveDate};
 use crate::error::CoreError;
 use crate::timeline::day::DayLog;
 use crate::utils::device::Context;
-use crate::utils::fs::ensure_dir;
+use crate::utils::fs::{ensure_dir, write_atomic};
 use crate::utils::markdown::{split_context_json, split_time_prefix};
 use crate::utils::paths::{self, timeline_file_path};
 
@@ -28,7 +28,7 @@ impl Timeline {
         let mut day = DayLog::parse(&self.read_raw(now.date_naive())?.unwrap_or_default());
         day.push(text, now, context);
 
-        fs::write(&file_path, day.render()?)?;
+        write_atomic(&file_path, day.render()?)?;
         Ok(())
     }
 
@@ -111,7 +111,7 @@ impl Timeline {
             return Ok(());
         }
 
-        fs::write(&file_path, day.render()?)?;
+        write_atomic(&file_path, day.render()?)?;
         Ok(())
     }
 }

--- a/core/src/utils/fs.rs
+++ b/core/src/utils/fs.rs
@@ -1,5 +1,6 @@
 use std::fs::{self, DirEntry};
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::error::CoreError;
 
@@ -7,6 +8,37 @@ pub fn ensure_dir(path: &Path) -> Result<(), CoreError> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
+    Ok(())
+}
+
+/// 同一プロセス内の一時ファイル名の衝突を避ける通し番号。
+static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// 同じディレクトリに一時ファイルを書いてから rename で置き換える。
+/// `fs::write` の直接上書きは、書いている途中でプロセスが落ちると
+/// 半分だけ書けたファイルを残す。タイムラインは追記のたびに 1 日ぶんを
+/// 丸ごと書き直すので、それはその日の記録全体の破損を意味する。
+/// rename は同一ファイルシステム内なら原子的で、読者は旧内容か新内容の
+/// どちらかしか見ない。
+///
+/// 名前が `.sync-tmp-` なのは、クラッシュで残っても同期スキャンの既存の
+/// 除外に一致し、`.md` を持たないのでノート一覧にも現れないため。
+/// 電源断への fsync までは踏み込まない: 保存のたびの fsync は
+/// モバイルの電池と引き換えになる。ここで防ぐのはプロセス死での破損。
+pub fn write_atomic<C: AsRef<[u8]>>(path: &Path, contents: C) -> Result<(), CoreError> {
+    let dir = match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent,
+        _ => Path::new("."),
+    };
+    let seq = TMP_SEQ.fetch_add(1, Ordering::Relaxed);
+    let tmp = dir.join(format!(".sync-tmp-{}-{seq}", std::process::id()));
+
+    fs::write(&tmp, contents)?;
+    fs::rename(&tmp, path).inspect_err(|_| {
+        // rename に失敗した一時ファイルを残すと次の書き込みの邪魔はしないが
+        // ゴミが積もる。消せなかったところで元のエラーのほうが重要。
+        let _ = fs::remove_file(&tmp);
+    })?;
     Ok(())
 }
 
@@ -74,5 +106,57 @@ mod tests {
         let missing = tmp.path().join("nope");
 
         assert!(list_md_files(&missing).unwrap().is_empty());
+    }
+
+    #[test]
+    fn write_atomic_writes_the_contents() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("note.md");
+
+        write_atomic(&path, "hello").unwrap();
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), "hello");
+    }
+
+    #[test]
+    fn write_atomic_replaces_what_was_there() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("note.md");
+        fs::write(&path, "old").unwrap();
+
+        write_atomic(&path, "new").unwrap();
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), "new");
+    }
+
+    /// 一時ファイルが残ると、名前次第でノート一覧や同期対象に化ける。
+    #[test]
+    fn write_atomic_leaves_no_temp_file_behind() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("note.md");
+
+        write_atomic(&path, "hello").unwrap();
+
+        let names: Vec<_> = fs::read_dir(tmp.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(names, vec!["note.md"]);
+    }
+
+    /// クラッシュで万一残っても、`.md` でないのでノート一覧には現れず、
+    /// `.sync-tmp-` なので同期スキャンの既存の除外にも一致する。
+    #[test]
+    fn write_atomic_temp_names_are_invisible_to_md_listing() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join(".sync-tmp-999-0"), "orphan").unwrap();
+        fs::write(tmp.path().join("real.md"), "x").unwrap();
+
+        let names: Vec<_> = list_md_files(tmp.path())
+            .unwrap()
+            .iter()
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(names, vec!["real.md"]);
     }
 }

--- a/tauri-app/src-tauri/src/auth.rs
+++ b/tauri-app/src-tauri/src/auth.rs
@@ -35,7 +35,8 @@ impl SyncConfig {
         fs::create_dir_all(base_dir).map_err(|e| e.to_string())?;
         let path = base_dir.join(SYNC_CONFIG_FILENAME);
         let content = serde_json::to_string_pretty(self).map_err(|e| e.to_string())?;
-        fs::write(&path, content).map_err(|e| e.to_string())?;
+        magical_merchant_core::utils::fs::write_atomic(&path, content)
+            .map_err(|e| e.to_string())?;
         Ok(())
     }
 
@@ -89,7 +90,7 @@ mod token_store {
     pub(super) fn store(base_dir: &Path, token: &str) -> Result<(), String> {
         fs::create_dir_all(base_dir).map_err(|e| e.to_string())?;
         let path = path(base_dir);
-        fs::write(&path, token).map_err(|e| e.to_string())?;
+        magical_merchant_core::utils::fs::write_atomic(&path, token).map_err(|e| e.to_string())?;
         fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).map_err(|e| e.to_string())
     }
 

--- a/tauri-app/src-tauri/src/sync.rs
+++ b/tauri-app/src-tauri/src/sync.rs
@@ -500,7 +500,10 @@ fn write_under(data_dir: &Path, key: &str, content: &[u8]) -> Result<(), String>
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| format!("mkdir {key}: {e}"))?;
     }
-    fs::write(&path, content).map_err(|e| format!("write {key}: {e}"))
+    // 直接上書きだと、ダウンロード書き込み中のクラッシュで手元のメモが
+    // 半分だけ書けたファイルに置き換わる
+    magical_merchant_core::utils::fs::write_atomic(&path, content)
+        .map_err(|e| format!("write {key}: {e}"))
 }
 
 fn decode(file: &DownloadedFile) -> Result<Vec<u8>, String> {


### PR DESCRIPTION
## Summary

`fs::write` は truncate してから書くため、書き込み中にプロセスが落ちると半分だけ書けたファイルが残る。タイムラインは追記のたびに1日ぶんを丸ごと書き直すので、この窓はその日の記録全体の破損を意味する。

同じディレクトリに一時ファイルを書いて `rename` で置き換える `write_atomic` を `utils/fs` に追加し、全書き込み経路（タイムライン・ノート・同期状態・同期ダウンロード・sync-config・認証トークン）を置き換えた。

- 一時ファイル名は `.sync-tmp-{pid}-{seq}`: 同期スキャンの既存除外パターンに一致し、`.md` 拡張子を持たないためクラッシュ残骸がノート一覧にも同期対象にも現れない
- fsync は意図的にスコープ外（保存ごとの fsync はモバイルの電池と引き換え。本修正の対象はプロセス死であって電源断ではない）

Closes #86

## Test plan

- [x] `write_atomic` の新規4テスト（内容・置換・一時ファイル残骸なし・残骸の不可視性）
- [x] Rust 全169テスト green、clippy clean

## 変更点の図解

### 変更前 — truncate してから書く

```mermaid
flowchart LR
    W["fs::write(note.md)"] --> T["note.md を truncate"]
    T --> B["バイト列を書く"]
    T -. "ここでクラッシュ" .-> X["空 / 半分だけのファイル<br/>タイムラインならその日全体が破損"]
    B --> OK["完全なファイル"]
```

### 変更後 — 一時ファイルに書いて rename で置換

```mermaid
flowchart LR
    W["write_atomic(note.md)"] --> T["同じディレクトリに<br/>.sync-tmp-pid-seq を書く"]
    T --> R["rename で note.md に置換<br/>(同一 FS 内なら原子的)"]
    T -. "ここでクラッシュ" .-> S["note.md は旧内容のまま無傷<br/>残骸は一覧にも同期にも現れない"]
    R --> OK["旧内容か新内容のどちらかしか観測されない"]
```

一時ファイル名 `.sync-tmp-*` は同期スキャンの既存除外パターンに一致し、`.md` 拡張子を持たないためノート一覧にも出ない。
