### PR TITLE
docs: add architecture overview with Mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ magical-merchant/
 └── plans/          # Implementation plans
 ```
 
+## Documentation
+
+- [Architecture](docs/introduction.md) — system overview, design decisions, and data flow (Mermaid diagrams)
+
 ## Getting Started
 
 ### Prerequisites

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,146 @@
+# Architecture
+
+Magical Merchant is a local-first note-taking app. Every save is a plain
+Markdown file written to the device; the network is only involved when the
+optional background sync runs. This page maps the moving parts and the
+decisions behind them.
+
+## System overview
+
+```mermaid
+flowchart LR
+    subgraph Device["Device (macOS / Android)"]
+        UI["SolidJS WebView<br/>tauri-app/src"]
+        Shell["Tauri shell (Rust)<br/>tauri-app/src-tauri"]
+        Core["magical-merchant-core<br/>core/"]
+        Files[("Markdown files<br/>app data dir")]
+        UI <-- "IPC (typedInvoke)" --> Shell
+        Shell --> Core
+        Core --> Files
+    end
+
+    MCP["mcp-cli<br/>MCP server for AI assistants"] --> Core
+
+    subgraph Cloud["Cloudflare (optional sync)"]
+        Worker["Worker<br/>workers/"]
+        R2[("R2 bucket")]
+        Worker --> R2
+    end
+
+    Shell -- "HTTPS: /sync-state, /sync/bulk" --> Worker
+    Browser["System browser"] -- "Google OAuth" --> Worker
+    Worker -- "JWT via deep link<br/>magical-merchant://auth" --> Shell
+```
+
+Three consumers share the same core crate: the desktop/mobile app, the MCP
+server (`mcp-cli`, read-only tools such as `search` and `read_timeline`),
+and the benchmarks. The core knows nothing about Tauri, HTTP, or the UI —
+it takes a base directory and works on files.
+
+## Key design decisions
+
+- **Local-first saves.** A capture or an edit never waits on the network.
+  Sync is a separate, debounced background step; if it never runs, the app
+  is still fully functional.
+- **Plain Markdown on disk.** The store is human-readable files, one per
+  note and one per timeline day. There is no database to migrate or corrupt;
+  sync and search operate on the same files the user could read themselves.
+- **Framework-independent core.** All business logic (timeline, notes,
+  search, sync diffing) lives in `core/` so the Tauri shell stays a thin
+  command layer and the same logic serves the MCP server.
+- **Server-authoritative sync state.** The client never constructs the sync
+  state it sends back; it stores what the server confirmed. Conflicts are
+  resolved local-wins, with the losing side kept as a `.sync-conflict-*`
+  copy so no edit is ever silently dropped.
+
+## On-disk layout
+
+```
+<app data dir>/
+├── data/                      # everything under here syncs
+│   ├── timeline/
+│   │   └── 2026-08-09.md      # one file per day, entries appended
+│   └── notes/
+│       └── 20260809_143000.md # one file per note, frontmatter + body
+├── .sync-state.json           # what the server last confirmed
+└── sync-config.json           # Workers URL, auto-sync flag
+```
+
+A timeline day file lists the devices used that day once in its
+frontmatter; each entry line carries a time prefix and a trailing JSON
+context (battery, network, location) that references the device list by
+index. Reading expands entries back to self-contained lines, so callers
+never see the on-disk compression.
+
+## Frontend structure
+
+```mermaid
+flowchart TD
+    App["App.tsx (Router)"]
+    Layout["AppLayout<br/>header, tabs, palette, sync state"]
+    Timeline["Timeline (eager — launch view)"]
+    Workspace["Workspace (lazy)"]
+    Settings["Settings (lazy)"]
+    Editor["MilkdownEditor + Toolbar (lazy)<br/>Milkdown / ProseMirror / Shiki"]
+    Preview["MarkdownPreview<br/>markdown-it + Shiki + Mermaid"]
+
+    App --> Layout
+    Layout --> Timeline
+    Layout --> Workspace
+    Layout --> Settings
+    Workspace --> Preview
+    Workspace -. "on edit" .-> Editor
+```
+
+The timeline is the launch view, so everything the editor drags in
+(Milkdown, ProseMirror, Shiki) is split out of the startup bundle and
+prefetched during idle time. All Tauri commands go through `typedInvoke`
+(`lib/commands.ts`), which types every command and notifies listeners on
+each successful mutation — that single hook drives auto-sync scheduling.
+
+## Quick capture flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant UI as CaptureBar
+    participant Ctx as location tracker
+    participant Rust as Tauri command
+    participant Core as core crate
+    participant Sync as sync client
+
+    User->>UI: Enter
+    UI->>Ctx: getClientContext()
+    Note over Ctx: last known fix returned immediately;<br/>cold GPS waits at most 1.5s
+    UI->>Rust: save_quick_capture(text, context)
+    Rust->>Core: save_timeline_entry
+    Core->>Core: append to data/timeline/YYYY-MM-DD.md
+    Rust-->>UI: ok — entry visible, input cleared
+    UI--)Sync: local mutation event
+    Note over Sync: 5s debounce, only if auto-sync is on
+    Sync->>Rust: sync_start
+    Rust->>Core: scan local files + diff against server state
+    Rust->>Rust: POST /sync/bulk (uploads, downloads, conflicts)
+```
+
+The save path never blocks on the network or on a GPS fix: coordinates come
+from a warm cache that refreshes in the background, and sync happens after
+the entry is already on disk.
+
+## Module index
+
+| Path                                                 | Responsibility                                                             |
+| ---------------------------------------------------- | -------------------------------------------------------------------------- |
+| [`core/src/timeline/`](../core/src/timeline)         | Day-file parsing, appends, edits; device-list frontmatter compression      |
+| [`core/src/note/`](../core/src/note)                 | Note CRUD and list summaries (frontmatter + preview + tags)                |
+| [`core/src/search.rs`](../core/src/search.rs)        | Substring search across timeline and notes                                 |
+| [`core/src/sync/`](../core/src/sync)                 | Local scan + hashing, diff against server state, conflict naming           |
+| [`tauri-app/src-tauri/`](../tauri-app/src-tauri/src) | Tauri commands, sync HTTP client, OAuth deep-link handling, device context |
+| [`tauri-app/src/`](../tauri-app/src)                 | SolidJS views, Milkdown editor integration, client-side device signals     |
+| [`workers/`](../workers/src)                         | Cloudflare Worker: Google OAuth, JWT, R2-backed bulk sync with ETag CAS    |
+| [`mcp-cli/`](../mcp-cli/src)                         | MCP server exposing read-only core tools to AI assistants                  |
+
+> [!NOTE]
+> UI priorities (simple → lightweight → stylish), the Milkdown plugin
+> policy, and editor performance constraints are defined in
+> [`CLAUDE.md`](../CLAUDE.md) and apply to every UI change.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -111,7 +111,7 @@ sequenceDiagram
 
     User->>UI: Enter
     UI->>Ctx: getClientContext()
