### PR TITLE
feat(editor): label code blocks and preview mermaid while editing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ If a dependency adds weight, it must justify itself against lightness.
 | Editor           | Milkdown (headless, SolidJS integration)    |
 | Syntax highlight | Shiki                                       |
 | Markdown         | markdown-it + Shiki                         |
-| Diagrams         | Mermaid (dynamic import, preview only)      |
+| Diagrams         | Mermaid (dynamic import)                    |
 
 ## Milkdown Plugins
 
@@ -39,6 +39,7 @@ If a dependency adds weight, it must justify itself against lightness.
 | External | `highlight`               | `@milkdown/plugin-highlight`           | Shiki syntax highlighting     |
 | Custom   | `exitCodeBlockPlugin`     | `src/lib/exit-code-block-plugin.ts`    | Mod-Enter to exit code blocks |
 | Custom   | `createPlaceholderPlugin` | `src/lib/placeholder-plugin.ts`        | Empty document placeholder    |
+| Custom   | `mermaidPreviewPlugin`    | `src/lib/mermaid-preview-plugin.ts`    | In-editor mermaid preview     |
 
 Rejected plugins (with reasons):
 

--- a/tauri-app/src/components/MilkdownEditor.tsx
+++ b/tauri-app/src/components/MilkdownEditor.tsx
@@ -11,6 +11,7 @@ import { highlight, highlightPluginConfig } from "@milkdown/plugin-highlight";
 import { createParser } from "@milkdown/plugin-highlight/shiki";
 import { getHighlighter } from "../lib/highlighter";
 import { exitCodeBlockPlugin } from "../lib/exit-code-block-plugin";
+import { mermaidPreviewPlugin } from "../lib/mermaid-preview-plugin";
 import { createPlaceholderPlugin } from "../lib/placeholder-plugin";
 import { getShikiTheme } from "../lib/theme";
 import type { JSX } from "solid-js";
@@ -64,6 +65,7 @@ export default function MilkdownEditor(props: MilkdownEditorProps): JSX.Element 
       .use(trailing)
       .use(linkTooltipPlugin)
       .use(exitCodeBlockPlugin)
+      .use(mermaidPreviewPlugin)
       .use(props.placeholder ? createPlaceholderPlugin(props.placeholder) : [])
       .create();
 

