### PR TITLE
fix(timeline): order a day's entries newest first

### DIFF
--- a/tauri-app/src/lib/items.test.ts
+++ b/tauri-app/src/lib/items.test.ts
@@ -26,8 +26,17 @@ function note(overrides: Partial<Note> = {}): Note {
 describe("toTimelineItems", () => {
   it("addresses each entry by date and position", () => {
     const items = toTimelineItems("2026-08-04", ["- [09:00:00] one", "- [10:00:00] two"]);
-    expect(items.map((i) => i.id)).toStrictEqual(["2026-08-04#0", "2026-08-04#1"]);
-    expect(items[1].index).toBe(1);
+    expect(items.map((i) => i.id)).toStrictEqual(["2026-08-04#1", "2026-08-04#0"]);
+  });
+
+  it("puts the newest entry of the day first", () => {
+    const items = toTimelineItems("2026-08-04", ["- [09:00:00] one", "- [10:00:00] two"]);
+    expect(items.map((i) => i.text)).toStrictEqual(["two", "one"]);
+  });
+
+  it("keeps the file position as the index so an edit reaches the right line", () => {
+    const items = toTimelineItems("2026-08-04", ["- [09:00:00] one", "- [10:00:00] two"]);
+    expect(items.map((i) => i.index)).toStrictEqual([1, 0]);
   });
 
   it("splits the recorded context out of the raw line", () => {
@@ -134,7 +143,7 @@ describe("replaceDayItems", () => {
 
     const updated = replaceDayItems(items, "2026-08-04", day("2026-08-04", ["today", "more"]));
 
-    expect(updated.map((i) => i.text)).toStrictEqual(["today", "more", "yesterday"]);
+    expect(updated.map((i) => i.text)).toStrictEqual(["more", "today", "yesterday"]);
   });
 
   it("puts the first entry of a new day at the top", () => {

--- a/tauri-app/src/lib/items.ts
+++ b/tauri-app/src/lib/items.ts
@@ -40,20 +40,27 @@ function firstLine(text: string): string {
   return line?.replace(/^#+\s*/, "").trim() ?? "";
 }
 
+/**
+ * 1 日ぶんの行を、新しい順（画面と同じ並び）の TimelineItem にする。
+ * ファイルは追記なので行は古い順に並ぶ。index には元の行位置を残す。
+ * 更新・削除はこの index で行を指すので、並べ替えは index を振った後にやる。
+ */
 export function toTimelineItems(date: string, raws: string[]): TimelineItem[] {
-  return raws.map((raw, index) => {
-    const parsed = parseTimelineEntry(raw);
-    return {
-      kind: "timeline",
-      id: `${date}#${index}`,
-      date,
-      index,
-      raw,
-      text: parsed.text,
-      time: parsed.time,
-      context: parsed.context,
-    };
-  });
+  return raws
+    .map((raw, index) => {
+      const parsed = parseTimelineEntry(raw);
+      return {
+        kind: "timeline" as const,
+        id: `${date}#${index}`,
+        date,
+        index,
+        raw,
+        text: parsed.text,
+        time: parsed.time,
+        context: parsed.context,
+      };
+    })
+    .toReversed();
 }
 
 export function toNoteItems(notes: Note[]): NoteItem[] {


### PR DESCRIPTION
## 現象

日付グループは新しい順なのに、1 日の中のエントリはファイルの追記順（古い順）のままだった。そのため画面の一番上が「今日の一番古いエントリ」になり、日をまたぐたびに並びの向きが反転していた。

```
今日
  09:00  ← 一番上が今日の最古
  15:00  ← 今日の最新
昨日
  08:00
  22:00
```

## 変更

`toTimelineItems` で、**index を振った後に** `.toReversed()` する。

`index` は `update_timeline_entry` / `delete_timeline_entry` に渡すファイルの行番号なので、画面の並びではなくファイルの並びを指し続ける必要がある。並べ替えを index 採番の後に置いているのはこのため。

呼び出し元は `Timeline.tsx` の `loadTimeline` と `reloadDay` の 2 箇所のみ。`replaceDayItems` は日付単位の差し替えなので日内の並びには影響しない。

## テスト

- 追加: 日内が新しい順で返ること / index が元の行位置のままであること
- 更新: id の期待値と `replaceDayItems` 差し替え後の並び

## 検証

- `pnpm test` → 19 ファイル / 188 テスト 全パス
- `pnpm exec tsgo -b` → 型エラーなし