### PR TITLE
test(commands): drop browser-mode module mocking for the Tauri IPC seam

### DIFF
--- a/tauri-app/src/lib/commands.test.ts
+++ b/tauri-app/src/lib/commands.test.ts
@@ -1,12 +1,22 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { invoke } from "@tauri-apps/api/core";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mockIPC, clearMocks } from "@tauri-apps/api/mocks";
+import type { ClientContext } from "./client-context";
 import { onLocalMutation, typedInvoke } from "./commands";
 
-vi.mock(import("@tauri-apps/api/core"), () => ({
-  invoke: vi.fn<(cmd: string, args?: unknown) => Promise<unknown>>(),
-}));
-
-const invokeMock = vi.mocked(invoke);
+// vi.mock("@tauri-apps/api/core") は使わない。browser mode のモジュールモックは
+// サーバー側の単一レジストリ越しに差し替えるため、並列実行下でモックが適用され
+// ないまま本物の invoke が渡ることがある (vitest-dev/vitest#8339)。CI だけで
+// 落ちる原因だった。mockIPC は window.__TAURI_INTERNALS__ を差し替えるだけで
+// モジュールグラフに触らないので、この競合と無縁。
+const CLIENT: ClientContext = {
+  latitude: null,
+  longitude: null,
+  battery: null,
+  isCharging: null,
+  networkType: null,
+  osVersion: null,
+  locale: null,
+};
 
 describe("typedInvoke local mutation notifications", () => {
   const seen: string[] = [];
@@ -14,46 +24,44 @@ describe("typedInvoke local mutation notifications", () => {
 
   beforeEach(() => {
     seen.length = 0;
-    invokeMock.mockReset();
-    invokeMock.mockResolvedValue(null);
+    mockIPC(() => null);
     stop = onLocalMutation(() => seen.push("mutated"));
   });
 
-  afterEach(() => stop());
+  afterEach(() => {
+    stop();
+    clearMocks();
+  });
 
   // 自動同期の合図。呼び出し側ごとに書くと必ず取りこぼす
   it("notifies after a write command succeeds", async () => {
-    await typedInvoke("update_draft", {
-      filePath: "a.md",
-      body: "x",
-      tags: [],
-      latitude: null,
-      longitude: null,
-    });
+    await typedInvoke("update_draft", { filePath: "a.md", body: "x", client: CLIENT });
     expect(seen).toHaveLength(1);
   });
 
   it("notifies for a quick capture", async () => {
-    await typedInvoke("save_quick_capture", { text: "hi", latitude: null, longitude: null });
+    await typedInvoke("save_quick_capture", { text: "hi", client: CLIENT });
     expect(seen).toHaveLength(1);
   });
 
   it("stays quiet for read-only commands", async () => {
-    invokeMock.mockResolvedValue([]);
+    mockIPC(() => []);
     await typedInvoke("list_notes");
     expect(seen).toHaveLength(0);
   });
 
   // 失敗した書き込みで同期すると、書けなかった内容を「同期済み」と見せてしまう
   it("stays quiet when the write fails", async () => {
-    invokeMock.mockRejectedValue(new Error("disk full"));
+    mockIPC(() => {
+      throw new Error("disk full");
+    });
     await expect(typedInvoke("delete_note", { filename: "a.md" })).rejects.toThrow("disk full");
     expect(seen).toHaveLength(0);
   });
 
   it("stops notifying once unsubscribed", async () => {
     stop();
-    await typedInvoke("save_document", { body: "x", tags: [], latitude: null, longitude: null });
+    await typedInvoke("save_document", { body: "x", tags: [], client: CLIENT });
     expect(seen).toHaveLength(0);
   });
 });

--- a/tauri-app/vitest.config.ts
+++ b/tauri-app/vitest.config.ts
@@ -5,7 +5,16 @@ import { playwright } from "@vitest/browser-playwright";
 export default defineConfig({
   plugins: [solid()],
   optimizeDeps: {
-    include: ["markdown-it", "shiki", "mermaid", "@solidjs/testing-library"],
+    // 実行中に発見された依存は再最適化とページリロードを引き起こし、Vitest が
+    // 「Vite unexpectedly reloaded a test」と警告する。テストからしか使わない
+    // @tauri-apps/api/mocks は取りこぼしやすいので明示しておく。
+    include: [
+      "markdown-it",
+      "shiki",
+      "mermaid",
+      "@solidjs/testing-library",
+      "@tauri-apps/api/mocks",
+    ],
   },
   test: {
     browser: {


### PR DESCRIPTION
## 1. 概要

- main の CI で `commands.test.ts` の5件が同時に落ちた（`invokeMock.mockReset is not a function`）。`vi.mock` のファクトリが適用されず、テストが本物の `invoke` を受け取っていた。同一ツリーが PR ブランチでは通り、再実行でも green になる flaky
- browser mode のモジュールモックは**全並列テストファイルが共有する単一のサーバー側レジストリ**越しに差し替えており、CI のタイミングで取りこぼすことがある（[vitest-dev/vitest#8339](https://github.com/vitest-dev/vitest/issues/8339)、未修正）。リポジトリ側で競合は塞げないので、依存すること自体をやめる
- 差し替え先を Tauri 公式の `mockIPC` に変更。`window.__TAURI_INTERNALS__` を置くだけでモジュールグラフに触らないため競合と無縁。実物の `invoke` が動き、IPC 層だけがスタブになるのでカバー範囲はむしろ広がる
- **これは回避策であって上流の修正ではない**。他のテストが `vi.mock` を使い始めれば同じ flaky が再発する。加えて `tsconfig.json` がテストを型チェック対象外にしているため、今回見つかった引数の乖離（`tags`/`latitude`/`longitude` vs 現在の `client`）のような drift は今後も CI で検出されない
- 思いつきに飛びつかないよう、対処の前に3つの仮説を実測で潰した（下表）

| 潰した仮説 | 検証方法 | 結果 |
| --- | --- | --- |
| pre-bundle が interception を壊す | `@tauri-apps/api/core` を `optimizeDeps.include` に強制投入 | 3/3 成功、不成立 |
| コールドキャッシュ | `cacheDir` を毎回変えて全スイート実行 | 3/3 成功、リロード警告なし、不成立 |
| 実行順序（`items.test.ts` が先に実物をロード） | 該当2ファイルのみを反復実行 | 12/12 成功、不成立 |

## 2. 図解

スタブの注入点がモジュールグラフから IPC 境界へ移った。緑の実線が追加、赤の破線が削除。

```mermaid
flowchart LR
  test["commands.test.ts"] --> ti["typedInvoke()"]
  ti --> core["@tauri-apps/api/core の invoke"]
  core --> internals["window.__TAURI_INTERNALS__"]
  internals --> outcome["resolve / reject"]

  reg["Vitest サーバー側の共有モックレジストリ"]
  ipc["mockIPC()"]

  reg -.->|"モジュールごと差し替え<br/>並列実行下で取りこぼす"| core
  ipc -->|"IPC 層だけ差し替え"| internals

  classDef added stroke:#3fb950,stroke-width:3px
  classDef removed stroke:#f85149,stroke-width:3px,stroke-dasharray:4 3
  class ipc added
  class reg removed
```

## 3. 変更ファイル

| ファイル | 変更 | 理由 |
| --- | --- | --- |
| `tauri-app/src/lib/commands.test.ts` | +29 / -21 | `vi.mock` を `mockIPC`/`clearMocks` に置換し、引数を現在の `CommandMap` に合わせる |
| `tauri-app/vitest.config.ts` | +10 / -1 | `@tauri-apps/api/mocks` を `optimizeDeps.include` に追加し、実行中発見による再最適化とページリロードを防ぐ |

**合計:** 2 ファイル, +39 / -22

## 4. テスト

- [x] `just tauri_app::test` を4回連続で実行 — 20 ファイル / 195 テストすべて成功、`Vite unexpectedly reloaded a test` 警告なし
- [x] `just tauri_app::check` — oxlint 0 件、`tsgo -b --noEmit` 通過、knip 通過
- [x] `nix fmt -- --fail-on-change` — 0 changed
- [x] mermaid 図を `mmdc` でレンダリング確認
- [x] CI — `frontend` 53s / `format` 34s / `changes` 6s すべて pass（`rust`・`workers`・`nix-package` は変更対象外で skip）