--- a/tauri-app/src/lib/mermaid-preview-plugin.ts
+++ b/tauri-app/src/lib/mermaid-preview-plugin.ts
@@ -1,0 +1,148 @@
+import { $view } from "@milkdown/kit/utils";
+import { codeBlockSchema } from "@milkdown/kit/preset/commonmark";
+import { renderDiagrams } from "./mermaid";
+import { isMermaidLanguage, createDebouncedDiagramRenderer } from "./mermaid-preview";
+import type { Node } from "@milkdown/kit/prose/model";
+import type { NodeView, ViewMutationRecord } from "@milkdown/kit/prose/view";
+
+/** 打鍵が止まったと見なすまでの時間。短いと打鍵中の構文エラー描画が増えるだけ */
+const RENDER_DELAY_MS = 400;
+
+/**
+ * code_block の node view。pre>code の既定構造は保ちつつ、mermaid のときだけ
+ * 直下にレンダリング済みの図をぶら下げる。
+ *
+ * widget decoration ではなく node view にしたのは、図の寿命がブロックの寿命と
+ * 一致するから。decoration set はトランザクションごとに再計算・再マッピングが
+ * 要るが、node view ならインスタンスがブロックごとに立ち、debounce タイマーや
+ * 直前の SVG をローカルに持てる。Shiki(@milkdown/plugin-highlight)は inline
+ * decoration しか使わないので、contentDOM を公開していれば干渉しない。
+ */
+class CodeBlockPreviewView implements NodeView {
+  dom: HTMLElement;
+  contentDOM: HTMLElement;
+
+  private readonly pre: HTMLElement;
+  private preview: HTMLElement | undefined;
+  private lastSource: string | undefined;
+  private lastSvg: string | undefined;
+
+  private readonly renderer = createDebouncedDiagramRenderer(
+    async (source) => {
+      const [svg] = await renderDiagrams([source]);
+      return svg ?? null;
+    },
+    (svg) => this.applyResult(svg),
+    RENDER_DELAY_MS,
+  );
+
+  constructor(node: Node) {
+    this.dom = document.createElement("div");
+    this.dom.className = "code-block-view";
+    this.pre = document.createElement("pre");
+    this.contentDOM = document.createElement("code");
+    this.pre.append(this.contentDOM);
+    this.dom.append(this.pre);
+    this.sync(node, { initial: true });
+  }
+
+  update(node: Node): boolean {
+    if (node.type.name !== "code_block") {
+      return false;
+    }
+    this.sync(node, { initial: false });
+    return true;
+  }
+
+  ignoreMutation(mutation: ViewMutationRecord): boolean {
+    if (mutation.type === "selection") {
+      return false;
+    }
+    // 図の差し込みや data-language の付け替えを ProseMirror が「外部からの
+    // 編集」と誤認して re-parse すると、カーソルとスクロールが飛ぶ
+    return !this.contentDOM.contains(mutation.target);
+  }
+
+  destroy(): void {
+    this.renderer.dispose();
+  }
+
+  private sync(node: Node, { initial }: { initial: boolean }): void {
+    const language = node.attrs.language as string;
+
+    // node view が立つと schema の toDOM は使われない。言語ラベルの CSS が
+    // 読む data-language はここで出し直す
+    if (language) {
+      this.pre.dataset.language = language;
+    } else {
+      delete this.pre.dataset.language;
+    }
+
+    if (!isMermaidLanguage(language)) {
+      this.resetPreview();
+      return;
+    }
+
+    const source = node.textContent;
+    // update は選択移動やハイライト装飾の更新でも呼ばれる。ソースが同じなら
+    // 描画し直さない(変換の局所化)
+    if (source === this.lastSource) {
+      return;
+    }
+    this.lastSource = source;
+
+    if (source.trim() === "") {
+      this.resetPreview();
+      return;
+    }
+    this.renderer.request(source, { immediate: initial });
+  }
+
+  private applyResult(svg: string | null): void {
+    if (svg === null) {
+      // 打鍵の途中は書きかけの構文になるのが普通。最後に描けた図を残して
+      // 落ち着きを保ち、まだ一度も描けていないときだけ控えめに伝える
+      if (!this.lastSvg) {
+        this.showNotice("図を描画できません");
+      }
+      return;
+    }
+    this.lastSvg = svg;
+    const preview = this.ensurePreview();
+    preview.classList.remove("is-error");
+    preview.innerHTML = svg;
+  }
+
+  private showNotice(text: string): void {
+    const preview = this.ensurePreview();
+    preview.classList.add("is-error");
+    preview.textContent = text;
+  }
+
+  private ensurePreview(): HTMLElement {
+    if (!this.preview) {
+      this.preview = document.createElement("div");
+      this.preview.className = "mermaid-editor-preview";
+      // 図は読み取り専用。編集対象はあくまで上のコードブロック
+      this.preview.contentEditable = "false";
+      this.dom.append(this.preview);
+    }
+    return this.preview;
+  }
+
+  private resetPreview(): void {
+    // 予約済みの描画を残すと、畳んだ後から図が生えてくる
+    this.renderer.cancel();
+    this.lastSource = undefined;
+    this.lastSvg = undefined;
+    this.preview?.remove();
+    this.preview = undefined;
+  }
+}
+
+export const mermaidPreviewPlugin = $view(
+  codeBlockSchema.node,
+  () =>
+    (node): NodeView =>
+      new CodeBlockPreviewView(node),
+);

