### PR TITLE
fix(note): keep frontmatter out of the note UI and repair mangled notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,19 @@ Rejected plugins (with reasons):
 - `code-block` component — requires CodeMirror (~150KB), conflicts with "lightweight"
 - `indent` / `upload` / `image-*` / `table-block` / `list-item-block` — no current feature need
 
+## Note Storage
+
+- **Filename**: `YYYYMMDD_HHMMSS.md` — an immutable ID stamped at creation.
+  Never rename to match the title: Syncthing sync, widget deep links (`?file=`)
+  and list-row identity all point at the filename
+- **Title**: derived from the first non-empty line of the body (Typora/Bear
+  style). It is display-only — filename and title are independent by design
+- **Frontmatter** (`time` / `tags` / `context`): a record of creation, preserved
+  verbatim on every edit. `time` must stay the creation time because the list
+  sorts by filename (= creation order); a moving `time` breaks date grouping
+- **The editor and preview only ever see the body.** Frontmatter routed through
+  Milkdown gets serialized back as escaped plain text and corrupts the file
+
 ## Editor Performance Principles
 
 Three non-negotiable constraints for Markdown editor design:

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,7 +14,7 @@ pub use error::CoreError;
 pub use note::error::NoteError;
 pub use note::{
     NoteSummary, create_draft_note, delete_note, list_notes, read_note, read_note_by_filename,
-    update_note,
+    repair_notes, update_note,
 };
 pub use search::{HitKind, SearchHit, search_all};
 pub use timeline::error::TimelineError;

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -1,4 +1,5 @@
 pub(crate) mod error;
+mod repair;
 pub(crate) mod repository;
 mod summary;
 
