### PR TITLE
feat(note): expose frontmatter in a metadata panel and drop filename display

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,7 +14,7 @@ pub use error::CoreError;
 pub use note::error::NoteError;
 pub use note::{
     NoteSummary, create_draft_note, delete_note, list_notes, read_note, read_note_by_filename,
-    repair_notes, update_note,
+    read_note_meta, repair_notes, update_note, update_note_meta,
 };
 pub use search::{HitKind, SearchHit, search_all};
 pub use timeline::error::TimelineError;
@@ -24,4 +24,6 @@ pub use timeline::{
 };
 pub use utils::device::Context as DeviceContext;
 pub use utils::frontmatter;
+/// 1 件ぶんのノートメタデータ。中身は frontmatter そのもの。
+pub use utils::frontmatter::NoteFrontmatter as NoteMeta;
 pub use utils::validated::NoteFilename;

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -48,6 +48,27 @@ pub fn delete_note(base_dir: &Path, filename: &NoteFilename) -> Result<(), CoreE
     Notes::new(base_dir.to_path_buf()).delete(filename)
 }
 
+/// frontmatter を 1 件ぶんそのまま返す。`NoteSummary` は一覧向けの要約
+/// (本文プレビュー入り・タグは本文の `#記法` と合流済み)で、こちらは
+/// メタデータ編集パネルが見る「ファイルに書いてある記録」そのもの。
+pub fn read_note_meta(
+    base_dir: &Path,
+    filename: &NoteFilename,
+) -> Result<frontmatter::NoteFrontmatter, CoreError> {
+    Notes::new(base_dir.to_path_buf()).read_meta(filename)
+}
+
+/// time と tags だけを差し替える。本文はもちろん、context も「どの端末で
+/// 書いたか」の記録なので編集の対象にしない。
+pub fn update_note_meta(
+    base_dir: &Path,
+    filename: &NoteFilename,
+    time: chrono::DateTime<chrono::FixedOffset>,
+    tags: &[String],
+) -> Result<(), CoreError> {
+    Notes::new(base_dir.to_path_buf()).update_meta(filename, time, tags)
+}
+
 /// 過去の編集で本文に混入した化けメタデータを直す。直したファイル数を返す。
 pub fn repair_notes(base_dir: &Path) -> Result<usize, CoreError> {
     repair::repair_all(&crate::utils::paths::notes_dir(base_dir))
@@ -257,5 +278,99 @@ mod tests {
     #[test]
     fn test_validate_rejects_non_md_extension() {
         assert!(NoteFilename::parse("evil.txt").is_err());
+    }
+
+    fn filename_of(path: &Path) -> NoteFilename {
+        NoteFilename::parse(path.file_name().unwrap().to_str().unwrap()).unwrap()
+    }
+
+    fn sample_time() -> chrono::DateTime<chrono::FixedOffset> {
+        use chrono::TimeZone as _;
+        chrono::FixedOffset::east_opt(9 * 3600)
+            .unwrap()
+            .with_ymd_and_hms(2026, 5, 3, 15, 39, 0)
+            .unwrap()
+    }
+
+    #[test]
+    fn read_note_meta_returns_time_tags_and_context() {
+        let tmp = TempDir::new().unwrap();
+        let path =
+            create_draft_note(tmp.path(), "body", &["sync".to_string()], &mock_context()).unwrap();
+
+        let meta = read_note_meta(tmp.path(), &filename_of(&path)).unwrap();
+
+        assert_eq!(meta.tags, vec!["sync"]);
+        assert_eq!(meta.context.unwrap().battery, Some(50));
+    }
+
+    #[test]
+    fn read_note_meta_not_found() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("data/notes")).unwrap();
+        let filename = NoteFilename::parse("nonexistent.md").unwrap();
+
+        let result = read_note_meta(tmp.path(), &filename);
+
+        assert!(matches!(result, Err(CoreError::NotFound(_))));
+    }
+
+    #[test]
+    fn update_note_meta_replaces_time_and_tags() {
+        let tmp = TempDir::new().unwrap();
+        let path =
+            create_draft_note(tmp.path(), "body", &["old".to_string()], &mock_context()).unwrap();
+        let filename = filename_of(&path);
+
+        update_note_meta(tmp.path(), &filename, sample_time(), &["log".to_string()]).unwrap();
+
+        let meta = read_note_meta(tmp.path(), &filename).unwrap();
+        assert_eq!(meta.time, sample_time());
+        assert_eq!(meta.tags, vec!["log"]);
+    }
+
+    /// メタデータの編集で本文が動いてはいけない。逆(本文編集がメタデータを
+    /// 保つ)は `update_note` 側のテストが見ている。
+    #[test]
+    fn update_note_meta_keeps_body_and_context() {
+        let tmp = TempDir::new().unwrap();
+        let path =
+            create_draft_note(tmp.path(), "# Title\nbody", &[], &mock_context()).unwrap();
+        let filename = filename_of(&path);
+
+        update_note_meta(tmp.path(), &filename, sample_time(), &[]).unwrap();
+
+        assert_eq!(read_note(&path).unwrap(), "# Title\nbody");
+        let meta = read_note_meta(tmp.path(), &filename).unwrap();
+        assert_eq!(meta.context.unwrap().battery, Some(50));
+    }
+
+    /// frontmatter が読めないファイルに time/tags をでっち上げて書き込むと、
+    /// 壊れた記録が正当なものに見えてしまう。書かずに断る。
+    #[test]
+    fn update_note_meta_rejects_broken_frontmatter() {
+        let tmp = TempDir::new().unwrap();
+        let notes_dir = tmp.path().join("data/notes");
+        fs::create_dir_all(&notes_dir).unwrap();
+        let broken = "---\ntime: [broken\n---\nbody";
+        fs::write(notes_dir.join("20260101_120000.md"), broken).unwrap();
+        let filename = NoteFilename::parse("20260101_120000.md").unwrap();
+
+        let result = update_note_meta(tmp.path(), &filename, sample_time(), &[]);
+
+        assert!(matches!(result, Err(CoreError::Parse(_))));
+        let content = fs::read_to_string(notes_dir.join("20260101_120000.md")).unwrap();
+        assert_eq!(content, broken);
+    }
+
+    #[test]
+    fn update_note_meta_not_found() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("data/notes")).unwrap();
+        let filename = NoteFilename::parse("nonexistent.md").unwrap();
+
+        let result = update_note_meta(tmp.path(), &filename, sample_time(), &[]);
+
+        assert!(matches!(result, Err(CoreError::NotFound(_))));
     }
 }

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -334,8 +334,7 @@ mod tests {
     #[test]
     fn update_note_meta_keeps_body_and_context() {
         let tmp = TempDir::new().unwrap();
-        let path =
-            create_draft_note(tmp.path(), "# Title\nbody", &[], &mock_context()).unwrap();
+        let path = create_draft_note(tmp.path(), "# Title\nbody", &[], &mock_context()).unwrap();
         let filename = filename_of(&path);
 
         update_note_meta(tmp.path(), &filename, sample_time(), &[]).unwrap();

--- a/core/src/note/repository.rs
+++ b/core/src/note/repository.rs
@@ -108,6 +108,36 @@ impl Notes {
         Ok(())
     }
 
+    pub(crate) fn read_meta(&self, filename: &NoteFilename) -> Result<NoteFrontmatter, CoreError> {
+        let content = fs::read_to_string(self.existing_note_path(filename)?)?;
+        let (fm, _body) = frontmatter::parse::<NoteFrontmatter>(&content)?;
+        Ok(fm)
+    }
+
+    /// time と tags だけを差し替えて書き戻す。本文と context には触れない。
+    ///
+    /// frontmatter が読めないファイルは `update` と違って作り直さない。
+    /// 本文の保存は失敗させられないが、メタデータ編集はでっち上げた記録を
+    /// 書くくらいなら断ったほうがいい。
+    pub(crate) fn update_meta(
+        &self,
+        filename: &NoteFilename,
+        time: chrono::DateTime<chrono::FixedOffset>,
+        tags: &[String],
+    ) -> Result<(), CoreError> {
+        let path = self.existing_note_path(filename)?;
+        let content = fs::read_to_string(&path)?;
+        let (existing, body) = frontmatter::parse::<NoteFrontmatter>(&content)?;
+
+        let fm = NoteFrontmatter {
+            time,
+            tags: tags.to_vec(),
+            context: existing.context,
+        };
+        write_atomic(&path, frontmatter::render(&fm, body)?)?;
+        Ok(())
+    }
+
     pub(crate) fn delete(&self, filename: &NoteFilename) -> Result<(), CoreError> {
         fs::remove_file(self.existing_note_path(filename)?)?;
         Ok(())

--- a/core/src/note/repository.rs
+++ b/core/src/note/repository.rs
@@ -58,7 +58,10 @@ impl Notes {
         Ok(summaries)
     }
 
-    pub(crate) fn read(&self, filename: &NoteFilename) -> Result<String, CoreError> {
+    /// 検証済みのノート名を実ファイルパスに解決する。名前の検証だけでは
+    /// シンボリックリンク越しに notes の外へ出られるので、canonicalize した
+    /// 実体が notes ディレクトリ配下にあることまで確かめる。
+    fn existing_note_path(&self, filename: &NoteFilename) -> Result<PathBuf, CoreError> {
         let fname = filename.as_str();
         let notes_dir = self.notes_dir();
         let file_path = notes_dir.join(fname);
@@ -72,8 +75,11 @@ impl Notes {
         if !canonical_file_path.starts_with(&canonical_notes_dir) {
             return Err(CoreError::PathTraversal(fname.to_string()));
         }
+        Ok(canonical_file_path)
+    }
 
-        let content = fs::read_to_string(canonical_file_path)?;
+    pub(crate) fn read(&self, filename: &NoteFilename) -> Result<String, CoreError> {
+        let content = fs::read_to_string(self.existing_note_path(filename)?)?;
         Ok(frontmatter::strip(&content).to_string())
     }
 
@@ -103,21 +109,7 @@ impl Notes {
     }
 
     pub(crate) fn delete(&self, filename: &NoteFilename) -> Result<(), CoreError> {
-        let fname = filename.as_str();
-        let notes_dir = self.notes_dir();
-        let file_path = notes_dir.join(fname);
-
-        if !file_path.exists() {
-            return Err(CoreError::NotFound(file_path.to_string_lossy().to_string()));
-        }
-
-        let canonical_notes_dir = fs::canonicalize(&notes_dir)?;
-        let canonical_file_path = fs::canonicalize(&file_path)?;
-        if !canonical_file_path.starts_with(&canonical_notes_dir) {
-            return Err(CoreError::PathTraversal(fname.to_string()));
-        }
-
-        fs::remove_file(canonical_file_path)?;
+        fs::remove_file(self.existing_note_path(filename)?)?;
         Ok(())
     }
 }

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -23,7 +23,7 @@ pub mod widget_bridge;
 mod widget_summary;
 
 use device::ClientContext;
-use magical_merchant_core::{NoteFilename, NoteSummary, SearchHit};
+use magical_merchant_core::{NoteFilename, NoteMeta, NoteSummary, SearchHit};
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_deep_link::DeepLinkExt as _;
 
@@ -95,6 +95,29 @@ fn read_note(handle: AppHandle, filename: String) -> Result<String, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
     let filename = NoteFilename::parse(&filename).map_err(|e| e.to_string())?;
     magical_merchant_core::read_note_by_filename(&base_dir, &filename).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn read_note_meta(handle: AppHandle, filename: String) -> Result<NoteMeta, String> {
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    let filename = NoteFilename::parse(&filename).map_err(|e| e.to_string())?;
+    magical_merchant_core::read_note_meta(&base_dir, &filename).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn update_note_meta(
+    handle: AppHandle,
+    filename: String,
+    time: String,
+    tags: Vec<String>,
+) -> Result<(), String> {
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    let filename = NoteFilename::parse(&filename).map_err(|e| e.to_string())?;
+    // オフセット付きの RFC 3339 で受ける。素の日時にすると、端末のタイム
+    // ゾーンが変わっただけで同じ入力が別の時刻を指してしまう
+    let time = chrono::DateTime::parse_from_rfc3339(&time).map_err(|e| e.to_string())?;
+    magical_merchant_core::update_note_meta(&base_dir, &filename, time, &tags)
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -233,6 +256,8 @@ pub fn run() {
             update_draft,
             list_notes,
             read_note,
+            read_note_meta,
+            update_note_meta,
             read_timeline,
             list_timeline_dates,
             read_timeline_by_date,

--- a/tauri-app/src/components/Icon.tsx
+++ b/tauri-app/src/components/Icon.tsx
@@ -42,6 +42,7 @@ const ICONS = {
   minus: () => import("@phosphor-icons/core/assets/regular/minus.svg?raw"),
   "magnifying-glass": () => import("@phosphor-icons/core/assets/regular/magnifying-glass.svg?raw"),
   "calendar-blank": () => import("@phosphor-icons/core/assets/regular/calendar-blank.svg?raw"),
+  info: () => import("@phosphor-icons/core/assets/regular/info.svg?raw"),
   x: () => import("@phosphor-icons/core/assets/regular/x.svg?raw"),
   check: () => import("@phosphor-icons/core/assets/regular/check.svg?raw"),
   "check-circle": () => import("@phosphor-icons/core/assets/regular/check-circle.svg?raw"),

--- a/tauri-app/src/components/NoteMetaPopover.tsx
+++ b/tauri-app/src/components/NoteMetaPopover.tsx
@@ -70,10 +70,7 @@ export default function NoteMetaPopover(props: NoteMetaPopoverProps): JSX.Elemen
 
   return (
     <div class="popover note-meta-popover">
-      <Show
-        when={!meta.error}
-        fallback={<p class="note-meta-error">メタデータを読み取れません</p>}
-      >
+      <Show when={!meta.error} fallback={<p class="note-meta-error">メタデータを読み取れません</p>}>
         <Show when={meta()}>
           {(m) => (
             <>

--- a/tauri-app/src/components/NoteMetaPopover.tsx
+++ b/tauri-app/src/components/NoteMetaPopover.tsx
@@ -1,0 +1,160 @@
+import { createEffect, createResource, createSignal, For, Show } from "solid-js";
+import type { JSX } from "solid-js";
+import Icon from "./Icon";
+import { typedInvoke } from "../lib/commands";
+import { addTag, contextRows, resolveEditedTime, toDatetimeLocal } from "../lib/note-meta";
+
+interface NoteMetaPopoverProps {
+  filename: string;
+  /** 保存後に一覧を読み直させる。time を変えると日付グループも動く。 */
+  onSaved: () => Promise<void>;
+  onClose: () => void;
+}
+
+/**
+ * ノートの frontmatter を見せる小さなパネル。
+ *
+ * 編集できるのは time と tags だけ。context は「どの端末で書いたか」の
+ * 記録なので読み取り専用で列挙する。ファイル名は同期とウィジェットが
+ * 指す ID であり、ここにも出さない。
+ */
+export default function NoteMetaPopover(props: NoteMetaPopoverProps): JSX.Element {
+  const [meta] = createResource(
+    () => props.filename,
+    (filename) => typedInvoke("read_note_meta", { filename }),
+  );
+
+  const [timeValue, setTimeValue] = createSignal("");
+  const [tags, setTags] = createSignal<string[]>([]);
+  const [tagInput, setTagInput] = createSignal("");
+  const [saving, setSaving] = createSignal(false);
+  const [failed, setFailed] = createSignal(false);
+
+  // 開いた時点でファイルに書いてある記録を編集の初期値にする
+  createEffect(() => {
+    const m = meta();
+    if (m) {
+      setTimeValue(toDatetimeLocal(m.time));
+      setTags(m.tags);
+    }
+  });
+
+  const commitTagInput = (): void => {
+    setTags((current) => addTag(current, tagInput()));
+    setTagInput("");
+  };
+
+  const save = async (): Promise<void> => {
+    const m = meta();
+    if (!m || saving()) {
+      return;
+    }
+    // 入力欄に打ちかけのタグが残っていたら、それも保存の意思とみなす
+    commitTagInput();
+    setSaving(true);
+    setFailed(false);
+    try {
+      await typedInvoke("update_note_meta", {
+        filename: props.filename,
+        time: resolveEditedTime(m.time, timeValue()),
+        tags: tags(),
+      });
+      await props.onSaved();
+      props.onClose();
+    } catch {
+      setFailed(true);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div class="popover note-meta-popover">
+      <Show
+        when={!meta.error}
+        fallback={<p class="note-meta-error">メタデータを読み取れません</p>}
+      >
+        <Show when={meta()}>
+          {(m) => (
+            <>
+              <label class="note-meta-field">
+                <span class="note-meta-label">作成日時</span>
+                <input
+                  type="datetime-local"
+                  class="note-meta-input"
+                  value={timeValue()}
+                  onInput={(e) => setTimeValue(e.currentTarget.value)}
+                />
+              </label>
+
+              <div class="note-meta-field">
+                <span class="note-meta-label">タグ</span>
+                <div class="note-meta-tags">
+                  <For each={tags()}>
+                    {(tag) => (
+                      <span class="tag-badge">
+                        #{tag}
+                        <button
+                          type="button"
+                          class="note-meta-tag-remove"
+                          aria-label={`タグ ${tag} を外す`}
+                          onClick={() => setTags((current) => current.filter((t) => t !== tag))}
+                        >
+                          <Icon name="x" size={10} />
+                        </button>
+                      </span>
+                    )}
+                  </For>
+                </div>
+                <input
+                  type="text"
+                  class="note-meta-input"
+                  placeholder="タグを追加"
+                  value={tagInput()}
+                  onInput={(e) => setTagInput(e.currentTarget.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      commitTagInput();
+                    }
+                  }}
+                />
+                <span class="note-meta-hint">作成時の記録。本文の #タグ は本文側で編集</span>
+              </div>
+
+              <Show when={contextRows(m().context).length > 0}>
+                <div class="note-meta-field">
+                  <span class="note-meta-label">記録時の環境</span>
+                  <div class="note-meta-context">
+                    <For each={contextRows(m().context)}>
+                      {(row) => (
+                        <>
+                          <span class="note-meta-context-label">{row.label}</span>
+                          <span>{row.value}</span>
+                        </>
+                      )}
+                    </For>
+                  </div>
+                </div>
+              </Show>
+
+              <div class="note-meta-actions">
+                <Show when={failed()}>
+                  <span class="note-meta-error">保存できませんでした</span>
+                </Show>
+                <button
+                  type="button"
+                  class="button-primary note-meta-save"
+                  disabled={saving()}
+                  onClick={() => void save()}
+                >
+                  保存
+                </button>
+              </div>
+            </>
+          )}
+        </Show>
+      </Show>
+    </div>
+  );
+}

--- a/tauri-app/src/layouts/AppLayout.tsx
+++ b/tauri-app/src/layouts/AppLayout.tsx
@@ -126,7 +126,7 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
     // ポータルや overlay の外に出たクリックを取りこぼす
     const onPointerDown = (e: MouseEvent): void => {
       const target = e.target instanceof Element ? e.target : null;
-      if (!target?.closest(".popover, .header-action, .calendar-button")) {
+      if (!target?.closest(".popover, .header-action, .calendar-button, .detail-meta-button")) {
         shell.closePopovers();
       }
     };

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -26,7 +26,7 @@ export interface NoteContext {
 }
 
 /** 1 件ぶんの frontmatter。`time` はオフセット付き RFC 3339。 */
-export interface NoteMeta {
+interface NoteMeta {
   time: string;
   tags: string[];
   context?: NoteContext;

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -9,6 +9,29 @@ export interface Note {
   preview: string;
 }
 
+/**
+ * 記録時の端末情報。core の `Context` は空のフィールドを省いて
+ * シリアライズするので、全部が省略可能。
+ */
+export interface NoteContext {
+  battery?: number;
+  is_charging?: boolean;
+  network_type?: string;
+  location?: { latitude: number; longitude: number };
+  os?: string;
+  os_version?: string;
+  arch?: string;
+  hostname?: string;
+  locale?: string;
+}
+
+/** 1 件ぶんの frontmatter。`time` はオフセット付き RFC 3339。 */
+export interface NoteMeta {
+  time: string;
+  tags: string[];
+  context?: NoteContext;
+}
+
 type HitKind = "timeline" | "note";
 
 export interface SearchHit {
@@ -46,6 +69,8 @@ interface CommandMap {
   };
   list_notes: { args: void; result: Note[] };
   read_note: { args: { filename: string }; result: string };
+  read_note_meta: { args: { filename: string }; result: NoteMeta };
+  update_note_meta: { args: { filename: string; time: string; tags: string[] }; result: void };
   delete_note: { args: { filename: string }; result: void };
   save_document: { args: { body: string; tags: string[] } & ClientArgs; result: void };
   sync_start: { args: void; result: void };
@@ -67,6 +92,7 @@ const MUTATING: ReadonlySet<CommandName> = new Set<CommandName>([
   "delete_timeline_entry",
   "create_draft",
   "update_draft",
+  "update_note_meta",
   "delete_note",
   "save_document",
 ]);

--- a/tauri-app/src/lib/items.test.ts
+++ b/tauri-app/src/lib/items.test.ts
@@ -6,6 +6,7 @@ import {
   groupNotes,
   itemMeta,
   itemTitle,
+  noteCreatedLabel,
   replaceDayItems,
 } from "./items";
 import type { Note } from "./commands";
@@ -128,6 +129,18 @@ describe("itemTitle", () => {
   it("labels an entry with no text", () => {
     const [item] = toTimelineItems("2026-08-04", ["- [09:00:00] "]);
     expect(itemTitle(item)).toBe("(空のメモ)");
+  });
+});
+
+describe("noteCreatedLabel", () => {
+  it("shows the creation time instead of the filename", () => {
+    const [item] = toNoteItems([note({ time: "2026-05-03T15:39:45+09:00" })]);
+    expect(noteCreatedLabel(item)).toBe("2026/05/03 15:39");
+  });
+
+  it("stays empty when the frontmatter had no readable time", () => {
+    const [item] = toNoteItems([note({ time: undefined })]);
+    expect(noteCreatedLabel(item)).toBe("");
   });
 });
 

--- a/tauri-app/src/lib/items.ts
+++ b/tauri-app/src/lib/items.ts
@@ -145,6 +145,16 @@ export function itemMeta(item: Item): string {
   return [date, tags].filter(Boolean).join(" · ");
 }
 
+/**
+ * 詳細ヘッダの作成日時。「2026/05/03 15:39」
+ * ファイル名は同期やウィジェットが指す不変の ID であって、人に見せる
+ * ものではない。人が読むのはこちら。
+ */
+export function noteCreatedLabel(item: NoteItem): string {
+  const date = item.date.replaceAll("-", "/");
+  return [date, item.time].filter(Boolean).join(" ");
+}
+
 export function itemTitle(item: Item): string {
   return item.kind === "timeline" ? firstLine(item.text) || UNTITLED : item.title;
 }

--- a/tauri-app/src/lib/note-meta.test.ts
+++ b/tauri-app/src/lib/note-meta.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { addTag, contextRows, resolveEditedTime, toDatetimeLocal } from "./note-meta";
+
+describe("toDatetimeLocal", () => {
+  it("keeps the wall-clock time as recorded", () => {
+    // 一覧と同じく「書かれた土地の時刻」をそのまま見せる。現在の端末の
+    // タイムゾーンに換算すると、一覧の時刻表示と食い違う
+    expect(toDatetimeLocal("2026-05-03T15:39:45+09:00")).toBe("2026-05-03T15:39");
+  });
+});
+
+describe("resolveEditedTime", () => {
+  it("returns the original untouched when the input did not change", () => {
+    // datetime-local は秒を持たない。素通しの値から組み立て直すと、
+    // 開いて閉じただけで秒が切り捨てられてしまう
+    const original = "2026-05-03T15:39:45+09:00";
+    expect(resolveEditedTime(original, "2026-05-03T15:39")).toBe(original);
+  });
+
+  it("keeps the original offset when the time changes", () => {
+    const original = "2026-05-03T15:39:45+09:00";
+    expect(resolveEditedTime(original, "2026-05-04T08:00")).toBe("2026-05-04T08:00:00+09:00");
+  });
+
+  it("keeps a UTC marker as-is", () => {
+    expect(resolveEditedTime("2026-05-03T15:39:45Z", "2026-05-04T08:00")).toBe(
+      "2026-05-04T08:00:00Z",
+    );
+  });
+});
+
+describe("addTag", () => {
+  it("appends a trimmed tag without the leading hash", () => {
+    expect(addTag(["a"], " #memo ")).toEqual(["a", "memo"]);
+  });
+
+  it("ignores empty input and duplicates", () => {
+    expect(addTag(["a"], "  ")).toEqual(["a"]);
+    expect(addTag(["a"], "a")).toEqual(["a"]);
+  });
+});
+
+describe("contextRows", () => {
+  it("lists only the fields that were recorded", () => {
+    const rows = contextRows({ os: "macos", os_version: "15.3", battery: 82 });
+    expect(rows).toEqual([
+      { label: "OS", value: "macos 15.3" },
+      { label: "バッテリー", value: "82%" },
+    ]);
+  });
+
+  it("marks a charging battery", () => {
+    expect(contextRows({ battery: 20, is_charging: true })).toEqual([
+      { label: "バッテリー", value: "20% (充電中)" },
+    ]);
+  });
+
+  it("renders network, hostname and location", () => {
+    const rows = contextRows({
+      network_type: "WiFi",
+      hostname: "MacBook",
+      location: { latitude: 35.67621, longitude: 139.65031 },
+    });
+    expect(rows).toEqual([
+      { label: "ネットワーク", value: "Wi-Fi" },
+      { label: "ホスト名", value: "MacBook" },
+      { label: "位置", value: "35.6762, 139.6503" },
+    ]);
+  });
+
+  it("returns nothing for a missing context", () => {
+    expect(contextRows(undefined)).toEqual([]);
+    expect(contextRows({})).toEqual([]);
+  });
+});

--- a/tauri-app/src/lib/note-meta.test.ts
+++ b/tauri-app/src/lib/note-meta.test.ts
@@ -59,7 +59,7 @@ describe("contextRows", () => {
     const rows = contextRows({
       network_type: "WiFi",
       hostname: "MacBook",
-      location: { latitude: 35.67621, longitude: 139.65031 },
+      location: { latitude: 35.676_21, longitude: 139.650_31 },
     });
     expect(rows).toEqual([
       { label: "ネットワーク", value: "Wi-Fi" },
@@ -69,7 +69,7 @@ describe("contextRows", () => {
   });
 
   it("returns nothing for a missing context", () => {
-    expect(contextRows(undefined)).toEqual([]);
+    expect(contextRows()).toEqual([]);
     expect(contextRows({})).toEqual([]);
   });
 });

--- a/tauri-app/src/lib/note-meta.ts
+++ b/tauri-app/src/lib/note-meta.ts
@@ -1,0 +1,85 @@
+/**
+ * ノートメタデータパネルの表示・編集ロジック。
+ *
+ * frontmatter の time はオフセット付き RFC 3339。ここでは Date に通さず
+ * 文字列のまま扱う。一覧(`items.ts`)が slice で「書かれた土地の時刻」を
+ * そのまま見せているので、パネルだけ端末のタイムゾーンに換算すると
+ * 同じノートが画面ごとに違う時刻を名乗ることになる。
+ */
+
+import type { NoteContext } from "./commands";
+
+/** RFC 3339 の time を datetime-local input の値(分まで)にする。 */
+export function toDatetimeLocal(rfc3339: string): string {
+  return rfc3339.slice(0, 16);
+}
+
+/**
+ * datetime-local の入力を保存する time に解決する。
+ *
+ * - 入力が元の値のままなら元の文字列を返す。input は秒を持たないので、
+ *   組み立て直すと開いて閉じただけで秒が消える
+ * - 変わっていたら元のオフセットを引き継ぐ。作成時のタイムゾーンは
+ *   context と同じ「記録」であり、編集した端末のもので上書きしない
+ */
+export function resolveEditedTime(original: string, edited: string): string {
+  if (edited === toDatetimeLocal(original)) {
+    return original;
+  }
+  const offset = /(?<offset>Z|[+-]\d{2}:\d{2})$/.exec(original)?.groups?.offset ?? "";
+  return `${edited}:00${offset}`;
+}
+
+/** 入力をタグとして追加する。先頭の `#` は落とし、空と重複は無視する。 */
+export function addTag(tags: string[], raw: string): string[] {
+  const tag = raw.trim().replace(/^#+/, "");
+  if (!tag || tags.includes(tag)) {
+    return tags;
+  }
+  return [...tags, tag];
+}
+
+const NETWORK_LABELS: Record<string, string> = {
+  WiFi: "Wi-Fi",
+  Ethernet: "有線",
+  Mobile: "モバイル回線",
+  Offline: "オフライン",
+};
+
+export interface ContextRow {
+  label: string;
+  value: string;
+}
+
+/** context のうち記録されているフィールドだけを、表示する行にする。 */
+export function contextRows(ctx: NoteContext | undefined): ContextRow[] {
+  if (!ctx) {
+    return [];
+  }
+  const rows: ContextRow[] = [];
+  if (ctx.os) {
+    rows.push({ label: "OS", value: [ctx.os, ctx.os_version].filter(Boolean).join(" ") });
+  }
+  if (ctx.battery !== undefined) {
+    rows.push({
+      label: "バッテリー",
+      value: `${ctx.battery}%${ctx.is_charging ? " (充電中)" : ""}`,
+    });
+  }
+  if (ctx.network_type) {
+    rows.push({ label: "ネットワーク", value: NETWORK_LABELS[ctx.network_type] ?? ctx.network_type });
+  }
+  if (ctx.hostname) {
+    rows.push({ label: "ホスト名", value: ctx.hostname });
+  }
+  if (ctx.location) {
+    rows.push({
+      label: "位置",
+      value: `${ctx.location.latitude.toFixed(4)}, ${ctx.location.longitude.toFixed(4)}`,
+    });
+  }
+  if (ctx.locale) {
+    rows.push({ label: "ロケール", value: ctx.locale });
+  }
+  return rows;
+}

--- a/tauri-app/src/lib/note-meta.ts
+++ b/tauri-app/src/lib/note-meta.ts
@@ -67,7 +67,10 @@ export function contextRows(ctx: NoteContext | undefined): ContextRow[] {
     });
   }
   if (ctx.network_type) {
-    rows.push({ label: "ネットワーク", value: NETWORK_LABELS[ctx.network_type] ?? ctx.network_type });
+    rows.push({
+      label: "ネットワーク",
+      value: NETWORK_LABELS[ctx.network_type] ?? ctx.network_type,
+    });
   }
   if (ctx.hostname) {
     rows.push({ label: "ホスト名", value: ctx.hostname });

--- a/tauri-app/src/lib/shell.tsx
+++ b/tauri-app/src/lib/shell.tsx
@@ -2,7 +2,7 @@ import { createContext, createSignal, useContext, onCleanup } from "solid-js";
 import type { Accessor, JSX } from "solid-js";
 
 /** 同時に開けるポップオーバーは 1 つだけ。 */
-type PopoverName = "sync" | "theme" | "calendar" | null;
+type PopoverName = "sync" | "theme" | "calendar" | "note-meta" | null;
 
 interface Toast {
   message: string;

--- a/tauri-app/src/styles/popover.css
+++ b/tauri-app/src/styles/popover.css
@@ -126,6 +126,103 @@
   font-family: inherit;
 }
 
+/* ---------------- note metadata ---------------- */
+
+/* 詳細ペインの右上、ⓘ ボタンの真下に吊るす */
+.note-meta-popover {
+  top: 44px;
+  right: 12px;
+  width: 264px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.note-meta-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.note-meta-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--app-text-faint);
+}
+
+/* frontmatter のタグが本文の #タグ と別物であることを控えめに伝える */
+.note-meta-hint {
+  font-size: 11px;
+  color: var(--app-text-faint);
+}
+
+.note-meta-input {
+  font: inherit;
+  font-size: 12.5px;
+  padding: 5px 8px;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-2);
+  background: var(--app-surface);
+  color: var(--app-text);
+}
+
+.note-meta-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.note-meta-tags:empty {
+  display: none;
+}
+
+.note-meta-tags .tag-badge {
+  gap: 3px;
+}
+
+.note-meta-tag-remove {
+  display: inline-flex;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+.note-meta-context {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 10px;
+  font-size: 11.5px;
+  color: var(--app-text-muted);
+}
+
+.note-meta-context-label {
+  color: var(--app-text-faint);
+}
+
+.note-meta-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--size-2);
+  border-top: 1px solid var(--app-surface-2);
+  padding-top: 8px;
+}
+
+.note-meta-save {
+  padding: 5px 14px;
+  font-size: 12px;
+}
+
+.note-meta-error {
+  margin: 0;
+  font-size: 12px;
+  color: var(--app-text-faint);
+}
+
 /* ---------------- calendar ---------------- */
 
 .calendar-popover {

--- a/tauri-app/src/styles/workspace.css
+++ b/tauri-app/src/styles/workspace.css
@@ -131,15 +131,6 @@
   color: var(--app-text-faint);
 }
 
-/* ファイル名は識別子なので等幅で。日付と混ざって読めなくならないように */
-.list-row-file {
-  font-family: ui-monospace, monospace;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 12rem;
-}
-
 .notes-empty {
   display: flex;
   flex-direction: column;
@@ -193,12 +184,11 @@
   border-bottom: 1px solid var(--app-hairline);
 }
 
-.detail-filename {
-  font-family: ui-monospace, monospace;
+/* ファイル名は同期やウィジェットが指す ID なので画面には出さない。
+   ヘッダに出すのは人が読む作成日時 */
+.detail-created {
   font-size: 13px;
   color: var(--app-text-faint);
-  overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -17,7 +17,7 @@ import MarkdownPreview from "../components/MarkdownPreview";
 import { typedInvoke } from "../lib/commands";
 import { getDeviceSignals } from "../lib/client-context";
 import { useShell } from "../lib/shell";
-import { groupNotes, itemTitle, toNoteItems } from "../lib/items";
+import { groupNotes, itemTitle, noteCreatedLabel, toNoteItems } from "../lib/items";
 import type { ItemGroup, NoteItem } from "../lib/items";
 
 // Milkdown + ProseMirror は編集を始めるまで要らない。一覧とプレビューだけの
@@ -233,7 +233,6 @@ export default function Workspace(): JSX.Element {
                         <span class="list-row-title">{itemTitle(item)}</span>
                         <span class="list-row-meta">
                           {noteDate(item as NoteItem)}
-                          <span class="list-row-file">{(item as NoteItem).filename}</span>
                           <For each={(item as NoteItem).tags}>
                             {(tag) => <span class="tag-badge">#{tag}</span>}
                           </For>
@@ -267,7 +266,9 @@ export default function Workspace(): JSX.Element {
                   <Icon name="arrow-left" size={18} />
                 </button>
                 <span class="detail-meta">
-                  <span class="detail-filename">{item().filename}</span>
+                  {/* ファイル名は同期やウィジェットが指す ID であって人に見せる
+                      ものではない。人が読むのは作成日時 */}
+                  <span class="detail-created">{noteCreatedLabel(item())}</span>
                   <Show when={editing() && saveStatus() !== "idle"}>
                     <span class="detail-save-status">
                       {saveStatus() === "saving" ? "保存中…" : "保存しました"}

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -14,6 +14,7 @@ import { useSearchParams } from "@solidjs/router";
 import type { Editor } from "@milkdown/kit/core";
 import Icon from "../components/Icon";
 import MarkdownPreview from "../components/MarkdownPreview";
+import NoteMetaPopover from "../components/NoteMetaPopover";
 import { typedInvoke } from "../lib/commands";
 import { getDeviceSignals } from "../lib/client-context";
 import { useShell } from "../lib/shell";
@@ -277,6 +278,16 @@ export default function Workspace(): JSX.Element {
                 </span>
 
                 <div class="detail-actions">
+                  <button
+                    type="button"
+                    class="icon-button detail-meta-button"
+                    title="ノート情報"
+                    aria-label="ノート情報"
+                    aria-expanded={shell.popover() === "note-meta"}
+                    onClick={() => shell.togglePopover("note-meta")}
+                  >
+                    <Icon name="info" size={17} />
+                  </button>
                   <Show
                     when={editing()}
                     fallback={
@@ -312,6 +323,16 @@ export default function Workspace(): JSX.Element {
                   </button>
                 </div>
               </div>
+
+              <Show when={shell.popover() === "note-meta"}>
+                <NoteMetaPopover
+                  filename={item().filename}
+                  onSaved={async () => {
+                    await refetchNotes();
+                  }}
+                  onClose={() => shell.closePopovers()}
+                />
+              </Show>
 
               <div class="detail-body">
                 <Show when={editing()} fallback={<MarkdownPreview source={noteBody()} />}>


### PR DESCRIPTION
## 1. 概要

- #96 以降 frontmatter は UI から完全に不可視だった。詳細ヘッダの ⓘ ボタンからポップオーバーで表示し、time(作成日時)と tags のみ編集できるようにする。context は「どの端末・状況で書いたか」の記録なので読み取り専用で列挙する
- ファイル名は作成時刻由来の内部 ID であってユーザーが選んだ名前ではないため、画面から消す(一覧行・詳細ヘッダ)。ヘッダには代わりに作成日時「2026/05/03 15:39」を出す
- `update_note_meta` は本文と context に触れない。また frontmatter が読めないファイルには**書かずに `Parse` エラーで断る** — 本文保存(`update_note`)は失敗させられないので作り直すが、メタデータ編集がでっち上げた記録を書くと壊れたファイルが正当に見えてしまう、という逆の判断
- time は IPC をオフセット付き RFC 3339 文字列で運び、フロントでも `Date` に通さず文字列 slice で扱う。端末のタイムゾーンを変えても表示・保存がずれず、未変更保存では秒と元のオフセットを保持する
- Tidy First: 先行コミットでパス解決(exists + canonicalize + prefix 検査)を `existing_note_path` に抽出し、read / delete / 新 API の 4 箇所で共用

## 2. 図解

メタデータの読み書き経路。緑枠が追加要素で、本文の保存経路(`update_note`)には手を入れていない。

```mermaid
flowchart LR
  header["詳細ヘッダ<br/>(ファイル名 → 作成日時)"] --> info["ⓘ NoteMetaPopover<br/>(time/tags 編集・context 表示)"]
  info -->|"read_note_meta /<br/>update_note_meta (RFC 3339)"| cmd["Tauri コマンド"]
  cmd --> core["Notes::read_meta / update_meta"]
  core -->|"time / tags のみ差し替え<br/>本文と context は不変"| file["data/notes/*.md"]
  classDef added stroke:#3fb950,stroke-width:3px
  class info,cmd,core added
```

## 3. 変更ファイル

| 領域           | ファイル | 変更       | 理由                                                                 |
| -------------- | -------- | ---------- | -------------------------------------------------------------------- |
| `core/src/`    | 3        | +155 / -17 | `read_note_meta` / `update_note_meta` 追加とパス解決の共通化(TDD 6件) |
| `tauri-app/src-tauri/` | 1 | +26 / -1  | 2 コマンドの公開。time は RFC 3339 文字列で IPC                      |
| `tauri-app/src/lib/`   | 6 | +213 / -2 | コマンド型・作成日時ラベル・時刻/コンテキスト整形ロジック+テスト     |
| `tauri-app/src/components/` ほか | 4 | +184 / -5 | `NoteMetaPopover` 新規、ヘッダ差し替え、shell のポップオーバー統合   |
| `tauri-app/src/styles/` | 2 | +100 / -13 | パネルのスタイル、ファイル名表示スタイルの削除                       |

**合計:** 16 ファイル, +678 / -36

## 4. テスト

- [x] `cargo test --workspace` — 全スイート通過(core 164 件、新規 6 件)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`(pedantic)— 警告 0
- [x] `pnpm test` — 21 ファイル / 207 件通過(note-meta 10 件・items 2 件を新規追加)
- [x] `pnpm exec tsgo -b` / `oxlint src/` — エラーなし
- [x] `nix fmt` — 適用済み
- [ ] 実アプリでの目視確認(パネルの開閉、time 編集後の一覧グルーピング変化)