--- a/tauri-app/src/lib/mermaid-preview.test.ts
+++ b/tauri-app/src/lib/mermaid-preview.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { isMermaidLanguage, createDebouncedDiagramRenderer } from "./mermaid-preview";
+
+const DELAY = 300;
+
+type RenderFn = (source: string) => Promise<string | null>;
+type ResultFn = (svg: string | null) => void;
+
+/** 描画完了の順番をテスト側で並べ替えるための、外から解決できる Promise */
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let stored!: (value: T) => void;
+  // 解決を外から握るには executor を書くしかない
+  // oxlint-disable-next-line promise/avoid-new
+  const promise = new Promise<T>((resolve) => {
+    stored = resolve;
+  });
+  return { promise, resolve: stored };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("isMermaidLanguage", () => {
+  it("matches the exact language", () => {
+    expect(isMermaidLanguage("mermaid")).toBe(true);
+  });
+
+  // フェンスの info 文字列は手打ちなので、大文字や前後の空白はよくある揺れ
+  it("ignores case and surrounding whitespace", () => {
+    expect(isMermaidLanguage("Mermaid")).toBe(true);
+    expect(isMermaidLanguage(" mermaid ")).toBe(true);
+  });
+
+  it("rejects other languages and the empty language", () => {
+    expect(isMermaidLanguage("rust")).toBe(false);
+    expect(isMermaidLanguage("")).toBe(false);
+  });
+});
+
+describe("createDebouncedDiagramRenderer", () => {
+  it("renders immediately when asked to", async () => {
+    const render = vi.fn<RenderFn>().mockResolvedValue("<svg/>");
+    const onResult = vi.fn<ResultFn>();
+    const renderer = createDebouncedDiagramRenderer(render, onResult, DELAY);
+
+    renderer.request("graph TD;", { immediate: true });
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalledWith("<svg/>"));
+
+    expect(render).toHaveBeenCalledExactlyOnceWith("graph TD;");
+  });
+
+  it("waits for the delay before rendering", () => {
+    const render = vi.fn<RenderFn>().mockResolvedValue("<svg/>");
+    const renderer = createDebouncedDiagramRenderer(render, vi.fn<ResultFn>(), DELAY);
+
+    renderer.request("graph TD;");
+    vi.advanceTimersByTime(DELAY - 1);
+    expect(render).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(render).toHaveBeenCalledExactlyOnceWith("graph TD;");
+  });
+
+  // 1 打鍵ごとに mermaid を回しては重すぎる。描くのは手が止まったあとの最新版だけ
+  it("collapses a burst of requests into one render of the newest source", () => {
+    const render = vi.fn<RenderFn>().mockResolvedValue("<svg/>");
+    const renderer = createDebouncedDiagramRenderer(render, vi.fn<ResultFn>(), DELAY);
+
+    renderer.request("graph T");
+    vi.advanceTimersByTime(DELAY - 50);
+    renderer.request("graph TD");
+    vi.advanceTimersByTime(DELAY - 50);
+    renderer.request("graph TD;");
+    vi.advanceTimersByTime(DELAY);
+
+    expect(render).toHaveBeenCalledExactlyOnceWith("graph TD;");
+  });
+
+  // 描画は非同期なので、古い描画が新しい描画を追い越して届くことがある
+  it("drops a stale result that resolves after a newer request", async () => {
+    const first = deferred<string | null>();
+    const second = deferred<string | null>();
+    const render = vi.fn<RenderFn>();
+    render.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const onResult = vi.fn<ResultFn>();
+    const renderer = createDebouncedDiagramRenderer(render, onResult, DELAY);
+
+    renderer.request("old", { immediate: true });
+    renderer.request("new", { immediate: true });
+    second.resolve("<svg new/>");
+    first.resolve("<svg old/>");
+    await vi.waitFor(() => expect(onResult).toHaveBeenCalled());
+
+    expect(onResult).toHaveBeenCalledExactlyOnceWith("<svg new/>");
+  });
+
+  it("cancel discards both the pending timer and in-flight results", async () => {
+    const inFlight = deferred<string | null>();
+    const render = vi.fn<RenderFn>().mockReturnValueOnce(inFlight.promise);
+    const onResult = vi.fn<ResultFn>();
+    const renderer = createDebouncedDiagramRenderer(render, onResult, DELAY);
+
+    renderer.request("graph TD;", { immediate: true });
+    renderer.request("graph TD;x");
+    renderer.cancel();
+    vi.advanceTimersByTime(DELAY);
+    inFlight.resolve("<svg/>");
+    await Promise.resolve();
+
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(onResult).not.toHaveBeenCalled();
+  });
+
+  it("dispose stops all future requests", () => {
+    const render = vi.fn<RenderFn>().mockResolvedValue("<svg/>");
+    const renderer = createDebouncedDiagramRenderer(render, vi.fn<ResultFn>(), DELAY);
+
+    renderer.dispose();
+    renderer.request("graph TD;", { immediate: true });
+    vi.advanceTimersByTime(DELAY);
+
+    expect(render).not.toHaveBeenCalled();
+  });
+});