@@ -45,6 +46,11 @@ pub fn read_note_by_filename(
 
 pub fn delete_note(base_dir: &Path, filename: &NoteFilename) -> Result<(), CoreError> {
     Notes::new(base_dir.to_path_buf()).delete(filename)
+}
+
+/// 過去の編集で本文に混入した化けメタデータを直す。直したファイル数を返す。
+pub fn repair_notes(base_dir: &Path) -> Result<usize, CoreError> {
+    repair::repair_all(&crate::utils::paths::notes_dir(base_dir))
 }
 
 #[cfg(test)]

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 
 use crate::error::CoreError;
 use crate::utils::device::Context;
+use crate::utils::frontmatter;
 use crate::utils::validated::NoteFilename;
 
 pub fn create_draft_note(
@@ -28,8 +29,11 @@ pub fn list_notes(base_dir: &Path) -> Result<Vec<NoteSummary>, CoreError> {
     Notes::new(base_dir.to_path_buf()).list()
 }
 
+/// ノートの本文を返す。frontmatter は保存形式の都合であって、
+/// 読む側(プレビュー・エディタ・MCP)に見せるものではない。
 pub fn read_note(file_path: &Path) -> Result<String, CoreError> {
-    Ok(std::fs::read_to_string(file_path)?)
+    let content = std::fs::read_to_string(file_path)?;
+    Ok(frontmatter::strip(&content).to_string())
 }
 
 pub fn read_note_by_filename(
@@ -46,6 +50,7 @@ pub fn delete_note(base_dir: &Path, filename: &NoteFilename) -> Result<(), CoreE
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::frontmatter::NoteFrontmatter;
     use std::fs;
     use tempfile::TempDir;
 
@@ -76,6 +81,44 @@ mod tests {
         let content = fs::read_to_string(&path).unwrap();
         assert!(content.contains("updated"));
         assert!(!content.contains("original"));
+    }
+
+    /// time は作成時刻。一覧はファイル名(作成時刻)順に並ぶので、編集で
+    /// time が動くと日付グループと並び順が食い違う。
+    #[test]
+    fn update_note_keeps_the_creation_time() {
+        let tmp = TempDir::new().unwrap();
+        let path = create_draft_note(tmp.path(), "original", &[], &mock_context()).unwrap();
+        let original = fs::read_to_string(&path).unwrap();
+        let (fm_before, _) = frontmatter::parse::<NoteFrontmatter>(&original).unwrap();
+
+        update_note(&path, "updated", &mock_context()).unwrap();
+
+        let updated = fs::read_to_string(&path).unwrap();
+        let (fm_after, body) = frontmatter::parse::<NoteFrontmatter>(&updated).unwrap();
+        assert_eq!(fm_after.time, fm_before.time);
+        assert_eq!(body, "updated");
+    }
+
+    /// context は「どの端末で書いたか」の記録。別の端末で編集しても
+    /// 作成時の記録が上書きされてはいけない。
+    #[test]
+    fn update_note_keeps_the_creation_context() {
+        let tmp = TempDir::new().unwrap();
+        let path = create_draft_note(tmp.path(), "original", &[], &mock_context()).unwrap();
+
+        let other_device = Context {
+            battery: Some(1),
+            is_charging: Some(true),
+            ..Context::default()
+        };
+        update_note(&path, "updated", &other_device).unwrap();
+
+        let updated = fs::read_to_string(&path).unwrap();
+        let (fm, _) = frontmatter::parse::<NoteFrontmatter>(&updated).unwrap();
+        let ctx = fm.context.unwrap();
+        assert_eq!(ctx.battery, Some(50));
+        assert_eq!(ctx.is_charging, Some(false));
     }
 
     /// タグ欄で付けていた頃のノートを編集しても、分類は消えてはいけない。
@@ -127,6 +170,28 @@ mod tests {
         let path = create_draft_note(tmp.path(), "full content", &[], &mock_context()).unwrap();
         let content = read_note(&path).unwrap();
         assert!(content.contains("full content"));
+    }
+
+    /// 読み取りが返すのは本文だけ。frontmatter を返すと、そのまま
+    /// プレビューやエディタに流れてメタデータが画面に出る。
+    #[test]
+    fn read_note_returns_body_without_frontmatter() {
+        let tmp = TempDir::new().unwrap();
+        let path = create_draft_note(tmp.path(), "# Title\nbody", &[], &mock_context()).unwrap();
+
+        assert_eq!(read_note(&path).unwrap(), "# Title\nbody");
+    }
+
+    #[test]
+    fn read_note_by_filename_returns_body_without_frontmatter() {
+        let tmp = TempDir::new().unwrap();
+        let path = create_draft_note(tmp.path(), "# Title\nbody", &[], &mock_context()).unwrap();
+        let fname = path.file_name().unwrap().to_str().unwrap();
+        let note_filename = NoteFilename::parse(fname).unwrap();
+
+        let content = read_note_by_filename(tmp.path(), &note_filename).unwrap();
+
+        assert_eq!(content, "# Title\nbody");
     }
 
     #[test]

--- a/core/src/note/repair.rs
+++ b/core/src/note/repair.rs
@@ -1,0 +1,218 @@
+use std::fs;
+use std::path::Path;
+
+use chrono::{DateTime, FixedOffset, Local, NaiveDateTime, TimeZone as _};
+
+use crate::error::CoreError;
+use crate::utils::frontmatter::{self, NoteFrontmatter};
+use crate::utils::fs::{list_md_files, write_atomic};
+
+/// 編集画面が frontmatter ごと Milkdown に通していた時期に保存されたノートは、
+/// 本文の先頭に「化けたメタデータ」を抱えている。開始区切りの `---` は `***` に、
+/// YAML はエスケープ付きの平文(`tags: \[]`)に、終了区切りは直前の行と合わさって
+/// setext 見出しの下線(`------`)になった塊で、frontmatter の time も編集時刻で
+/// 上書きされている。その塊を取り除き、time をファイル名の作成時刻へ戻す。
+///
+/// 該当しないファイルには一切書き込まない。全ファイルを書き直すと
+/// 同期(Syncthing)が無変更のノートまで転送し直すことになる。
+pub(crate) fn repair_all(notes_dir: &Path) -> Result<usize, CoreError> {
+    let mut repaired = 0;
+    for entry in list_md_files(notes_dir)? {
+        let path = entry.path();
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok((fm, body)) = frontmatter::parse::<NoteFrontmatter>(&content) else {
+            continue;
+        };
+        let Some(clean_body) = strip_mangled_metadata(body) else {
+            continue;
+        };
+
+        let filename = entry.file_name().to_string_lossy().to_string();
+        let fixed = NoteFrontmatter {
+            time: filename_time(&filename).unwrap_or(fm.time),
+            tags: fm.tags,
+            context: fm.context,
+        };
+        write_atomic(&path, frontmatter::render(&fixed, &clean_body)?)?;
+        repaired += 1;
+    }
+    Ok(repaired)
+}
+
+/// 本文先頭の化けたメタデータ塊を取り除いた本文を返す。塊が無ければ `None`。
+///
+/// `***` も `time:` で始まる行もユーザーが書き得るので、開始区切り・時刻として
+/// 読める time 行・ダッシュだけの終了行、の三点が揃ったときだけ塊とみなす。
+fn strip_mangled_metadata(body: &str) -> Option<String> {
+    let lines: Vec<&str> = body.lines().collect();
+    let mut i = 0;
+
+    while lines.get(i).is_some_and(|l| l.trim().is_empty()) {
+        i += 1;
+    }
+    if lines.get(i) != Some(&"***") {
+        return None;
+    }
+    i += 1;
+    while lines.get(i).is_some_and(|l| l.trim().is_empty()) {
+        i += 1;
+    }
+
+    let time_value = lines.get(i)?.strip_prefix("time: ")?;
+    DateTime::parse_from_rfc3339(time_value.trim()).ok()?;
+
+    // 終了区切りの成れの果て: ダッシュ 3 本以上だけの行
+    let is_dash_line = |l: &str| l.len() >= 3 && l.bytes().all(|b| b == b'-');
+    while i < lines.len() && !is_dash_line(lines[i]) {
+        i += 1;
+    }
+    if i == lines.len() {
+        return None;
+    }
+    i += 1;
+
+    // 塊の直後に残った空行と `<br />`(空段落の成れの果て)も本文には要らない
+    while lines
+        .get(i)
+        .is_some_and(|l| l.trim().is_empty() || l.trim() == "<br />")
+    {
+        i += 1;
+    }
+
+    Some(lines[i..].join("\n"))
+}
+
+/// `20260503_153910.md` のようなファイル名から作成時刻を読む。
+/// frontmatter の time は編集で上書きされてきた履歴があるが、
+/// ファイル名は作成時に振られたまま変わらない。
+fn filename_time(filename: &str) -> Option<DateTime<FixedOffset>> {
+    let stem = filename.get(..15)?;
+    let naive = NaiveDateTime::parse_from_str(stem, "%Y%m%d_%H%M%S").ok()?;
+    let local = Local.from_local_datetime(&naive).earliest()?;
+    Some(local.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// 実際に壊れていたファイルと同じ形の再現。
+    const MANGLED: &str = concat!(
+        "---\n",
+        "time: 2026-08-09T20:38:50.370362+09:00\n",
+        "tags:\n",
+        "- keep\n",
+        "context:\n",
+        "  battery: 100\n",
+        "  is_charging: true\n",
+        "---\n",
+        "***\n",
+        "\n",
+        "time: 2026-05-03T15:47:06.544569369+09:00\n",
+        "tags: \\[]\n",
+        "context:\n",
+        "battery: 64\n",
+        "is\\_charging: false\n",
+        "os\\_version: '26.6'\n",
+        "locale: ja\\_JP\n",
+        "--------------\n",
+        "\n",
+        "<br />\n",
+        "\n",
+        "<br />\n",
+        "\n",
+        "# EVOJについて\n",
+        "本文はここから\n",
+    );
+
+    fn seed(dir: &Path, name: &str, content: &str) {
+        fs::write(dir.join(name), content).unwrap();
+    }
+
+    #[test]
+    fn repairs_a_mangled_note_and_restores_the_filename_time() {
+        let tmp = TempDir::new().unwrap();
+        seed(tmp.path(), "20260503_153910.md", MANGLED);
+
+        let repaired = repair_all(tmp.path()).unwrap();
+
+        assert_eq!(repaired, 1);
+        let content = fs::read_to_string(tmp.path().join("20260503_153910.md")).unwrap();
+        let (fm, body) = frontmatter::parse::<NoteFrontmatter>(&content).unwrap();
+        assert_eq!(body, "# EVOJについて\n本文はここから");
+        assert_eq!(fm.tags, vec!["keep"]);
+        assert!(fm.context.is_some());
+        let expected = Local
+            .with_ymd_and_hms(2026, 5, 3, 15, 39, 10)
+            .single()
+            .unwrap();
+        assert_eq!(fm.time, expected);
+    }
+
+    #[test]
+    fn repair_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        seed(tmp.path(), "20260503_153910.md", MANGLED);
+
+        repair_all(tmp.path()).unwrap();
+        let after_first = fs::read_to_string(tmp.path().join("20260503_153910.md")).unwrap();
+        let repaired = repair_all(tmp.path()).unwrap();
+
+        assert_eq!(repaired, 0);
+        let after_second = fs::read_to_string(tmp.path().join("20260503_153910.md")).unwrap();
+        assert_eq!(after_first, after_second);
+    }
+
+    /// ユーザーが本文に書いた `***`(水平線)を化けたメタデータと
+    /// 取り違えて消してはいけない。
+    #[test]
+    fn a_user_written_horizontal_rule_is_not_metadata() {
+        let tmp = TempDir::new().unwrap();
+        let content = "---\ntime: 2026-04-30T02:01:21+09:00\ntags: []\n---\nあ\n\n***\n\n本文\n";
+        seed(tmp.path(), "20260430_020116.md", content);
+
+        let repaired = repair_all(tmp.path()).unwrap();
+
+        assert_eq!(repaired, 0);
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("20260430_020116.md")).unwrap(),
+            content
+        );
+    }
+
+    /// `***` 直後でも、日時として読めない行が続くなら塊ではない。
+    #[test]
+    fn a_rule_followed_by_plain_text_is_left_alone() {
+        let tmp = TempDir::new().unwrap();
+        let content =
+            "---\ntime: 2026-04-30T02:01:21+09:00\ntags: []\n---\n***\n\ntime: 未定\n---\n";
+        seed(tmp.path(), "20260430_020116.md", content);
+
+        assert_eq!(repair_all(tmp.path()).unwrap(), 0);
+    }
+
+    /// 同期の衝突ファイル名でも先頭のタイムスタンプは読める。
+    #[test]
+    fn filename_time_reads_conflict_filenames() {
+        let time = filename_time("20260320_033440.sync-conflict-20260511-031336..md").unwrap();
+        let expected = Local
+            .with_ymd_and_hms(2026, 3, 20, 3, 34, 40)
+            .single()
+            .unwrap();
+        assert_eq!(time, expected);
+    }
+
+    #[test]
+    fn filename_time_rejects_foreign_names() {
+        assert!(filename_time("readme.md").is_none());
+    }
+
+    #[test]
+    fn a_missing_directory_repairs_nothing() {
+        let tmp = TempDir::new().unwrap();
+        assert_eq!(repair_all(&tmp.path().join("nope")).unwrap(), 0);
+    }
+}

--- a/core/src/note/repository.rs
+++ b/core/src/note/repository.rs
@@ -73,23 +73,31 @@ impl Notes {
             return Err(CoreError::PathTraversal(fname.to_string()));
         }
 
-        Ok(fs::read_to_string(canonical_file_path)?)
+        let content = fs::read_to_string(canonical_file_path)?;
+        Ok(frontmatter::strip(&content).to_string())
     }
 
