### PR TITLE
fix(ui): ignore IME composition Enter in text inputs

### DIFF
--- a/tauri-app/src/components/CaptureBar.test.tsx
+++ b/tauri-app/src/components/CaptureBar.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, fireEvent, cleanup } from "@solidjs/testing-library";
+import CaptureBar from "./CaptureBar";
+
+function renderCaptureBar() {
+  const onSend = vi.fn<(text: string) => Promise<void>>().mockResolvedValue();
+  const { container } = render(() => <CaptureBar onSend={onSend} />);
+  const textarea = container.querySelector<HTMLTextAreaElement>(".capture-input");
+  if (!textarea) {
+    throw new Error("capture-input not found");
+  }
+  return { onSend, textarea };
+}
+
+describe("CaptureBar", () => {
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+  });
+
+  it("sends the trimmed text on Enter", () => {
+    const { onSend, textarea } = renderCaptureBar();
+    fireEvent.input(textarea, { target: { value: "買い物メモ " } });
+
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(onSend).toHaveBeenCalledExactlyOnceWith("買い物メモ");
+  });
+
+  // macOS の WKWebView では、日本語 IME の変換確定 Enter も keydown として
+  // 届く。isComposing を見ずに送信すると、漢字変換を確定できない (#102)
+  it("does not send while the IME is composing", () => {
+    const { onSend, textarea } = renderCaptureBar();
+    fireEvent.input(textarea, { target: { value: "かんじへんかん" } });
+
+    fireEvent.keyDown(textarea, { key: "Enter", isComposing: true });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  // WebKit は互換のため合成中の keydown を keyCode 229 で届けることがある
+  it("does not send on the legacy keyCode 229 Enter", () => {
+    const { onSend, textarea } = renderCaptureBar();
+    fireEvent.input(textarea, { target: { value: "かんじへんかん" } });
+
+    fireEvent.keyDown(textarea, { key: "Enter", keyCode: 229 });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});

--- a/tauri-app/src/components/CaptureBar.tsx
+++ b/tauri-app/src/components/CaptureBar.tsx
@@ -1,6 +1,7 @@
 import { createSignal, createMemo, For, Show } from "solid-js";
 import type { JSX } from "solid-js";
 import Icon from "./Icon";
+import { isImeComposing } from "../lib/ime";
 import { matchTagPrefix, tagDraftAt } from "../lib/tags";
 import type { TagCount } from "../lib/tags";
 
@@ -105,6 +106,10 @@ export default function CaptureBar(props: CaptureBarProps): JSX.Element {
   };
 
   const onKeyDown = (e: KeyboardEvent & { currentTarget: HTMLTextAreaElement }): void => {
+    // 変換確定の Enter は IME のもの。送信にもタグ確定にも使わない (#102)
+    if (e.key === "Enter" && isImeComposing(e)) {
+      return;
+    }
     if (rows() > 0) {
       if (e.key === "ArrowDown") {
         e.preventDefault();

--- a/tauri-app/src/components/CommandPalette.tsx
+++ b/tauri-app/src/components/CommandPalette.tsx
@@ -5,6 +5,7 @@ import type { IconName } from "./Icon";
 import { typedInvoke } from "../lib/commands";
 import type { SearchHit } from "../lib/commands";
 import { createDebouncedAccessor } from "../lib/debounce";
+import { isImeComposing } from "../lib/ime";
 
 interface PaletteCommand {
   id: string;
@@ -81,7 +82,8 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
       setCursor(Math.max(clampedCursor() - 1, 0));
       return;
     }
-    if (e.key === "Enter") {
+    // 変換確定の Enter は IME のもの。行の実行には使わない (#102)
+    if (e.key === "Enter" && !isImeComposing(e)) {
       e.preventDefault();
       rows()[clampedCursor()]?.run();
     }

--- a/tauri-app/src/components/FirstRunCard.tsx
+++ b/tauri-app/src/components/FirstRunCard.tsx
@@ -2,6 +2,7 @@ import { createSignal, Show } from "solid-js";
 import type { JSX } from "solid-js";
 import Icon from "./Icon";
 import { typedInvoke } from "../lib/commands";
+import { isImeComposing } from "../lib/ime";
 
 const DISMISSED_KEY = "first-run-dismissed";
 
@@ -70,7 +71,8 @@ export default function FirstRunCard(props: FirstRunCardProps): JSX.Element {
             placeholder="https://....workers.dev"
             onInput={(e) => setUrl(e.currentTarget.value)}
             onKeyDown={(e) => {
-              if (e.key === "Enter") {
+              // 変換確定の Enter は IME のもの。接続には使わない (#102)
+              if (e.key === "Enter" && !isImeComposing(e)) {
                 e.preventDefault();
                 connect();
               }

--- a/tauri-app/src/components/NoteMetaPopover.tsx
+++ b/tauri-app/src/components/NoteMetaPopover.tsx
@@ -2,6 +2,7 @@ import { createEffect, createResource, createSignal, For, Show } from "solid-js"
 import type { JSX } from "solid-js";
 import Icon from "./Icon";
 import { typedInvoke } from "../lib/commands";
+import { isImeComposing } from "../lib/ime";
 import { addTag, contextRows, resolveEditedTime, toDatetimeLocal } from "../lib/note-meta";
 
 interface NoteMetaPopoverProps {
@@ -110,7 +111,8 @@ export default function NoteMetaPopover(props: NoteMetaPopoverProps): JSX.Elemen
                   value={tagInput()}
                   onInput={(e) => setTagInput(e.currentTarget.value)}
                   onKeyDown={(e) => {
-                    if (e.key === "Enter") {
+                    // 変換確定の Enter は IME のもの。タグ確定には使わない (#102)
+                    if (e.key === "Enter" && !isImeComposing(e)) {
                       e.preventDefault();
                       commitTagInput();
                     }

--- a/tauri-app/src/lib/ime.test.ts
+++ b/tauri-app/src/lib/ime.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { isImeComposing } from "./ime";
+
+describe("isImeComposing", () => {
+  it("returns false for a plain Enter", () => {
+    expect(isImeComposing(new KeyboardEvent("keydown", { key: "Enter" }))).toBe(false);
+  });
+
+  it("returns true while the IME is composing", () => {
+    expect(isImeComposing(new KeyboardEvent("keydown", { key: "Enter", isComposing: true }))).toBe(
+      true,
+    );
+  });
+
+  // isComposing が立たない古い WebKit は keyCode 229 だけで合成中を伝える
+  it("returns true for the legacy keyCode 229", () => {
+    const e = new KeyboardEvent("keydown", { key: "Enter" });
+    Object.defineProperty(e, "keyCode", { value: 229 });
+    expect(isImeComposing(e)).toBe(true);
+  });
+});

--- a/tauri-app/src/lib/ime.ts
+++ b/tauri-app/src/lib/ime.ts
@@ -1,0 +1,10 @@
+/**
+ * IME の変換中に届いた keydown かどうか。
+ *
+ * macOS の WKWebView は日本語 IME の変換確定 Enter も通常の keydown として
+ * 届けるため、これを見ずに Enter で確定処理をすると漢字変換が完了できない。
+ * keyCode 229 は isComposing が立たない古い WebKit 実装のための互換値。
+ */
+export function isImeComposing(e: KeyboardEvent): boolean {
+  return e.isComposing || e.keyCode === 229;
+}


### PR DESCRIPTION
## Summary

- macOS (WKWebView) では日本語 IME の変換確定 Enter が通常の keydown として届くため、タイムラインの入力欄で漢字変換を確定しようとするとその場で送信されてしまい、変換が完了できなかった (#102)
- keydown の Enter を `e.isComposing`(古い WebKit 互換として `e.keyCode === 229` も)で判定する `isImeComposing` を `src/lib/ime.ts` に追加し、変換中の Enter では送信・タグ確定をしないようにした
- 同じ「テキスト入力の Enter keydown で確定する」パターンを持つ CommandPalette(行の実行)・NoteMetaPopover(タグ追加)・FirstRunCard(同期接続)にも同じガードを適用した。ボタンやリスト選択の Enter は IME と無関係なので触っていない
- 修正は TDD で実施: `isComposing: true` の Enter で `onSend` が呼ばれないことを検証する失敗テストを先に書き(Red)、ガード追加で通した(Green)

## 背景と再現条件

1. Mac 版アプリでタイムラインの入力欄に日本語を入力する(例: 「かんじへんかん」)
2. スペースで変換し、Return で確定しようとする
3. 変換確定の Return がそのまま送信として扱われ、未確定のまま記録されてしまう

ブラウザ実装によっては変換中の keydown に `isComposing` が立たず `keyCode 229` だけで伝えるものがあるため、両方を見ている。

## Diagram

Enter で確定する 4 つのテキスト入力が、新設の `isImeComposing` ガード(緑の太枠 = 追加)を通ってから確定するようになる。

```mermaid
flowchart LR
  subgraph inputs["Enter で確定するテキスト入力"]
    capture["CaptureBar<br/>(送信・タグ確定)"]
    palette["CommandPalette<br/>(行の実行)"]
    meta["NoteMetaPopover<br/>(タグ追加)"]
    firstrun["FirstRunCard<br/>(同期接続)"]
  end
  capture -- "keydown Enter" --> guard["isImeComposing<br/>src/lib/ime.ts"]
  palette -- "keydown Enter" --> guard
  meta -- "keydown Enter" --> guard
  firstrun -- "keydown Enter" --> guard
  guard -- "変換中<br/>(isComposing / keyCode 229)" --> ime["何もしない<br/>(Enter は IME の変換確定に)"]
  guard -- "通常の Enter" --> commit["従来どおり確定"]

  classDef added stroke:#3fb950,stroke-width:3px
  class guard,ime added
```

## Files changed

| ファイル | 変更内容 |
| --- | --- |
| `tauri-app/src/lib/ime.ts` | 変換中の keydown か判定する `isImeComposing` を新設(`isComposing` / 互換の `keyCode 229`) |
| `tauri-app/src/lib/ime.test.ts` | 通常 Enter は false、`isComposing` と `keyCode 229` は true を検証 |
| `tauri-app/src/components/CaptureBar.tsx` | onKeyDown の先頭で変換中の Enter を無視。送信とタグ補完の確定の両方を守る |
| `tauri-app/src/components/CaptureBar.test.tsx` | 新規: 通常 Enter で送信される・変換中の Enter(`isComposing` / `keyCode 229`)では送信されないことを検証 |
| `tauri-app/src/components/CommandPalette.tsx` | 検索入力の Enter に同じガード。変換確定で行が実行されるのを防ぐ |
| `tauri-app/src/components/NoteMetaPopover.tsx` | タグ入力の Enter に同じガード。変換確定でタグが追加されるのを防ぐ |
| `tauri-app/src/components/FirstRunCard.tsx` | URL 入力の Enter に同じガード。変換確定で接続が走るのを防ぐ |

**Total:** 7 files, +95 / -3

## Test plan

- [x] `just check`(oxlint / tsgo / knip、Rust・workers 含む)が通ることを確認
- [x] `just test` が通ることを確認(tauri-app: 24 files / 225 tests passed、workers: 33 tests passed、Rust: passed)
- [x] 修正前に CaptureBar の IME テスト 2 件が失敗する(送信されてしまう)ことを確認してから修正した(Red → Green)
- [ ] Mac 実機で日本語入力の変換確定 Return が送信されないことを手元で確認

Closes #102