--- a/tauri-app/src/lib/mermaid-preview.ts
+++ b/tauri-app/src/lib/mermaid-preview.ts
@@ -1,0 +1,75 @@
+/**
+ * フェンスの言語が mermaid かどうか。info 文字列は手打ちなので、
+ * 大文字小文字や前後の空白の揺れは同じ言語として扱う。
+ */
+export function isMermaidLanguage(language: string): boolean {
+  return language.trim().toLowerCase() === "mermaid";
+}
+
+interface RequestOptions {
+  /** ノート起動時など、既に完成しているソースは待たせず即描く */
+  immediate?: boolean;
+}
+
+export interface DebouncedDiagramRenderer {
+  request(source: string, options?: RequestOptions): void;
+  /** 予約済み・進行中の描画を捨てる。プレビュー自体を畳むときに使う */
+  cancel(): void;
+  dispose(): void;
+}
+
+/**
+ * mermaid の描画を「手が止まってから 1 回」にまとめる。描画は非同期なので、
+ * 古い描画が新しい描画を追い越して届くことがあり、版数で最新以外を捨てる。
+ * render 関数を注入させるのは、重い mermaid 本体なしでこの制御をテストするため。
+ */
+export function createDebouncedDiagramRenderer(
+  render: (source: string) => Promise<string | null>,
+  onResult: (svg: string | null) => void,
+  delayMs: number,
+): DebouncedDiagramRenderer {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let version = 0;
+  let disposed = false;
+
+  const clearTimer = (): void => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  const run = async (source: string): Promise<void> => {
+    const current = ++version;
+    const svg = await render(source);
+    if (!disposed && current === version) {
+      onResult(svg);
+    }
+  };
+
+  return {
+    request(source, options) {
+      if (disposed) {
+        return;
+      }
+      clearTimer();
+      if (options?.immediate) {
+        void run(source);
+        return;
+      }
+      timer = setTimeout(() => {
+        timer = undefined;
+        void run(source);
+      }, delayMs);
+    },
+    cancel() {
+      clearTimer();
+      // 進行中の結果も版数を進めて無効化する
+      version += 1;
+    },
+    dispose() {
+      disposed = true;
+      clearTimer();
+    },
+  };
+}

--- a/tauri-app/src/styles/editor.css
+++ b/tauri-app/src/styles/editor.css
@@ -97,6 +97,27 @@
   pointer-events: none;
 }
 
+/* mermaid のエディタ内プレビュー: コードブロックの直下に描いた図をぶら下げる。
+   幅に合わせて縮め、mermaid が SVG に付ける max-width(原寸)以上には広げない */
+.milkdown-editor .mermaid-editor-preview {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--size-2);
+  user-select: none;
+}
+
+.milkdown-editor .mermaid-editor-preview svg {
+  max-width: 100%;
+  height: auto;
+}
+
+/* まだ一度も描けていないときだけ出す控えめな知らせ */
+.milkdown-editor .mermaid-editor-preview.is-error {
+  justify-content: flex-start;
+  font-size: var(--font-size-0);
+  color: var(--app-text-muted);
+}
+
 .milkdown-editor blockquote {
   border-left: 3px solid var(--app-border);
   padding-left: var(--size-3);

--- a/tauri-app/src/styles/editor.css
+++ b/tauri-app/src/styles/editor.css
@@ -79,6 +79,24 @@
   padding: 0;
 }
 