-    /// 本文だけを書き換える。
+    /// 本文だけを書き換える。frontmatter は作成時の記録なので手を付けない。
     ///
-    /// タグは本文の `#記法` から読むようになったので、UI から渡されることは
-    /// もう無い。frontmatter に残っている古いタグは、読み直してそのまま書き戻す。
-    /// 引数から消えたぶんを空で上書きすると、タグ欄で付けていた頃のノートから
-    /// 分類が消える。
+    /// - time: 作成時刻。一覧はファイル名(作成時刻)順に並ぶため、編集で
+    ///   動かすと日付グループと並び順が食い違う
+    /// - tags: 本文の `#記法` に移行済みだが、タグ欄で付けていた頃のぶんを
+    ///   空で上書きすると過去のノートから分類が消える
+    /// - context: どの端末で書いたかの記録。編集端末で上書きしない
+    ///
+    /// frontmatter が読めないファイルだけ、今この場の時刻と端末で作り直す。
     pub(crate) fn update(path: &Path, body: &str, context: &Context) -> Result<(), CoreError> {
         let existing = fs::read_to_string(path).unwrap_or_default();
-        let tags = frontmatter::parse::<NoteFrontmatter>(&existing)
-            .map(|(fm, _)| fm.tags)
-            .unwrap_or_default();
+        let fm = frontmatter::parse::<NoteFrontmatter>(&existing).map_or_else(
+            |_| NoteFrontmatter {
+                time: Local::now().into(),
+                tags: Vec::new(),
+                context: Some(context.clone()),
+            },
+            |(fm, _)| fm,
+        );
 
-        let now = Local::now();
-        let markdown = format_note_markdown(body, &tags, now, context)?;
+        let markdown = frontmatter::render(&fm, body)?;
         write_atomic(path, markdown)?;
         Ok(())
     }

