### PR TITLE
fix(ci): install frontend deps before tauri android init

### DIFF
--- a/tauri-app/justfile
+++ b/tauri-app/justfile
@@ -20,7 +20,7 @@ test: setup
 dev: setup
   pnpm tauri dev
 
-android-init:
+android-init: setup
   pnpm tauri android init
 
 android-dev: setup


### PR DESCRIPTION
## Summary

初回のリリース CI（v0.1.0 タグ、run 31298557919）が `tauri: command not found` で失敗した。`android-init` レシピだけ `setup`（pnpm install）への依存が抜けており、fresh checkout の CI では node_modules が無いまま `pnpm tauri android init` が走る。ローカルでは node_modules が常に存在するため一度も顕在化しなかった。

`android-release-build: setup` と同様に依存を1行足しただけ。

## Test plan

- [x] 差分は justfile の依存1行のみ（`android-dev: setup` / `android-release-build: setup` と同型）
- [x] マージ後、タグ `v0.1.0` を新しい main に付け替えて再リリース → CI が通ることを確認