### PR TITLE
feat(timeline): replace per-entry delete with guarded bulk selection

### DIFF
--- a/tauri-app/src/components/Icon.tsx
+++ b/tauri-app/src/components/Icon.tsx
@@ -44,6 +44,7 @@ const ICONS = {
   "calendar-blank": () => import("@phosphor-icons/core/assets/regular/calendar-blank.svg?raw"),
   x: () => import("@phosphor-icons/core/assets/regular/x.svg?raw"),
   check: () => import("@phosphor-icons/core/assets/regular/check.svg?raw"),
+  circle: () => import("@phosphor-icons/core/assets/regular/circle.svg?raw"),
   "check-circle": () => import("@phosphor-icons/core/assets/regular/check-circle.svg?raw"),
   "file-text": () => import("@phosphor-icons/core/assets/regular/file-text.svg?raw"),
   "caret-left": () => import("@phosphor-icons/core/assets/regular/caret-left.svg?raw"),

--- a/tauri-app/src/lib/items.test.ts
+++ b/tauri-app/src/lib/items.test.ts
@@ -172,9 +172,9 @@ describe("replaceDayItems", () => {
   });
 });
 
-describe("planBulkDelete", () => {
-  const target = (date: string, index: number) => ({ date, index });
+const target = (date: string, index: number) => ({ date, index });
 
+describe("planBulkDelete", () => {
   it("deletes within a day from the highest index so earlier deletes cannot shift later ones", () => {
     const plan = planBulkDelete([
       target("2026-08-04", 0),

--- a/tauri-app/src/lib/items.test.ts
+++ b/tauri-app/src/lib/items.test.ts
@@ -7,6 +7,7 @@ import {
   itemMeta,
   itemTitle,
   replaceDayItems,
+  planBulkDelete,
 } from "./items";
 import type { Note } from "./commands";
 
@@ -168,5 +169,41 @@ describe("replaceDayItems", () => {
     const updated = replaceDayItems(items, "2026-08-04", []);
 
     expect(updated.map((i) => i.date)).toStrictEqual(["2026-08-03"]);
+  });
+});
+
+describe("planBulkDelete", () => {
+  const target = (date: string, index: number) => ({ date, index });
+
+  it("deletes within a day from the highest index so earlier deletes cannot shift later ones", () => {
+    const plan = planBulkDelete([
+      target("2026-08-04", 0),
+      target("2026-08-04", 2),
+      target("2026-08-04", 1),
+    ]);
+    expect(plan).toStrictEqual([
+      target("2026-08-04", 2),
+      target("2026-08-04", 1),
+      target("2026-08-04", 0),
+    ]);
+  });
+
+  it("keeps each day's deletes together while ordering indexes per day", () => {
+    const plan = planBulkDelete([
+      target("2026-08-04", 1),
+      target("2026-08-03", 0),
+      target("2026-08-04", 3),
+      target("2026-08-03", 2),
+    ]);
+    expect(plan).toStrictEqual([
+      target("2026-08-04", 3),
+      target("2026-08-04", 1),
+      target("2026-08-03", 2),
+      target("2026-08-03", 0),
+    ]);
+  });
+
+  it("returns nothing for an empty selection", () => {
+    expect(planBulkDelete([])).toStrictEqual([]);
   });
 });

--- a/tauri-app/src/lib/items.ts
+++ b/tauri-app/src/lib/items.ts
@@ -108,6 +108,32 @@ export function replaceDayItems(
   return [...kept.slice(0, insertAt), ...dayItems, ...kept.slice(insertAt)];
 }
 
+export interface DeleteTarget {
+  date: string;
+  index: number;
+}
+
+/**
+ * まとめて消すときの実行順を決める。delete_timeline_entry は date + index で
+ * 行を指すので、同じ日の中で小さい index から消すと残りの行が繰り上がって
+ * 後続の index が別の行を指してしまう。日ごとにまとめ、index の大きい順に
+ * 並べることでズレを起こさない。日どうしの順は選択順を尊重する。
+ */
+export function planBulkDelete(targets: DeleteTarget[]): DeleteTarget[] {
+  const byDate = new Map<string, number[]>();
+  for (const { date, index } of targets) {
+    const indexes = byDate.get(date);
+    if (indexes) {
+      indexes.push(index);
+    } else {
+      byDate.set(date, [index]);
+    }
+  }
+  return [...byDate].flatMap(([date, indexes]) =>
+    indexes.toSorted((a, b) => b - a).map((index) => ({ date, index })),
+  );
+}
+
 export interface TimelineDay {
   /** `YYYY-MM-DD`。見出しの文字は表示側で作る。 */
   date: string;

--- a/tauri-app/src/styles/timeline.css
+++ b/tauri-app/src/styles/timeline.css
@@ -119,13 +119,9 @@
   border: none;
 }
 
-/* 消えた跡はレールも途切れさせる。取り消せば元に戻る */
-.entry--deleting .entry-rail-line {
-  background: repeating-linear-gradient(to bottom, var(--app-border) 0 4px, transparent 4px 9px);
-}
-
-.entry--deleting .entry-rail-dot {
-  display: none;
+.entry--selected .entry-rail-dot {
+  background: var(--app-accent);
+  border-color: var(--app-accent);
 }
 
 .entry-body {
@@ -176,42 +172,132 @@
   gap: 4px;
 }
 
-/* ---------------- hover actions ---------------- */
+/* ---------------- selection mode ---------------- */
 
-.entry-tools {
-  position: absolute;
-  top: -6px;
-  right: 0;
+/* 入口はリスト右上のテキストボタン 1 つだけ。普段は視界に入らない濃さに抑える */
+.timeline-toolbar {
   display: flex;
-  gap: 2px;
-  padding: 2px;
-  background: var(--app-surface);
-  border: 1px solid var(--app-hairline);
-  border-radius: 8px;
-  box-shadow: 0 4px 12px -6px rgb(20 20 25 / 20%);
-  opacity: 0;
-  pointer-events: none;
+  justify-content: flex-end;
+  align-items: center;
+  min-height: 24px;
+  margin-bottom: -24px;
 }
 
-.entry:hover .entry-tools,
-.entry-tools:focus-within {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-.entry-tool {
-  display: flex;
-  padding: 6px;
+.timeline-toolbar-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
   border: none;
   border-radius: var(--radius-2);
   background: none;
+  font-size: 12px;
   color: var(--app-text-faint);
   cursor: pointer;
 }
 
-.entry-tool:hover {
+.timeline-toolbar-button:hover {
   background: var(--app-hairline);
   color: var(--app-text);
+}
+
+.timeline-toolbar-hint {
+  font-size: 12px;
+  color: var(--app-text-faint);
+}
+
+.entry-select {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  max-width: 552px;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  text-align: start;
+  font-family: inherit;
+  font-size: 15px;
+  line-height: 1.75;
+  color: var(--app-text);
+  cursor: pointer;
+  border-radius: var(--radius-2);
+}
+
+.entry-select:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: 2px;
+}
+
+.entry-select .icon {
+  /* 1 行目の文字の中心に合わせる */
+  margin-top: 5px;
+  flex-shrink: 0;
+  color: var(--app-text-hint);
+}
+
+.entry--selected .entry-select .icon {
+  color: var(--app-accent);
+}
+
+.entry-select-text {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  min-width: 0;
+}
+
+/* 削除バーは入力バーと同じ場所に出す。画面に浮く箱を増やさない */
+.capture-dock .select-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 640px;
+  max-width: calc(100% - 48px);
+  padding: 10px 10px 10px 16px;
+  background: var(--app-surface);
+  border: 1px solid var(--app-border);
+  border-radius: 14px;
+  box-shadow: 0 12px 32px -8px rgb(20 20 25 / 18%);
+  pointer-events: auto;
+}
+
+.select-bar-label {
+  margin-right: auto;
+  font-size: 13px;
+  color: var(--app-text);
+}
+
+.select-bar-danger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border: none;
+  border-radius: 10px;
+  background: var(--app-danger);
+  color: var(--gray-0);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.select-bar-danger:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.select-bar-plain {
+  padding: 8px 12px;
+  border: none;
+  border-radius: 10px;
+  background: none;
+  color: var(--app-text-muted);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.select-bar-plain:hover {
+  background: var(--app-hairline);
 }
 
 /* ---------------- in-place editor ---------------- */
@@ -249,17 +335,6 @@
   gap: var(--size-2);
   margin-top: 8px;
   font-size: 11.5px;
-  color: var(--app-text-faint);
-}
-
-.entry-tombstone {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 12px 14px;
-  border: 1px dashed var(--app-border);
-  border-radius: 10px;
-  font-size: 13px;
   color: var(--app-text-faint);
 }
 
@@ -392,18 +467,10 @@
     font-size: 16px;
   }
 
-  /* 指の届く範囲に常に出す。モバイルには hover が無い。
-     出しっぱなしにするぶん、本文が下をくぐらないよう場所を空ける */
-  .entry-tools {
-    opacity: 1;
-    pointer-events: auto;
-    top: -4px;
-  }
-
   .entry-text,
+  .entry-select,
   .entry-meta {
     max-width: none;
-    padding-right: 34px;
   }
 
   .capture-dock {

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -18,7 +18,7 @@ import { typedInvoke } from "../lib/commands";
 import { getClientContext } from "../lib/client-context";
 import { useShell } from "../lib/shell";
 import { formatDayHeading, toIsoDate } from "../lib/day-labels";
-import { groupTimelineByDay, replaceDayItems, toTimelineItems } from "../lib/items";
+import { groupTimelineByDay, planBulkDelete, replaceDayItems, toTimelineItems } from "../lib/items";
 import type { TimelineItem } from "../lib/items";
 import { entryMeta } from "../lib/timeline-meta";
 import { countTags, parseTags } from "../lib/tags";
@@ -26,7 +26,6 @@ import type { DeviceContext } from "../lib/parse-timeline";
 
 /** 一覧に最初から載せる日数。カレンダーで遡ったぶんは都度足す。 */
 const RECENT_DAYS = 14;
-const UNDO_MS = 5000;
 
 async function loadTimeline(extraDates: string[]): Promise<TimelineItem[]> {
   const dates = await typedInvoke("list_timeline_dates");
@@ -44,13 +43,14 @@ async function loadTimeline(extraDates: string[]): Promise<TimelineItem[]> {
 interface EntryProps {
   item: TimelineItem;
   editing: boolean;
-  deleting: boolean;
+  selecting: boolean;
+  selected: boolean;
   draft: () => string;
   saved: () => boolean;
   onDraft: (text: string) => void;
   onEdit: () => void;
   onCommit: () => void;
-  onDelete: () => void;
+  onToggle: () => void;
 }
 
 function Entry(props: EntryProps): JSX.Element {
@@ -59,7 +59,7 @@ function Entry(props: EntryProps): JSX.Element {
   return (
     <article
       class="entry"
-      classList={{ "entry--active": props.editing, "entry--deleting": props.deleting }}
+      classList={{ "entry--active": props.editing, "entry--selected": props.selected }}
     >
       <span class="entry-time">{props.item.time.slice(0, 5)}</span>
       <span class="entry-rail" aria-hidden="true">
@@ -68,13 +68,6 @@ function Entry(props: EntryProps): JSX.Element {
       </span>
 
       <div class="entry-body">
-        <Show when={props.deleting}>
-          <div class="entry-tombstone">
-            <Icon name="trash" size={14} />
-            エントリを削除しました
-          </div>
-        </Show>
-
         <Show when={props.editing}>
           <div class="entry-editor">
             <textarea
@@ -99,18 +92,22 @@ function Entry(props: EntryProps): JSX.Element {
           </div>
         </Show>
 
-        <Show when={!props.editing && !props.deleting}>
-          <div class="entry-tools">
-            <button
-              type="button"
-              class="entry-tool"
-              title="削除"
-              aria-label="削除"
-              onClick={() => props.onDelete()}
-            >
-              <Icon name="trash" size={15} />
-            </button>
-          </div>
+        <Show when={!props.editing && props.selecting}>
+          {/* 選択モード中は本文クリックが編集ではなく選択のトグルになる */}
+          <button
+            type="button"
+            class="entry-select"
+            aria-pressed={props.selected}
+            onClick={() => props.onToggle()}
+          >
+            <Icon name={props.selected ? "check-circle" : "circle"} size={16} />
+            <span class="entry-select-text">
+              <TagText text={props.item.text} />
+            </span>
+          </button>
+        </Show>
+
+        <Show when={!props.editing && !props.selecting}>
           {/* 本文そのものが編集の入口。button なのはキーボードから開けるようにするため */}
           <button type="button" class="entry-text" onClick={() => props.onEdit()}>
             <TagText text={props.item.text} />
@@ -163,8 +160,13 @@ export default function Timeline(): JSX.Element {
   const [editing, setEditing] = createSignal<TimelineItem | null>(null);
   const [draft, setDraft] = createSignal("");
   const [saved, setSaved] = createSignal(false);
-  /** 削除の取り消し待ち。5 秒経つまで本削除しないので、消えた跡だけ残す。 */
-  const [pendingDelete, setPendingDelete] = createSignal<string[]>([]);
+  /** 選択モード。入っている間は本文クリックが編集ではなく選択になる。 */
+  const [selecting, setSelecting] = createSignal(false);
+  const [selected, setSelected] = createSignal<ReadonlySet<string>>(new Set());
+  /** 削除前のワンクッション。確認バーが出ている間だけ true。 */
+  const [confirming, setConfirming] = createSignal(false);
+  /** 削除の実行中。連打で同じ行を二度消さないための鍵。 */
+  const [deleting, setDeleting] = createSignal(false);
 
   const [timeline, { refetch, mutate }] = createResource(extraDates, loadTimeline);
 
@@ -202,8 +204,6 @@ export default function Timeline(): JSX.Element {
   const contextsFor = (iso: string): (DeviceContext | null)[] =>
     (timeline() ?? []).filter((i) => i.date === iso).map((i) => i.context);
 
-  const isDeleting = (id: string): boolean => pendingDelete().includes(id);
-
   /** 書いた日だけ読み直す。全日の読み直しは保存 1 回に日数ぶんの IPC を払う。 */
   const reloadDay = async (date: string): Promise<void> => {
     const items = toTimelineItems(date, await typedInvoke("read_timeline_by_date", { date }));
@@ -217,9 +217,6 @@ export default function Timeline(): JSX.Element {
 
   // ---- その場編集（Esc / フォーカスを外すと確定）----
   const startEditing = (item: TimelineItem): void => {
-    if (isDeleting(item.id)) {
-      return;
-    }
     setDraft(item.text);
     setSaved(false);
     setEditing(item);
@@ -240,23 +237,73 @@ export default function Timeline(): JSX.Element {
   // タブを切り替えても書きかけを捨てない。blur はアンマウントでは飛ばない。
   onCleanup(() => void commitEdit());
 
-  // ---- 削除 + Undo（5 秒は跡だけ残し、経過後に本削除）----
-  const remove = (item: TimelineItem): void => {
-    setPendingDelete((ids) => [...ids, item.id]);
+  // ---- まとめて削除（選択 → 確認 → 実行）----
+  const startSelecting = (): void => {
+    // 書きかけを確定してから入る。編集と選択が同時だと本文クリックの意味が曖昧になる
+    void commitEdit();
+    setSelecting(true);
+  };
 
-    const commit = setTimeout(() => {
-      void (async () => {
-        await typedInvoke("delete_timeline_entry", { date: item.date, index: item.index });
-        await reloadDay(item.date);
-        setPendingDelete((ids) => ids.filter((id) => id !== item.id));
-      })();
-    }, UNDO_MS);
+  const exitSelecting = (): void => {
+    setSelecting(false);
+    setSelected(new Set<string>());
+    setConfirming(false);
+  };
 
-    shell.showToast("エントリを削除しました", () => {
-      clearTimeout(commit);
-      setPendingDelete((ids) => ids.filter((id) => id !== item.id));
+  const toggleSelected = (id: string): void => {
+    // 選び直したら確認は仕切り直す。件数の変わった確認をそのまま実行させない
+    setConfirming(false);
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
     });
   };
+
+  const runDelete = async (): Promise<void> => {
+    // 連打で同じ index を二度消させない
+    if (deleting()) {
+      return;
+    }
+    setDeleting(true);
+    try {
+      const ids = selected();
+      const plan = planBulkDelete(entries().filter((item) => ids.has(item.id)));
+      // 同じ日の index は前の削除で行が繰り上がると意味が変わるので、並列にせず順に消す
+      for (const target of plan) {
+        await typedInvoke("delete_timeline_entry", { date: target.date, index: target.index });
+      }
+      await Promise.all([...new Set(plan.map((t) => t.date))].map(reloadDay));
+      exitSelecting();
+      shell.showToast(`${plan.length}件のエントリを削除しました`);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  // Esc で一段ずつ戻る: 確認バー → 選択モード → 通常
+  createEffect(() => {
+    if (!selecting()) {
+      return;
+    }
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key !== "Escape") {
+        return;
+      }
+      e.preventDefault();
+      if (confirming()) {
+        setConfirming(false);
+      } else {
+        exitSelecting();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    onCleanup(() => window.removeEventListener("keydown", onKey));
+  });
 
   return (
     <div class="timeline">
@@ -270,6 +317,18 @@ export default function Timeline(): JSX.Element {
           />
 
           <Show when={days().length} fallback={<EmptyTimeline filtered={Boolean(tagFilter())} />}>
+            <div class="timeline-toolbar">
+              <Show
+                when={!selecting()}
+                fallback={<span class="timeline-toolbar-hint">消すエントリを選んでください</span>}
+              >
+                <button type="button" class="timeline-toolbar-button" onClick={startSelecting}>
+                  <Icon name="check-square" size={14} />
+                  選択
+                </button>
+              </Show>
+            </div>
+
             <For each={days()}>
               {(day) => {
                 const heading = createMemo(() => formatDayHeading(day.date, today));
@@ -286,13 +345,14 @@ export default function Timeline(): JSX.Element {
                         <Entry
                           item={item}
                           editing={editing()?.id === item.id}
-                          deleting={isDeleting(item.id)}
+                          selecting={selecting()}
+                          selected={selected().has(item.id)}
                           draft={draft}
                           saved={saved}
                           onDraft={setDraft}
                           onEdit={() => startEditing(item)}
                           onCommit={() => void commitEdit()}
-                          onDelete={() => remove(item)}
+                          onToggle={() => toggleSelected(item.id)}
                         />
                       )}
                     </For>
@@ -305,7 +365,45 @@ export default function Timeline(): JSX.Element {
       </div>
 
       <div class="capture-dock">
-        <CaptureBar onSend={capture} knownTags={knownTags()} />
+        <Show when={selecting()} fallback={<CaptureBar onSend={capture} knownTags={knownTags()} />}>
+          <div class="select-bar" role="toolbar" aria-label="まとめて削除">
+            <Show
+              when={confirming()}
+              fallback={
+                <>
+                  <span class="select-bar-label">{selected().size}件選択中</span>
+                  <button
+                    type="button"
+                    class="select-bar-danger"
+                    disabled={selected().size === 0}
+                    onClick={() => setConfirming(true)}
+                  >
+                    <Icon name="trash" size={14} />
+                    削除 ({selected().size}件)
+                  </button>
+                  <button type="button" class="select-bar-plain" onClick={exitSelecting}>
+                    キャンセル
+                  </button>
+                </>
+              }
+            >
+              <span class="select-bar-label">
+                {selected().size}件のエントリを削除します。よろしいですか？
+              </span>
+              <button
+                type="button"
+                class="select-bar-danger"
+                disabled={deleting()}
+                onClick={() => void runDelete()}
+              >
+                削除する
+              </button>
+              <button type="button" class="select-bar-plain" onClick={() => setConfirming(false)}>
+                戻る
+              </button>
+            </Show>
+          </div>
+        </Show>
       </div>
 
       <Show when={shell.popover() === "calendar"}>

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -275,9 +275,10 @@ export default function Timeline(): JSX.Element {
       const plan = planBulkDelete(entries().filter((item) => ids.has(item.id)));
       // 同じ日の index は前の削除で行が繰り上がると意味が変わるので、並列にせず順に消す
       for (const target of plan) {
+        // oxlint-disable-next-line no-await-in-loop
         await typedInvoke("delete_timeline_entry", { date: target.date, index: target.index });
       }
-      await Promise.all([...new Set(plan.map((t) => t.date))].map(reloadDay));
+      await Promise.all([...new Set(plan.map((t) => t.date))].map((date) => reloadDay(date)));
       exitSelecting();
       shell.showToast(`${plan.length}件のエントリを削除しました`);
     } finally {
@@ -301,8 +302,8 @@ export default function Timeline(): JSX.Element {
         exitSelecting();
       }
     };
-    window.addEventListener("keydown", onKey);
-    onCleanup(() => window.removeEventListener("keydown", onKey));
+    globalThis.addEventListener("keydown", onKey);
+    onCleanup(() => globalThis.removeEventListener("keydown", onKey));
   });
 
   return (


### PR DESCRIPTION
## 1. 概要

- エントリ本文のすぐ横にあるゴミ箱ボタンがワンタップで削除を始めるため、誤操作で消しやすかった。ワンタップの破壊操作そのものを廃止する
- 削除は「選択モード → 削除 (n件) → インライン確認」の一本のみにする。確認というワンクッションを設けたので、5 秒 Undo(tombstone)は二重の安全装置になり、関連コードごと廃止した
- `delete_timeline_entry` は date + index で行を指すため、先に消した行の繰り上がりで後続の index がずれる。日付ごとに index 降順へ並べる `planBulkDelete` を純関数に切り出し(単体テスト付き)、直列に実行する
- 確認バーは画面下の入力バー(capture dock)を選択中だけ差し替える形にし、新しい浮き UI を増やさない。Esc は確認 → 選択 → 通常と一段ずつ戻る

## 2. 図解

削除フローの状態遷移。旧フロー(ゴミ箱ワンタップ → 5 秒 Undo)は消滅し、実行に至るには必ず確認を通る。

```mermaid
stateDiagram-v2
  [*] --> Normal
  Normal --> Selecting: 「選択」
  Selecting --> Confirming: エントリを選び「削除 (n件)」
  Confirming --> Selecting: 「戻る」/ Esc / 選び直し
  Confirming --> Normal: 「削除する」→ planBulkDelete で直列実行
  Selecting --> Normal: 「キャンセル」/ Esc
```

## 3. 変更ファイル

| ファイル                            | 変更       | 理由                                                         |
| ----------------------------------- | ---------- | ------------------------------------------------------------ |
| `tauri-app/src/lib/items.ts`        | +26 / -0   | index ずれを防ぐ削除順を決める `planBulkDelete` を追加       |
| `tauri-app/src/lib/items.test.ts`   | +37 / -0   | 同上の 0-1-N テスト(日付混在・降順・選択順の維持)            |
| `tauri-app/src/views/Timeline.tsx`  | +147 / -49 | 即時削除+Undo を廃止し、選択モードと確認バーに置き換え       |
| `tauri-app/src/styles/timeline.css` | +116 / -49 | entry-tools/tombstone を削除、選択行・確認バーのスタイル追加 |
| `tauri-app/src/components/Icon.tsx` | +1 / -0    | 未選択チェック用の `circle` アイコン登録                     |

**合計:** 5 ファイル, +327 / -98

## 4. テスト

- [x] `pnpm test` — 20 ファイル / 198 件全通過(`planBulkDelete` は Red → Green を確認)
- [x] `pnpm exec tsgo -b` — 型エラーなし
- [x] `nix fmt` — 適用済み(import の折返し 1 箇所のみ)
- [ ] タッチ端末(Android)での選択モードの操作感確認