+/* 言語ラベル: code_block が pre に書き出す data-language を attr() で見せるだけ。
+   DOM ノードもプラグインも増やさない、いちばん軽い形 */
+.milkdown-editor pre[data-language] {
+  position: relative;
+}
+
+.milkdown-editor pre[data-language]::before {
+  content: attr(data-language);
+  position: absolute;
+  top: var(--size-1);
+  right: var(--size-2);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-0);
+  line-height: 1;
+  color: var(--app-text-muted);
+  pointer-events: none;
+}
+
 .milkdown-editor blockquote {
   border-left: 3px solid var(--app-border);
   padding-left: var(--size-3);


### PR DESCRIPTION
## 1. 概要

- ```mermaid と書いても素のコードブロックと同じ見た目で、何を編集しているのかわからなかった。mermaid ブロックの直下に描画済みの図を常設プレビューとして出す
- 同様に全コードブロックへ言語ラベルを出す。commonmark の `code_block` は `pre` に `data-language` を出すため、ラベル自体は CSS の `attr()` だけで済む(nodeView 化後は toDOM が使われないので nodeView 側で属性を出し直す)
- 実装方式は widget decoration ではなく `code_block` の nodeView。図の寿命がブロックの寿命と一致し、debounce タイマーと直近 SVG をインスタンスにローカルに持てる。Shiki(`@milkdown/plugin-highlight`)は inline decoration のみと実物で確認済みで、contentDOM を公開する nodeView とは干渉しない
- 打鍵中は書きかけの構文になるのが普通なので、エラー時は最後に成功した図を残す。描画は debounce 400ms+版数管理で、追い越して届いた古い非同期結果を破棄する(この制御は render 関数注入で mermaid 本体なしに単体テスト)
- 編集性能の原則を維持: ソースが同じなら再描画せず、`ignoreMutation` で図の差し込みによるカーソル・スクロール破壊を防ぎ、mermaid 本体は dynamic import のまま(ビルドで分離チャンクを確認)

## 2. 図解

エディタ内コードブロックの新しい描画経路。緑枠が追加された要素で、`code_block` ノード自体と pre/code 構造は従来のまま。

```mermaid
flowchart LR
  cb["code_block ノード"] --> view["CodeBlockPreviewView<br/>(nodeView)"]
  view --> pre["pre[data-language] &gt; code"]
  pre -.->|"CSS ::before"| label["言語ラベル"]
  view -->|"language=mermaid のみ"| sched["debounce 400ms<br/>最新版勝ちスケジューラ"]
  sched --> svg["mermaid-editor-preview<br/>(SVG・編集不可)"]
  classDef added stroke:#3fb950,stroke-width:3px
  class view,label,sched,svg added
```

## 3. 変更ファイル

| ファイル                                    | 変更      | 理由                                                       |
| ------------------------------------------- | --------- | ---------------------------------------------------------- |
| `tauri-app/src/lib/mermaid-preview-plugin.ts` | +148 / -0 | code_block nodeView(言語属性の出し直し+図の差し込み)       |
| `tauri-app/src/lib/mermaid-preview.ts`      | +75 / -0  | 言語判定と debounce/最新版勝ちスケジューラ(テスト可能に分離) |
| `tauri-app/src/lib/mermaid-preview.test.ts` | +129 / -0 | スケジューラの 9 ケース(debounce・追い越し・cancel/dispose) |
| `tauri-app/src/styles/editor.css`           | +39 / -0  | 言語ラベル(`attr(data-language)`)とプレビューのスタイル     |
| `tauri-app/src/components/MilkdownEditor.tsx` | +2 / -0 | プラグイン登録                                             |
| `CLAUDE.md`                                 | +2 / -1   | Milkdown Plugins 表への追記と mermaid の記述更新           |

**合計:** 6 ファイル, +395 / -1

## 4. テスト

- [x] `pnpm test` — 21 ファイル / 204 件全通過(新規 9 件を含む)
- [x] `tsgo -b --noEmit` / `oxlint src/` / `pnpm knip` — すべてエラー・警告なし
- [x] `pnpm run build` — 成功。mermaid が分離チャンク(`mermaid.core-*.js`)のままであることを確認
- [x] `nix fmt` — 差分なし
- [ ] 実アプリでの目視確認(図の見た目、コードブロック編集中のカーソル挙動)