--- a/core/src/note/summary.rs
+++ b/core/src/note/summary.rs
@@ -22,7 +22,9 @@ impl Summary {
             if let Ok((fm, body)) = frontmatter::parse::<NoteFrontmatter>(content) {
                 (Some(fm.time), fm.tags, body)
             } else {
-                (None, Vec::new(), content)
+                // parse に失敗しても frontmatter の区切りは剥がす。壊れた
+                // メタデータを本文扱いすると、一覧のタイトルとプレビューに YAML が出る。
+                (None, Vec::new(), frontmatter::strip(content))
             };
 
         // 本文に書かれた `#タグ` が今の入力方法。frontmatter に残っているのは
@@ -76,6 +78,20 @@ mod tests {
         assert!(summary.time.is_some());
         assert_eq!(summary.tags, vec!["a", "b"]);
         assert!(summary.preview.contains("# Title"));
+    }
+
+    /// frontmatter が YAML として壊れているノート。時刻とタグは諦めるが、
+    /// メタデータをタイトル・プレビューに出してはいけない。
+    #[test]
+    fn broken_frontmatter_does_not_leak_into_preview() {
+        let content = "---\ntime: [broken\n---\n# Title\nbody";
+        let summary = Summary::from_file(
+            PathBuf::from("/test/note.md"),
+            "note.md".to_string(),
+            content,
+        );
+        assert!(summary.time.is_none());
+        assert_eq!(summary.preview, "# Title\nbody");
     }
 
     #[test]

--- a/core/src/utils/frontmatter.rs
+++ b/core/src/utils/frontmatter.rs
@@ -24,6 +24,24 @@ pub fn parse<T: DeserializeOwned>(content: &str) -> Result<(T, &str), CoreError>
     markdown_frontmatter::parse::<T>(content).map_err(|e| CoreError::Parse(format!("{e:?}")))
 }
 