-    Note over Ctx: last known fix returned immediately;<br/>cold GPS waits at most 1.5s
+    Note over Ctx: last known fix returned immediately —<br/>cold GPS waits at most 1.5s
     UI->>Rust: save_quick_capture(text, context)
     Rust->>Core: save_timeline_entry
     Core->>Core: append to data/timeline/YYYY-MM-DD.md


### PR DESCRIPTION
## Summary

`docs/` ディレクトリを新設し、アーキテクチャの俯瞰ページ `docs/introduction.md` を追加。README に Documentation セクションを足してリンクした。

内容:

- **システム全体図**（Mermaid flowchart）: WebView ↔ Tauri shell ↔ core crate ↔ md ファイル、mcp-cli の core 共有、Cloudflare Worker + R2 同期、Google OAuth deep link
- **設計判断の言語化**: local-first 保存 / plain Markdown ストア / framework 非依存 core / server-authoritative な同期状態（local-wins + 競合コピー）
- **ディスクレイアウト**: 1日1ファイルのタイムライン、ノート、`.sync-state.json` の役割と day frontmatter の圧縮形式
- **フロントエンド構造図**: 起動ビュー（eager）とエディタ一式（lazy + アイドルプリフェッチ）のバンドル分割
- **クイックキャプチャのシーケンス図**: 位置情報キャッシュ → ローカル保存 → 5s debounce 自動同期
- **モジュール索引**: 実ソースディレクトリへのリンク付き

未マージの #88-90 に依存する記述は含めず、それらのマージ前後どちらでも正しいレベルに揃えている。

## Test plan

- [x] `just fmt` clean
- [x] モジュール索引・README のリンク先がすべて実在することを確認
- [x] GitHub 上で Mermaid 4図のレンダリングを目視確認（マージ前に Files changed タブで見えます）