+/// frontmatter を捨てて本文だけを返す。`parse` と違い YAML の中身は見ないので、
+/// メタデータが壊れているファイルでも本文が画面に漏れ出さない。
+/// 区切りが閉じていなければ frontmatter とはみなさず全文を返す。
+#[must_use]
+pub fn strip(content: &str) -> &str {
+    let Some(rest) = content.strip_prefix("---\n") else {
+        return content;
+    };
+    if let Some(idx) = rest.find("\n---\n") {
+        return &rest[idx + "\n---\n".len()..];
+    }
+    if rest.ends_with("\n---") {
+        // 閉じ区切りがファイル末尾: 本文が空のノート
+        return "";
+    }
+    content
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -79,6 +97,33 @@ mod tests {
         assert!(rendered.starts_with("---\n"));
         assert!(rendered.contains("\n---\n"));
         assert!(rendered.ends_with("body"));
+    }
+
+    #[test]
+    fn strip_removes_frontmatter() {
+        assert_eq!(strip("---\ntime: x\n---\nbody line"), "body line");
+    }
+
+    #[test]
+    fn strip_returns_whole_content_without_frontmatter() {
+        assert_eq!(strip("just body"), "just body");
+    }
+
+    /// YAML として壊れていても、区切りの中身を本文に漏らさない。
+    #[test]
+    fn strip_drops_broken_yaml_frontmatter() {
+        assert_eq!(strip("---\n:{ not yaml ::\n---\nbody"), "body");
+    }
+
+    #[test]
+    fn strip_handles_empty_body() {
+        assert_eq!(strip("---\ntime: x\n---"), "");
+    }
+
+    /// 閉じ区切りが無いなら frontmatter ではない(本文先頭の水平線かもしれない)。
+    #[test]
+    fn strip_keeps_unclosed_delimiter() {
+        assert_eq!(strip("---\nno closing"), "---\nno closing");
     }
 
     #[test]

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -76,7 +76,17 @@ fn update_draft(file_path: String, body: String, client: ClientContext) -> Resul
 
 #[tauri::command]
 fn list_notes(handle: AppHandle) -> Result<Vec<NoteSummary>, String> {
+    // 過去の編集で本文に混入した化けメタデータを、最初の一覧より前に一度だけ直す。
+    // setup でやらないのは、Android の `app_data_dir` がメインスレッドから
+    // 呼べないのと、修復前の一覧が一瞬でも画面に出るのを避けるため。
+    // 修復に失敗してもノートが読めなくなるよりは、そのまま出すほうがいい。
+    static REPAIR: std::sync::Once = std::sync::Once::new();
+
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    REPAIR.call_once(|| {
+        let _ = magical_merchant_core::repair_notes(&base_dir);
+    });
+
     magical_merchant_core::list_notes(&base_dir).map_err(|e| e.to_string())
 }
 


### PR DESCRIPTION
## 1. 概要

- ノートの読み取りが frontmatter 込みの生ファイルを返し、UI がそのままプレビューと Milkdown に流していたため、メタデータが画面に出ていた。読み取りは本文のみ返す
- frontmatter がエディタを往復すると化けた平文として本文へ混入し、保存のたびに `time` / `context` が編集端末の値で上書きされていた。更新は既存 frontmatter を保持して本文だけ書き換える。`time` は作成時刻に固定する — 一覧はファイル名(=作成順)ソートなので、`time` が動くと日付グルーピングが崩れる
- 既に壊れていたノート(実データで4件)は `repair_notes` が化けた塊を除去し、`time` をファイル名から復元する。初回 `list_notes` の前に一度だけ走る
- 命名は「ファイル名=作成時刻の不変 ID、タイトル=本文の先頭行」に確定。Syncthing とウィジェットの deep link がファイル名を指すため、タイトル変更でのリネームは不採用
- リスク: repair の検出は「`***` + 日時として読める `time:` 行 + ダッシュ終端」の三点一致に絞った保守的なもの。別の形で壊れたファイルは直らないが、`strip` により表示へは漏れない

## 2. 図解

ノートの読み書き経路。緑枠が追加された要素で、frontmatter は UI を経由せず update へ直接渡る。

```mermaid
flowchart LR
  file["data/notes/*.md"] --> strip["frontmatter::strip / parse"]
  strip -->|"本文のみ"| ui["プレビュー / Milkdown"]
  ui -->|"編集後の本文"| update["Notes::update"]
  strip -->|"time / tags / context を温存"| update
  update --> file
  repair["repair_notes<br/>(初回 list_notes の前に一度)"] -.->|"化けた塊を除去し time を復元"| file
  classDef added stroke:#3fb950,stroke-width:3px
  class strip,repair added
```

## 3. 変更ファイル

| ファイル                        | 変更      | 理由                                                          |
| ------------------------------- | --------- | ------------------------------------------------------------- |
| `core/src/utils/frontmatter.rs` | +45 / -0  | YAML が壊れていても本文を切り出す `strip` を追加              |
| `core/src/note/repository.rs`   | +20 / -12 | read は本文のみ返し、update は既存 frontmatter を書き戻す     |
| `core/src/note/summary.rs`      | +17 / -1  | parse 失敗時も一覧のタイトル・プレビューにメタデータを漏らさない |
| `core/src/note/repair.rs`       | +218 / -0 | 化けメタデータの検出・除去と time 復元(新規)                  |
| `core/src/note.rs`              | +72 / -1  | `repair_notes` の公開と read の本文化、回帰テスト             |
| `core/src/lib.rs`               | +1 / -1   | `repair_notes` の re-export                                   |
| `tauri-app/src-tauri/src/lib.rs`| +10 / -0  | 初回 `list_notes` の前に一度だけ修復を実行                    |
| `CLAUDE.md`                     | +13 / -0  | Note Storage(命名と frontmatter の扱い)の決定を記録           |

**合計:** 8 ファイル, +396 / -15

## 4. テスト

- [x] `just verify` — fmt 差分なし、clippy warning 0、テスト全通過(Rust 202 / frontend 195 / workers 33)
- [x] 実データのコピー 39 件に repair を実行 — 破損 4 件のみ変化、他 35 件はバイト単位で無変更(`diff -rq` で確認)
- [x] 実端末のデータも修復済み(バックアップ: `/tmp/mm-backup-20260813`)
- [ ] Android 側での表示確認(修復済みデータが同期で届いた後のウィジェット表示)
