### PR TITLE
feat(editor): add a hover copy button and skip highlighting unloaded languages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ If a dependency adds weight, it must justify itself against lightness.
 | External | `highlight`               | `@milkdown/plugin-highlight`           | Shiki syntax highlighting     |
 | Custom   | `exitCodeBlockPlugin`     | `src/lib/exit-code-block-plugin.ts`    | Mod-Enter to exit code blocks |
 | Custom   | `createPlaceholderPlugin` | `src/lib/placeholder-plugin.ts`        | Empty document placeholder    |
-| Custom   | `mermaidPreviewPlugin`    | `src/lib/mermaid-preview-plugin.ts`    | In-editor mermaid preview     |
+| Custom   | `codeBlockViewPlugin`     | `src/lib/code-block-view-plugin.ts`    | In-editor mermaid preview     |
 
 Rejected plugins (with reasons):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ If a dependency adds weight, it must justify itself against lightness.
 | External | `highlight`               | `@milkdown/plugin-highlight`           | Shiki syntax highlighting     |
 | Custom   | `exitCodeBlockPlugin`     | `src/lib/exit-code-block-plugin.ts`    | Mod-Enter to exit code blocks |
 | Custom   | `createPlaceholderPlugin` | `src/lib/placeholder-plugin.ts`        | Empty document placeholder    |
-| Custom   | `codeBlockViewPlugin`     | `src/lib/code-block-view-plugin.ts`    | In-editor mermaid preview     |
+| Custom   | `codeBlockViewPlugin`     | `src/lib/code-block-view-plugin.ts`    | Copy button + mermaid preview |
 
 Rejected plugins (with reasons):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,19 +27,20 @@ If a dependency adds weight, it must justify itself against lightness.
 
 ## Milkdown Plugins
 
-| Category | Plugin                    | Import                                 | Purpose                       |
-| -------- | ------------------------- | -------------------------------------- | ----------------------------- |
-| Built-in | `commonmark`              | `@milkdown/kit/preset/commonmark`      | Base Markdown                 |
-| Built-in | `listener`                | `@milkdown/kit/plugin/listener`        | onChange callback             |
-| Built-in | `cursor`                  | `@milkdown/kit/plugin/cursor`          | Gap cursor + drop cursor      |
-| Built-in | `history`                 | `@milkdown/kit/plugin/history`         | Undo/Redo                     |
-| Built-in | `clipboard`               | `@milkdown/kit/plugin/clipboard`       | Improved copy/paste           |
-| Built-in | `trailing`                | `@milkdown/kit/plugin/trailing`        | Trailing paragraph            |
-| Built-in | `linkTooltipPlugin`       | `@milkdown/kit/component/link-tooltip` | Link preview/edit             |
-| External | `highlight`               | `@milkdown/plugin-highlight`           | Shiki syntax highlighting     |
-| Custom   | `exitCodeBlockPlugin`     | `src/lib/exit-code-block-plugin.ts`    | Mod-Enter to exit code blocks |
-| Custom   | `createPlaceholderPlugin` | `src/lib/placeholder-plugin.ts`        | Empty document placeholder    |
-| Custom   | `codeBlockViewPlugin`     | `src/lib/code-block-view-plugin.ts`    | Copy button + mermaid preview |
+| Category | Plugin                    | Import                                 | Purpose                                              |
+| -------- | ------------------------- | -------------------------------------- | ---------------------------------------------------- |
+| Built-in | `commonmark`              | `@milkdown/kit/preset/commonmark`      | Base Markdown                                        |
+| Built-in | `listener`                | `@milkdown/kit/plugin/listener`        | onChange callback                                    |
+| Built-in | `cursor`                  | `@milkdown/kit/plugin/cursor`          | Gap cursor + drop cursor                             |
+| Built-in | `history`                 | `@milkdown/kit/plugin/history`         | Undo/Redo                                            |
+| Built-in | `clipboard`               | `@milkdown/kit/plugin/clipboard`       | Improved copy/paste                                  |
+| Built-in | `trailing`                | `@milkdown/kit/plugin/trailing`        | Trailing paragraph                                   |
+| Built-in | `linkTooltipPlugin`       | `@milkdown/kit/component/link-tooltip` | Link preview/edit                                    |
+| External | `highlight`               | `@milkdown/plugin-highlight`           | Shiki syntax highlighting                            |
+| Custom   | `exitCodeBlockPlugin`     | `src/lib/exit-code-block-plugin.ts`    | Mod-Enter to exit code blocks                        |
+| Custom   | `createPlaceholderPlugin` | `src/lib/placeholder-plugin.ts`        | Empty document placeholder                           |
+| Custom   | `codeBlockViewPlugin`     | `src/lib/code-block-view-plugin.ts`    | Language input + copy button + mermaid figure view   |
+| Custom   | `codeBlockActivePlugin`   | `src/lib/code-block-active-plugin.ts`  | is-active class on code blocks the selection touches |
 
 Rejected plugins (with reasons):
 

--- a/tauri-app/src/components/MilkdownEditor.tsx
+++ b/tauri-app/src/components/MilkdownEditor.tsx
@@ -13,6 +13,7 @@ import { getHighlighter } from "../lib/highlighter";
 import { withKnownLanguages } from "../lib/highlight-parser";
 import { exitCodeBlockPlugin } from "../lib/exit-code-block-plugin";
 import { codeBlockViewPlugin } from "../lib/code-block-view-plugin";
+import { codeBlockActivePlugin } from "../lib/code-block-active-plugin";
 import { createPlaceholderPlugin } from "../lib/placeholder-plugin";
 import { getShikiTheme } from "../lib/theme";
 import type { JSX } from "solid-js";
@@ -71,6 +72,7 @@ export default function MilkdownEditor(props: MilkdownEditorProps): JSX.Element 
       .use(linkTooltipPlugin)
       .use(exitCodeBlockPlugin)
       .use(codeBlockViewPlugin)
+      .use(codeBlockActivePlugin)
       .use(props.placeholder ? createPlaceholderPlugin(props.placeholder) : [])
       .create();
 

--- a/tauri-app/src/components/MilkdownEditor.tsx
+++ b/tauri-app/src/components/MilkdownEditor.tsx
@@ -12,7 +12,7 @@ import { createParser } from "@milkdown/plugin-highlight/shiki";
 import { getHighlighter } from "../lib/highlighter";
 import { withKnownLanguages } from "../lib/highlight-parser";
 import { exitCodeBlockPlugin } from "../lib/exit-code-block-plugin";
-import { mermaidPreviewPlugin } from "../lib/mermaid-preview-plugin";
+import { codeBlockViewPlugin } from "../lib/code-block-view-plugin";
 import { createPlaceholderPlugin } from "../lib/placeholder-plugin";
 import { getShikiTheme } from "../lib/theme";
 import type { JSX } from "solid-js";
@@ -70,7 +70,7 @@ export default function MilkdownEditor(props: MilkdownEditorProps): JSX.Element 
       .use(trailing)
       .use(linkTooltipPlugin)
       .use(exitCodeBlockPlugin)
-      .use(mermaidPreviewPlugin)
+      .use(codeBlockViewPlugin)
       .use(props.placeholder ? createPlaceholderPlugin(props.placeholder) : [])
       .create();
 

--- a/tauri-app/src/components/MilkdownEditor.tsx
+++ b/tauri-app/src/components/MilkdownEditor.tsx
@@ -10,6 +10,7 @@ import { linkTooltipPlugin } from "@milkdown/kit/component/link-tooltip";
 import { highlight, highlightPluginConfig } from "@milkdown/plugin-highlight";
 import { createParser } from "@milkdown/plugin-highlight/shiki";
 import { getHighlighter } from "../lib/highlighter";
+import { withKnownLanguages } from "../lib/highlight-parser";
 import { exitCodeBlockPlugin } from "../lib/exit-code-block-plugin";
 import { mermaidPreviewPlugin } from "../lib/mermaid-preview-plugin";
 import { createPlaceholderPlugin } from "../lib/placeholder-plugin";
@@ -38,9 +39,13 @@ export default function MilkdownEditor(props: MilkdownEditorProps): JSX.Element 
     // Shiki's Highlighter type is structurally compatible but comes from a
     // different copy of the package than the one @milkdown/plugin-highlight
     // resolves, so the nominal types do not line up.
-    const parser = createParser(highlighter as Parameters<typeof createParser>[0], {
-      theme: getShikiTheme(),
-    });
+    // 未読込の言語(mermaid など)は素通しにして ShikiError を防ぐ(#101)
+    const parser = withKnownLanguages(
+      createParser(highlighter as Parameters<typeof createParser>[0], {
+        theme: getShikiTheme(),
+      }),
+      highlighter.getLoadedLanguages(),
+    );
 
     editor = await Editor.make()
       .config((ctx) => {

--- a/tauri-app/src/components/MilkdownEditor.tsx
+++ b/tauri-app/src/components/MilkdownEditor.tsx
@@ -11,6 +11,7 @@ import { highlight, highlightPluginConfig } from "@milkdown/plugin-highlight";
 import { createParser } from "@milkdown/plugin-highlight/shiki";
 import { getHighlighter } from "../lib/highlighter";
 import { withKnownLanguages } from "../lib/highlight-parser";
+import { buildLanguageSuggestions, ensureLanguageDatalist } from "../lib/language-suggestions";
 import { exitCodeBlockPlugin } from "../lib/exit-code-block-plugin";
 import { codeBlockViewPlugin } from "../lib/code-block-view-plugin";
 import { codeBlockActivePlugin } from "../lib/code-block-active-plugin";
@@ -40,6 +41,9 @@ export default function MilkdownEditor(props: MilkdownEditorProps): JSX.Element 
     // Shiki's Highlighter type is structurally compatible but comes from a
     // different copy of the package than the one @milkdown/plugin-highlight
     // resolves, so the nominal types do not line up.
+    // 言語入力の補完候補(コードブロック共有の datalist)
+    ensureLanguageDatalist(document, buildLanguageSuggestions(highlighter.getLoadedLanguages()));
+
     // 未読込の言語(mermaid など)は素通しにして ShikiError を防ぐ(#101)
     const parser = withKnownLanguages(
       createParser(highlighter as Parameters<typeof createParser>[0], {

--- a/tauri-app/src/lib/active-code-block.test.ts
+++ b/tauri-app/src/lib/active-code-block.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { Schema } from "@milkdown/kit/prose/model";
+import { activeCodeBlockRanges } from "./active-code-block";
+
+// milkdown の schema はエディタ ctx がないと組めないので、位置計算に必要な
+// 形だけの最小 schema で文書を作る(判定は node type 名しか見ない)
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: { group: "block", content: "text*" },
+    code_block: { group: "block", content: "text*", code: true },
+    blockquote: { group: "block", content: "block+" },
+    text: {},
+  },
+});
+
+// 位置: paragraph "hello" = [0,7)、code_block "graph TD;" = [7,18)
+const doc = schema.node("doc", null, [
+  schema.node("paragraph", null, [schema.text("hello")]),
+  schema.node("code_block", null, [schema.text("graph TD;")]),
+]);
+
+describe("activeCodeBlockRanges", () => {
+  it("returns the enclosing block for a cursor inside it", () => {
+    expect(activeCodeBlockRanges(doc, 10, 10)).toEqual([{ from: 7, to: 18 }]);
+  });
+
+  it("returns nothing for a cursor outside every code block", () => {
+    expect(activeCodeBlockRanges(doc, 2, 2)).toEqual([]);
+  });
+
+  it("includes a block the selection only partially covers", () => {
+    expect(activeCodeBlockRanges(doc, 2, 10)).toEqual([{ from: 7, to: 18 }]);
+  });
+
+  it("returns every block inside a wide selection", () => {
+    const two = schema.node("doc", null, [
+      schema.node("code_block", null, [schema.text("a")]),
+      schema.node("paragraph", null, [schema.text("x")]),
+      schema.node("code_block", null, [schema.text("b")]),
+    ]);
+    // code_block "a" = [0,3)、paragraph = [3,6)、code_block "b" = [6,9)
+    expect(activeCodeBlockRanges(two, 0, two.content.size)).toEqual([
+      { from: 0, to: 3 },
+      { from: 6, to: 9 },
+    ]);
+  });
+
+  // blockquote 内の code_block も編集対象。入れ子でも見つける
+  it("finds a block nested inside another node", () => {
+    const nested = schema.node("doc", null, [
+      schema.node("blockquote", null, [schema.node("code_block", null, [schema.text("a")])]),
+    ]);
+    // blockquote = [0,5)、code_block "a" = [1,4)
+    expect(activeCodeBlockRanges(nested, 2, 2)).toEqual([{ from: 1, to: 4 }]);
+  });
+});

--- a/tauri-app/src/lib/active-code-block.ts
+++ b/tauri-app/src/lib/active-code-block.ts
@@ -1,0 +1,24 @@
+import type { Node } from "@milkdown/kit/prose/model";
+
+export interface NodeRange {
+  from: number;
+  to: number;
+}
+
+/**
+ * 選択範囲 [from, to] に触れている code_block のノード範囲を集める。
+ * mermaid ブロックの「カーソルが中にある間だけソースを見せる」判定に使う。
+ * カーソル(from === to)が中にあるブロックも、選択が部分的にかすった
+ * ブロックも「触れている」として扱う。
+ */
+export function activeCodeBlockRanges(doc: Node, from: number, to: number): NodeRange[] {
+  const ranges: NodeRange[] = [];
+  doc.nodesBetween(from, to, (node, pos) => {
+    if (node.type.name !== "code_block") {
+      return true;
+    }
+    ranges.push({ from: pos, to: pos + node.nodeSize });
+    return false;
+  });
+  return ranges;
+}

--- a/tauri-app/src/lib/code-block-active-plugin.ts
+++ b/tauri-app/src/lib/code-block-active-plugin.ts
@@ -1,0 +1,29 @@
+import { $prose } from "@milkdown/kit/utils";
+import { Plugin } from "@milkdown/kit/prose/state";
+import { Decoration, DecorationSet } from "@milkdown/kit/prose/view";
+import { activeCodeBlockRanges } from "./active-code-block";
+
+/**
+ * 選択が触れている code_block に is-active クラスを付ける。node decoration の
+ * 属性は ProseMirror が nodeView の dom に反映するので、nodeView 側に選択の
+ * 配線は要らない。mermaid ブロックの「図がメイン、ソースはカーソルが中に
+ * ある間だけ」表示(CSS)がこのクラスを読む。
+ */
+export const codeBlockActivePlugin = $prose(
+  () =>
+    new Plugin({
+      props: {
+        decorations(state) {
+          const { from, to } = state.selection;
+          const ranges = activeCodeBlockRanges(state.doc, from, to);
+          if (ranges.length === 0) {
+            return DecorationSet.empty;
+          }
+          return DecorationSet.create(
+            state.doc,
+            ranges.map((range) => Decoration.node(range.from, range.to, { class: "is-active" })),
+          );
+        },
+      },
+    }),
+);

--- a/tauri-app/src/lib/code-block-view-plugin.ts
+++ b/tauri-app/src/lib/code-block-view-plugin.ts
@@ -6,7 +6,7 @@ import checkIcon from "@phosphor-icons/core/assets/regular/check.svg?raw";
 import { renderDiagrams } from "./mermaid";
 import { isMermaidLanguage, createDebouncedDiagramRenderer } from "./mermaid-preview";
 import { createCopyFeedback } from "./copy-feedback";
-import { LANGUAGE_DATALIST_ID } from "./language-suggestions";
+import { LANGUAGE_DATALIST_ID, languageLabelWidth } from "./language-suggestions";
 import type { Node } from "@milkdown/kit/prose/model";
 import type { EditorView, NodeView, ViewMutationRecord } from "@milkdown/kit/prose/view";
 
@@ -191,7 +191,7 @@ class CodeBlockPreviewView implements NodeView {
 
   private resizeLanguageInput(): void {
     // 入力はラベル扱いなので、値の長さちょうどに縮めておく(下限は placeholder 分)
-    this.languageInput.size = Math.max(this.languageInput.value.length, 4);
+    this.languageInput.style.width = languageLabelWidth(this.languageInput.value);
   }
 
   private sync(node: Node, { initial }: { initial: boolean }): void {

--- a/tauri-app/src/lib/code-block-view-plugin.ts
+++ b/tauri-app/src/lib/code-block-view-plugin.ts
@@ -6,6 +6,7 @@ import checkIcon from "@phosphor-icons/core/assets/regular/check.svg?raw";
 import { renderDiagrams } from "./mermaid";
 import { isMermaidLanguage, createDebouncedDiagramRenderer } from "./mermaid-preview";
 import { createCopyFeedback } from "./copy-feedback";
+import { LANGUAGE_DATALIST_ID } from "./language-suggestions";
 import type { Node } from "@milkdown/kit/prose/model";
 import type { EditorView, NodeView, ViewMutationRecord } from "@milkdown/kit/prose/view";
 
@@ -37,6 +38,7 @@ class CodeBlockPreviewView implements NodeView {
   private readonly getPos: () => number | undefined;
   private readonly pre: HTMLElement;
   private readonly copyButton: HTMLButtonElement;
+  private readonly languageInput: HTMLInputElement;
   private preview: HTMLElement | undefined;
   private node: Node;
   private lastSource: string | undefined;
@@ -66,7 +68,8 @@ class CodeBlockPreviewView implements NodeView {
     this.pre = document.createElement("pre");
     this.contentDOM = document.createElement("code");
     this.copyButton = this.createCopyButton();
-    this.pre.append(this.contentDOM, this.copyButton);
+    this.languageInput = this.createLanguageInput();
+    this.pre.append(this.contentDOM, this.languageInput, this.copyButton);
     this.dom.append(this.pre);
     this.sync(node, { initial: true });
   }
@@ -80,8 +83,9 @@ class CodeBlockPreviewView implements NodeView {
   }
 
   /**
-   * 編集ノードの外の部品(図・コピー ボタン)への操作は ProseMirror に
-   * 渡さない。渡すと図のクリックが node selection になったりする。
+   * 編集ノードの外の部品(図・コピー ボタン・言語入力)への操作は
+   * ProseMirror に渡さない。渡すと言語入力の打鍵をエディタの keymap が
+   * 拾ったり、図のクリックが node selection になったりする。
    * pre の余白クリック(カーソル配置)は通すため、部品だけに絞る
    */
   stopEvent(event: Event): boolean {
@@ -89,7 +93,11 @@ class CodeBlockPreviewView implements NodeView {
     if (!(target instanceof globalThis.Node)) {
       return false;
     }
-    return this.copyButton.contains(target) || (this.preview?.contains(target) ?? false);
+    return (
+      this.copyButton.contains(target) ||
+      this.languageInput.contains(target) ||
+      (this.preview?.contains(target) ?? false)
+    );
   }
 
   ignoreMutation(mutation: ViewMutationRecord): boolean {
@@ -132,16 +140,76 @@ class CodeBlockPreviewView implements NodeView {
     this.copyButton.innerHTML = copied ? checkIcon : copyIcon;
   }
 
+  /**
+   * 言語ラベルを兼ねる小さな入力。datalist(highlighter の読込済み言語+
+   * mermaid)から補完が出る。未知言語のハイライトを黙ってスキップする分
+   * (#101)、綴り違いに気づく場所はここになる
+   */
+  private createLanguageInput(): HTMLInputElement {
+    const input = document.createElement("input");
+    input.type = "text";
+    input.className = "code-language-input";
+    input.setAttribute("list", LANGUAGE_DATALIST_ID);
+    input.setAttribute("aria-label", "言語");
+    input.placeholder = "言語";
+    input.spellcheck = false;
+    input.autocapitalize = "off";
+    input.tabIndex = -1;
+    input.addEventListener("change", () => {
+      this.commitLanguage(input.value);
+    });
+    input.addEventListener("input", () => {
+      this.resizeLanguageInput();
+    });
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        // change(コミット)を発火させてから、続けて書けるよう本文へ戻す
+        event.preventDefault();
+        input.blur();
+        this.focusSource();
+      } else if (event.key === "Escape") {
+        input.value = this.node.attrs.language as string;
+        this.resizeLanguageInput();
+        input.blur();
+      }
+    });
+    return input;
+  }
+
+  private commitLanguage(value: string): void {
+    const pos = this.getPos();
+    if (pos === undefined) {
+      return;
+    }
+    const language = value.trim();
+    if (language === (this.node.attrs.language as string)) {
+      return;
+    }
+    const { state } = this.view;
+    this.view.dispatch(state.tr.setNodeMarkup(pos, undefined, { ...this.node.attrs, language }));
+  }
+
+  private resizeLanguageInput(): void {
+    // 入力はラベル扱いなので、値の長さちょうどに縮めておく(下限は placeholder 分)
+    this.languageInput.size = Math.max(this.languageInput.value.length, 4);
+  }
+
   private sync(node: Node, { initial }: { initial: boolean }): void {
     this.node = node;
     const language = node.attrs.language as string;
 
-    // node view が立つと schema の toDOM は使われない。言語ラベルの CSS が
-    // 読む data-language はここで出し直す
+    // node view が立つと schema の toDOM は使われない。data-language は
+    // ここで出し直す(スタイルのフックとして残す)
     if (language) {
       this.pre.dataset.language = language;
     } else {
       delete this.pre.dataset.language;
+    }
+
+    // 編集中の値をエディタ側の更新で潰さない
+    if (document.activeElement !== this.languageInput) {
+      this.languageInput.value = language;
+      this.resizeLanguageInput();
     }
 
     if (!isMermaidLanguage(language)) {

--- a/tauri-app/src/lib/code-block-view-plugin.ts
+++ b/tauri-app/src/lib/code-block-view-plugin.ts
@@ -1,16 +1,23 @@
 import { $view } from "@milkdown/kit/utils";
 import { codeBlockSchema } from "@milkdown/kit/preset/commonmark";
+import copyIcon from "@phosphor-icons/core/assets/regular/copy.svg?raw";
+import checkIcon from "@phosphor-icons/core/assets/regular/check.svg?raw";
 import { renderDiagrams } from "./mermaid";
 import { isMermaidLanguage, createDebouncedDiagramRenderer } from "./mermaid-preview";
+import { createCopyFeedback } from "./copy-feedback";
 import type { Node } from "@milkdown/kit/prose/model";
 import type { NodeView, ViewMutationRecord } from "@milkdown/kit/prose/view";
 
 /** 打鍵が止まったと見なすまでの時間。短いと打鍵中の構文エラー描画が増えるだけ */
 const RENDER_DELAY_MS = 400;
 
+/** コピー後にチェック表示を戻すまでの時間。押した実感が持てる最短くらい */
+const COPY_RESET_MS = 1500;
+
 /**
- * code_block の node view。pre>code の既定構造は保ちつつ、mermaid のときだけ
- * 直下にレンダリング済みの図をぶら下げる。
+ * code_block の node view。pre>code の既定構造は保ちつつ、ホバーで現れる
+ * コピー ボタンを角に置き、mermaid のときだけ直下にレンダリング済みの図を
+ * ぶら下げる。
  *
  * widget decoration ではなく node view にしたのは、図の寿命がブロックの寿命と
  * 一致するから。decoration set はトランザクションごとに再計算・再マッピングが
@@ -23,9 +30,17 @@ class CodeBlockPreviewView implements NodeView {
   contentDOM: HTMLElement;
 
   private readonly pre: HTMLElement;
+  private readonly copyButton: HTMLButtonElement;
   private preview: HTMLElement | undefined;
+  private node: Node;
   private lastSource: string | undefined;
   private lastSvg: string | undefined;
+
+  private readonly copyFeedback = createCopyFeedback(
+    (text) => navigator.clipboard.writeText(text),
+    (copied) => this.applyCopyState(copied),
+    COPY_RESET_MS,
+  );
 
   private readonly renderer = createDebouncedDiagramRenderer(
     async (source) => {
@@ -37,11 +52,13 @@ class CodeBlockPreviewView implements NodeView {
   );
 
   constructor(node: Node) {
+    this.node = node;
     this.dom = document.createElement("div");
     this.dom.className = "code-block-view";
     this.pre = document.createElement("pre");
     this.contentDOM = document.createElement("code");
-    this.pre.append(this.contentDOM);
+    this.copyButton = this.createCopyButton();
+    this.pre.append(this.contentDOM, this.copyButton);
     this.dom.append(this.pre);
     this.sync(node, { initial: true });
   }
@@ -65,9 +82,37 @@ class CodeBlockPreviewView implements NodeView {
 
   destroy(): void {
     this.renderer.dispose();
+    this.copyFeedback.dispose();
+  }
+
+  /**
+   * ホバーで現れるコピー ボタン(表示制御は CSS)。編集ノードの外なので
+   * contentEditable を切り、mousedown を止めてカーソルと選択を守る
+   */
+  private createCopyButton(): HTMLButtonElement {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "code-copy-button";
+    button.contentEditable = "false";
+    button.tabIndex = -1;
+    button.setAttribute("aria-label", "コードをコピー");
+    button.innerHTML = copyIcon;
+    button.addEventListener("mousedown", (event) => {
+      event.preventDefault();
+    });
+    button.addEventListener("click", () => {
+      this.copyFeedback.copy(this.node.textContent);
+    });
+    return button;
+  }
+
+  private applyCopyState(copied: boolean): void {
+    this.copyButton.classList.toggle("is-copied", copied);
+    this.copyButton.innerHTML = copied ? checkIcon : copyIcon;
   }
 
   private sync(node: Node, { initial }: { initial: boolean }): void {
+    this.node = node;
     const language = node.attrs.language as string;
 
     // node view が立つと schema の toDOM は使われない。言語ラベルの CSS が

--- a/tauri-app/src/lib/code-block-view-plugin.ts
+++ b/tauri-app/src/lib/code-block-view-plugin.ts
@@ -1,12 +1,13 @@
 import { $view } from "@milkdown/kit/utils";
 import { codeBlockSchema } from "@milkdown/kit/preset/commonmark";
+import { TextSelection } from "@milkdown/kit/prose/state";
 import copyIcon from "@phosphor-icons/core/assets/regular/copy.svg?raw";
 import checkIcon from "@phosphor-icons/core/assets/regular/check.svg?raw";
 import { renderDiagrams } from "./mermaid";
 import { isMermaidLanguage, createDebouncedDiagramRenderer } from "./mermaid-preview";
 import { createCopyFeedback } from "./copy-feedback";
 import type { Node } from "@milkdown/kit/prose/model";
-import type { NodeView, ViewMutationRecord } from "@milkdown/kit/prose/view";
+import type { EditorView, NodeView, ViewMutationRecord } from "@milkdown/kit/prose/view";
 
 /** 打鍵が止まったと見なすまでの時間。短いと打鍵中の構文エラー描画が増えるだけ */
 const RENDER_DELAY_MS = 400;
@@ -17,7 +18,10 @@ const COPY_RESET_MS = 1500;
 /**
  * code_block の node view。pre>code の既定構造は保ちつつ、ホバーで現れる
  * コピー ボタンを角に置き、mermaid のときだけ直下にレンダリング済みの図を
- * ぶら下げる。
+ * ぶら下げる。図が最新ソースを描けている間は has-diagram クラスが立ち、
+ * カーソルがブロック外にあるとき CSS がソースを隠して図だけを見せる
+ * (Slite/Typora 流)。描画に失敗している間はクラスを下ろし、ソースを
+ * 隠さない — 隠すと壊れた図を直せなくなる。
  *
  * widget decoration ではなく node view にしたのは、図の寿命がブロックの寿命と
  * 一致するから。decoration set はトランザクションごとに再計算・再マッピングが
@@ -29,6 +33,8 @@ class CodeBlockPreviewView implements NodeView {
   dom: HTMLElement;
   contentDOM: HTMLElement;
 
+  private readonly view: EditorView;
+  private readonly getPos: () => number | undefined;
   private readonly pre: HTMLElement;
   private readonly copyButton: HTMLButtonElement;
   private preview: HTMLElement | undefined;
@@ -51,8 +57,10 @@ class CodeBlockPreviewView implements NodeView {
     RENDER_DELAY_MS,
   );
 
-  constructor(node: Node) {
+  constructor(node: Node, view: EditorView, getPos: () => number | undefined) {
     this.node = node;
+    this.view = view;
+    this.getPos = getPos;
     this.dom = document.createElement("div");
     this.dom.className = "code-block-view";
     this.pre = document.createElement("pre");
@@ -69,6 +77,19 @@ class CodeBlockPreviewView implements NodeView {
     }
     this.sync(node, { initial: false });
     return true;
+  }
+
+  /**
+   * 編集ノードの外の部品(図・コピー ボタン)への操作は ProseMirror に
+   * 渡さない。渡すと図のクリックが node selection になったりする。
+   * pre の余白クリック(カーソル配置)は通すため、部品だけに絞る
+   */
+  stopEvent(event: Event): boolean {
+    const { target } = event;
+    if (!(target instanceof globalThis.Node)) {
+      return false;
+    }
+    return this.copyButton.contains(target) || (this.preview?.contains(target) ?? false);
   }
 
   ignoreMutation(mutation: ViewMutationRecord): boolean {
@@ -146,7 +167,9 @@ class CodeBlockPreviewView implements NodeView {
   private applyResult(svg: string | null): void {
     if (svg === null) {
       // 打鍵の途中は書きかけの構文になるのが普通。最後に描けた図を残して
-      // 落ち着きを保ち、まだ一度も描けていないときだけ控えめに伝える
+      // 落ち着きを保ち、まだ一度も描けていないときだけ控えめに伝える。
+      // 描けていない間はソースを隠さない(隠すと直せない)
+      this.dom.classList.remove("has-diagram");
       if (!this.lastSvg) {
         this.showNotice("図を描画できません");
       }
@@ -156,6 +179,7 @@ class CodeBlockPreviewView implements NodeView {
     const preview = this.ensurePreview();
     preview.classList.remove("is-error");
     preview.innerHTML = svg;
+    this.dom.classList.add("has-diagram");
   }
 
   private showNotice(text: string): void {
@@ -170,9 +194,25 @@ class CodeBlockPreviewView implements NodeView {
       this.preview.className = "mermaid-editor-preview";
       // 図は読み取り専用。編集対象はあくまで上のコードブロック
       this.preview.contentEditable = "false";
+      // 図だけの表示のとき、図をクリックしたらソースを開いて編集に入る
+      this.preview.addEventListener("click", () => {
+        this.focusSource();
+      });
       this.dom.append(this.preview);
     }
     return this.preview;
+  }
+
+  /** カーソルをブロック末尾に置いて is-active(ソース表示)に入る */
+  private focusSource(): void {
+    const pos = this.getPos();
+    if (pos === undefined) {
+      return;
+    }
+    const { state } = this.view;
+    const end = pos + this.node.nodeSize - 1;
+    this.view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, end)));
+    this.view.focus();
   }
 
   private resetPreview(): void {
@@ -182,12 +222,13 @@ class CodeBlockPreviewView implements NodeView {
     this.lastSvg = undefined;
     this.preview?.remove();
     this.preview = undefined;
+    this.dom.classList.remove("has-diagram");
   }
 }
 
 export const codeBlockViewPlugin = $view(
   codeBlockSchema.node,
   () =>
-    (node): NodeView =>
-      new CodeBlockPreviewView(node),
+    (node, view, getPos): NodeView =>
+      new CodeBlockPreviewView(node, view, getPos),
 );

--- a/tauri-app/src/lib/code-block-view-plugin.ts
+++ b/tauri-app/src/lib/code-block-view-plugin.ts
@@ -158,9 +158,6 @@ class CodeBlockPreviewView implements NodeView {
     input.addEventListener("change", () => {
       this.commitLanguage(input.value);
     });
-    input.addEventListener("input", () => {
-      this.resizeLanguageInput();
-    });
     input.addEventListener("keydown", (event) => {
       if (event.key === "Enter") {
         // change(コミット)を発火させてから、続けて書けるよう本文へ戻す
@@ -169,7 +166,6 @@ class CodeBlockPreviewView implements NodeView {
         this.focusSource();
       } else if (event.key === "Escape") {
         input.value = this.node.attrs.language as string;
-        this.resizeLanguageInput();
         input.blur();
       }
     });
@@ -189,14 +185,6 @@ class CodeBlockPreviewView implements NodeView {
     this.view.dispatch(state.tr.setNodeMarkup(pos, undefined, { ...this.node.attrs, language }));
   }
 
-  private resizeLanguageInput(): void {
-    // 入力はラベル扱いなので、値の実測幅ちょうどに縮めておく。ch 単位は
-    // --font-mono の先頭フォントが無い環境でフォールバックの実グリフ幅と
-    // ずれて末尾が欠けるため、scrollWidth で測る(下限は CSS の min-width)
-    this.languageInput.style.width = "0";
-    this.languageInput.style.width = `${this.languageInput.scrollWidth}px`;
-  }
-
   private sync(node: Node, { initial }: { initial: boolean }): void {
     this.node = node;
     const language = node.attrs.language as string;
@@ -212,7 +200,6 @@ class CodeBlockPreviewView implements NodeView {
     // 編集中の値をエディタ側の更新で潰さない
     if (document.activeElement !== this.languageInput) {
       this.languageInput.value = language;
-      this.resizeLanguageInput();
     }
 
     if (!isMermaidLanguage(language)) {

--- a/tauri-app/src/lib/code-block-view-plugin.ts
+++ b/tauri-app/src/lib/code-block-view-plugin.ts
@@ -6,7 +6,7 @@ import checkIcon from "@phosphor-icons/core/assets/regular/check.svg?raw";
 import { renderDiagrams } from "./mermaid";
 import { isMermaidLanguage, createDebouncedDiagramRenderer } from "./mermaid-preview";
 import { createCopyFeedback } from "./copy-feedback";
-import { LANGUAGE_DATALIST_ID, languageLabelWidth } from "./language-suggestions";
+import { LANGUAGE_DATALIST_ID } from "./language-suggestions";
 import type { Node } from "@milkdown/kit/prose/model";
 import type { EditorView, NodeView, ViewMutationRecord } from "@milkdown/kit/prose/view";
 
@@ -190,8 +190,11 @@ class CodeBlockPreviewView implements NodeView {
   }
 
   private resizeLanguageInput(): void {
-    // 入力はラベル扱いなので、値の長さちょうどに縮めておく(下限は placeholder 分)
-    this.languageInput.style.width = languageLabelWidth(this.languageInput.value);
+    // 入力はラベル扱いなので、値の実測幅ちょうどに縮めておく。ch 単位は
+    // --font-mono の先頭フォントが無い環境でフォールバックの実グリフ幅と
+    // ずれて末尾が欠けるため、scrollWidth で測る(下限は CSS の min-width)
+    this.languageInput.style.width = "0";
+    this.languageInput.style.width = `${this.languageInput.scrollWidth}px`;
   }
 
   private sync(node: Node, { initial }: { initial: boolean }): void {

--- a/tauri-app/src/lib/code-block-view-plugin.ts
+++ b/tauri-app/src/lib/code-block-view-plugin.ts
@@ -140,7 +140,7 @@ class CodeBlockPreviewView implements NodeView {
   }
 }
 
-export const mermaidPreviewPlugin = $view(
+export const codeBlockViewPlugin = $view(
   codeBlockSchema.node,
   () =>
     (node): NodeView =>

--- a/tauri-app/src/lib/copy-feedback.test.ts
+++ b/tauri-app/src/lib/copy-feedback.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createCopyFeedback } from "./copy-feedback";
+
+const RESET = 1500;
+
+type WriteFn = (text: string) => Promise<void>;
+type StateFn = (copied: boolean) => void;
+
+/** 書き込み完了の順番をテスト側で握るための、外から解決できる Promise */
+function deferred(): { promise: Promise<void>; resolve: () => void; reject: () => void } {
+  let storedResolve!: () => void;
+  let storedReject!: () => void;
+  // 解決を外から握るには executor を書くしかない
+  // oxlint-disable-next-line promise/avoid-new
+  const promise = new Promise<void>((resolve, reject) => {
+    storedResolve = resolve;
+    storedReject = reject;
+  });
+  return { promise, resolve: storedResolve, reject: storedReject };
+}
+
+/** vi.waitFor はタイマーも進めてしまうので、マイクロタスクだけを流す */
+function flushMicrotasks(): Promise<void> {
+  return vi.advanceTimersByTimeAsync(0);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createCopyFeedback", () => {
+  it("writes the text, reports copied, and resets after the delay", async () => {
+    const write = vi.fn<WriteFn>(() => Promise.resolve());
+    const onState = vi.fn<StateFn>();
+    const feedback = createCopyFeedback(write, onState, RESET);
+
+    feedback.copy("const a = 1;");
+    await flushMicrotasks();
+
+    expect(onState).toHaveBeenCalledExactlyOnceWith(true);
+    expect(write).toHaveBeenCalledExactlyOnceWith("const a = 1;");
+    vi.advanceTimersByTime(RESET);
+    expect(onState).toHaveBeenLastCalledWith(false);
+  });
+
+  // 連打しても「コピー済み」表示がチカチカしないよう、リセットは最後の 1 回分だけ
+  it("restarts the reset timer when copy is pressed again", async () => {
+    const write = vi.fn<WriteFn>(() => Promise.resolve());
+    const onState = vi.fn<StateFn>();
+    const feedback = createCopyFeedback(write, onState, RESET);
+
+    feedback.copy("a");
+    await flushMicrotasks();
+    vi.advanceTimersByTime(RESET - 100);
+    feedback.copy("a");
+    await flushMicrotasks();
+    expect(onState).toHaveBeenCalledTimes(2);
+
+    vi.advanceTimersByTime(RESET - 100);
+    expect(onState).not.toHaveBeenCalledWith(false);
+    vi.advanceTimersByTime(100);
+    expect(onState).toHaveBeenLastCalledWith(false);
+  });
+
+  // クリップボードが使えない環境では黙って何もしない。誤った「コピー済み」を出すよりよい
+  it("reports nothing when the clipboard write fails", async () => {
+    const failure = deferred();
+    const write = vi.fn<WriteFn>().mockReturnValue(failure.promise);
+    const onState = vi.fn<StateFn>();
+    const feedback = createCopyFeedback(write, onState, RESET);
+
+    feedback.copy("a");
+    failure.reject();
+    await Promise.resolve();
+    vi.advanceTimersByTime(RESET);
+
+    expect(onState).not.toHaveBeenCalled();
+  });
+
+  it("dispose drops pending resets and in-flight writes", async () => {
+    const inFlight = deferred();
+    const write = vi.fn<WriteFn>().mockReturnValue(inFlight.promise);
+    const onState = vi.fn<StateFn>();
+    const feedback = createCopyFeedback(write, onState, RESET);
+
+    feedback.copy("a");
+    feedback.dispose();
+    inFlight.resolve();
+    await Promise.resolve();
+    vi.advanceTimersByTime(RESET);
+
+    expect(onState).not.toHaveBeenCalled();
+  });
+});

--- a/tauri-app/src/lib/copy-feedback.ts
+++ b/tauri-app/src/lib/copy-feedback.ts
@@ -1,0 +1,55 @@
+export interface CopyFeedback {
+  copy(text: string): void;
+  dispose(): void;
+}
+
+/**
+ * コピー操作の「コピー済み」表示を制御する。書き込みが成功したときだけ
+ * copied を報せ、一定時間後に自動で戻す。連打してもリセットは最後の
+ * 1 回分だけ。writeText を注入させるのは、実クリップボードなしで
+ * この制御をテストするため。
+ */
+export function createCopyFeedback(
+  writeText: (text: string) => Promise<void>,
+  onStateChange: (copied: boolean) => void,
+  resetMs: number,
+): CopyFeedback {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let disposed = false;
+
+  const clearTimer = (): void => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  return {
+    copy(text) {
+      if (disposed) {
+        return;
+      }
+      void (async () => {
+        try {
+          await writeText(text);
+        } catch {
+          // クリップボードが使えないときは黙る。誤った「コピー済み」を出すよりよい
+          return;
+        }
+        if (disposed) {
+          return;
+        }
+        clearTimer();
+        onStateChange(true);
+        timer = setTimeout(() => {
+          timer = undefined;
+          onStateChange(false);
+        }, resetMs);
+      })();
+    },
+    dispose() {
+      disposed = true;
+      clearTimer();
+    },
+  };
+}

--- a/tauri-app/src/lib/highlight-parser.test.ts
+++ b/tauri-app/src/lib/highlight-parser.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from "vitest";
+import { withKnownLanguages } from "./highlight-parser";
+import type { Parser } from "@milkdown/plugin-highlight/shiki";
+
+const LOADED = ["javascript", "js", "typescript", "ts", "rust"];
+
+function parserOptions(language?: string) {
+  return { content: "let x = 1;", language, pos: 0, size: 12 };
+}
+
+describe("withKnownLanguages", () => {
+  it("delegates to the inner parser for a loaded language", () => {
+    const inner = vi.fn<Parser>().mockReturnValue([]);
+    const parser = withKnownLanguages(inner, LOADED);
+
+    const result = parser(parserOptions("rust"));
+
+    expect(inner).toHaveBeenCalledExactlyOnceWith(parserOptions("rust"));
+    expect(result).toEqual([]);
+  });
+
+  // フェンスの info 文字列は手打ちなので、大文字や前後の空白はよくある揺れ。
+  // Shiki の言語 ID は小文字なので、正規化してから照合・委譲する
+  it("normalizes case and whitespace before matching", () => {
+    const inner = vi.fn<Parser>().mockReturnValue([]);
+    const parser = withKnownLanguages(inner, LOADED);
+
+    parser(parserOptions(" TS "));
+
+    expect(inner).toHaveBeenCalledExactlyOnceWith(parserOptions("ts"));
+  });
+
+  // 読み込んでいない言語を Shiki に渡すと ShikiError が投げられ、
+  // prosemirror-highlight が console error を出した上で後続ブロックの
+  // ハイライトまで打ち切ってしまう(issue #101)
+  it("returns no decorations for a language the highlighter has not loaded", () => {
+    const inner = vi.fn<Parser>();
+    const parser = withKnownLanguages(inner, LOADED);
+
+    const result = parser(parserOptions("mermaid"));
+
+    expect(inner).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it("returns no decorations when the language is missing or empty", () => {
+    const inner = vi.fn<Parser>();
+    const parser = withKnownLanguages(inner, LOADED);
+
+    expect(parser(parserOptions())).toEqual([]);
+    expect(parser(parserOptions(""))).toEqual([]);
+    expect(inner).not.toHaveBeenCalled();
+  });
+});

--- a/tauri-app/src/lib/highlight-parser.ts
+++ b/tauri-app/src/lib/highlight-parser.ts
@@ -1,0 +1,25 @@
+import type { Parser } from "@milkdown/plugin-highlight/shiki";
+
+/**
+ * ハイライトを highlighter が読み込み済みの言語だけに絞るデコレータ。
+ *
+ * 未読込の言語(mermaid など)を Shiki に渡すと ShikiError が投げられ、
+ * prosemirror-highlight は console error を出した上で同じ走査内の後続
+ * コードブロックのハイライトまで打ち切ってしまう(issue #101)。
+ * 文法を足すのではなく手前で素通しにするのは、mermaid はブロック直下に
+ * 描画済みの図が出るためテキスト側の色付けの価値が薄く、文法ファイル
+ * (約 36KB)のバンドル増が Lightweight に見合わないから。
+ *
+ * fence の info 文字列は手打ちなので、照合の前に小文字化と trim で
+ * 正規化し、Shiki には正規化済みの言語 ID を渡す。
+ */
+export function withKnownLanguages(parser: Parser, loadedLanguages: readonly string[]): Parser {
+  const known = new Set(loadedLanguages);
+  return (options) => {
+    const language = options.language?.trim().toLowerCase();
+    if (!language || !known.has(language)) {
+      return [];
+    }
+    return parser({ ...options, language });
+  };
+}

--- a/tauri-app/src/lib/language-suggestions.test.ts
+++ b/tauri-app/src/lib/language-suggestions.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import {
   buildLanguageSuggestions,
   ensureLanguageDatalist,
+  languageLabelWidth,
   LANGUAGE_DATALIST_ID,
 } from "./language-suggestions";
 
@@ -19,6 +20,19 @@ describe("buildLanguageSuggestions", () => {
   it("always offers mermaid even though the highlighter does not load it", () => {
     expect(buildLanguageSuggestions([])).toEqual(["mermaid"]);
     expect(buildLanguageSuggestions(["mermaid", "ts"])).toEqual(["mermaid", "ts"]);
+  });
+});
+
+describe("languageLabelWidth", () => {
+  // input の size 属性は平均文字幅ベースで、monospace でも "mermaid" が
+  // 「mermai」に欠けた。ch 単位+丸め誤差ぶんの余白で文字数に追従させる
+  it("gives every character a ch plus rounding slack", () => {
+    expect(languageLabelWidth("mermaid")).toBe("8ch");
+  });
+
+  it("keeps room for the placeholder when the value is short or empty", () => {
+    expect(languageLabelWidth("js")).toBe("5ch");
+    expect(languageLabelWidth("")).toBe("5ch");
   });
 });
 

--- a/tauri-app/src/lib/language-suggestions.test.ts
+++ b/tauri-app/src/lib/language-suggestions.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, afterEach } from "vitest";
 import {
   buildLanguageSuggestions,
   ensureLanguageDatalist,
-  languageLabelWidth,
   LANGUAGE_DATALIST_ID,
 } from "./language-suggestions";
 
@@ -20,19 +19,6 @@ describe("buildLanguageSuggestions", () => {
   it("always offers mermaid even though the highlighter does not load it", () => {
     expect(buildLanguageSuggestions([])).toEqual(["mermaid"]);
     expect(buildLanguageSuggestions(["mermaid", "ts"])).toEqual(["mermaid", "ts"]);
-  });
-});
-
-describe("languageLabelWidth", () => {
-  // input の size 属性は平均文字幅ベースで、monospace でも "mermaid" が
-  // 「mermai」に欠けた。ch 単位+丸め誤差ぶんの余白で文字数に追従させる
-  it("gives every character a ch plus rounding slack", () => {
-    expect(languageLabelWidth("mermaid")).toBe("8ch");
-  });
-
-  it("keeps room for the placeholder when the value is short or empty", () => {
-    expect(languageLabelWidth("js")).toBe("5ch");
-    expect(languageLabelWidth("")).toBe("5ch");
   });
 });
 

--- a/tauri-app/src/lib/language-suggestions.test.ts
+++ b/tauri-app/src/lib/language-suggestions.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  buildLanguageSuggestions,
+  ensureLanguageDatalist,
+  LANGUAGE_DATALIST_ID,
+} from "./language-suggestions";
+
+describe("buildLanguageSuggestions", () => {
+  it("sorts the loaded languages", () => {
+    expect(buildLanguageSuggestions(["ts", "bash", "rust"])).toEqual([
+      "bash",
+      "mermaid",
+      "rust",
+      "ts",
+    ]);
+  });
+
+  // mermaid はハイライト対象外でも図が描ける言語なので、候補から漏らさない
+  it("always offers mermaid even though the highlighter does not load it", () => {
+    expect(buildLanguageSuggestions([])).toEqual(["mermaid"]);
+    expect(buildLanguageSuggestions(["mermaid", "ts"])).toEqual(["mermaid", "ts"]);
+  });
+});
+
+describe("ensureLanguageDatalist", () => {
+  afterEach(() => {
+    document.querySelector(`#${LANGUAGE_DATALIST_ID}`)?.remove();
+  });
+
+  it("creates a datalist with one option per language", () => {
+    const id = ensureLanguageDatalist(document, ["js", "rust"]);
+
+    expect(id).toBe(LANGUAGE_DATALIST_ID);
+    const options = document.querySelectorAll(`#${LANGUAGE_DATALIST_ID} option`);
+    expect([...options].map((o) => (o as HTMLOptionElement).value)).toEqual(["js", "rust"]);
+  });
+
+  // エディタは開き直されるし、ブロックごとに nodeView が立つ。何度呼んでも 1 つ
+  it("reuses the existing datalist instead of adding a second one", () => {
+    ensureLanguageDatalist(document, ["js"]);
+    ensureLanguageDatalist(document, ["js", "rust"]);
+
+    expect(document.querySelectorAll("datalist")).toHaveLength(1);
+    const options = document.querySelectorAll(`#${LANGUAGE_DATALIST_ID} option`);
+    expect(options).toHaveLength(2);
+  });
+});

--- a/tauri-app/src/lib/language-suggestions.ts
+++ b/tauri-app/src/lib/language-suggestions.ts
@@ -1,0 +1,32 @@
+export const LANGUAGE_DATALIST_ID = "code-language-suggestions";
+
+/**
+ * 言語入力の補完候補。highlighter の読込済み言語(エイリアス込み)に、
+ * ハイライト対象外でも図が描ける mermaid を足して並べる。未知言語の
+ * ハイライトを黙ってスキップするようにした(#101)ぶん、綴り違いの
+ * 受け皿はこの補完が担う。
+ */
+export function buildLanguageSuggestions(loadedLanguages: readonly string[]): string[] {
+  return [...new Set(["mermaid", ...loadedLanguages])].toSorted();
+}
+
+/**
+ * 全コードブロックの言語入力が共有する datalist を document に 1 つだけ置く。
+ * nodeView はブロックごとに立つので、呼び出しは冪等にしておく。
+ */
+export function ensureLanguageDatalist(doc: Document, languages: readonly string[]): string {
+  let list = doc.querySelector(`#${LANGUAGE_DATALIST_ID}`);
+  if (!list) {
+    list = doc.createElement("datalist");
+    list.id = LANGUAGE_DATALIST_ID;
+    doc.body.append(list);
+  }
+  list.replaceChildren(
+    ...languages.map((language) => {
+      const option = doc.createElement("option");
+      option.value = language;
+      return option;
+    }),
+  );
+  return LANGUAGE_DATALIST_ID;
+}

--- a/tauri-app/src/lib/language-suggestions.ts
+++ b/tauri-app/src/lib/language-suggestions.ts
@@ -11,6 +11,16 @@ export function buildLanguageSuggestions(loadedLanguages: readonly string[]): st
 }
 
 /**
+ * 言語入力の表示幅。input の size 属性は「平均文字幅」ベースで、monospace
+ * でも "mermaid" が「mermai」に欠けた。ch 単位なら等幅で 1 文字 = 1ch なので、
+ * 文字数+丸め誤差ぶんの余白 1ch で追従させる。下限は placeholder
+ * 「言語」(全角 2 文字 ≈ 4ch)が収まる幅。
+ */
+export function languageLabelWidth(value: string): string {
+  return `${Math.max(value.length, 4) + 1}ch`;
+}
+
+/**
  * 全コードブロックの言語入力が共有する datalist を document に 1 つだけ置く。
  * nodeView はブロックごとに立つので、呼び出しは冪等にしておく。
  */

--- a/tauri-app/src/lib/language-suggestions.ts
+++ b/tauri-app/src/lib/language-suggestions.ts
@@ -11,16 +11,6 @@ export function buildLanguageSuggestions(loadedLanguages: readonly string[]): st
 }
 
 /**
- * 言語入力の表示幅。input の size 属性は「平均文字幅」ベースで、monospace
- * でも "mermaid" が「mermai」に欠けた。ch 単位なら等幅で 1 文字 = 1ch なので、
- * 文字数+丸め誤差ぶんの余白 1ch で追従させる。下限は placeholder
- * 「言語」(全角 2 文字 ≈ 4ch)が収まる幅。
- */
-export function languageLabelWidth(value: string): string {
-  return `${Math.max(value.length, 4) + 1}ch`;
-}
-
-/**
  * 全コードブロックの言語入力が共有する datalist を document に 1 つだけ置く。
  * nodeView はブロックごとに立つので、呼び出しは冪等にしておく。
  */

--- a/tauri-app/src/lib/mermaid-figure-click.test.ts
+++ b/tauri-app/src/lib/mermaid-figure-click.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach } from "vitest";
+import "../styles/editor.css";
+
+/**
+ * 図だけ表示のとき、ユーザーが最も押すのは描画された図そのもの。
+ * ソースを開くクリック ハンドラは preview コンテナに付いているので、
+ * SVG の内部要素(図形や foreignObject のラベル)がヒットテストで
+ * クリックを食うと、コンテナ余白しか反応しなくなる。
+ */
+describe("mermaid figure click-through", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("hits the preview container even when the point is inside the svg", () => {
+    document.body.innerHTML = `
+      <div class="milkdown-editor">
+        <div class="milkdown">
+          <div class="ProseMirror">
+            <div class="code-block-view has-diagram">
+              <pre><code>graph TD;</code></pre>
+              <div class="mermaid-editor-preview"><svg width="200" height="100" viewBox="0 0 200 100"><g><rect x="0" y="0" width="200" height="100" fill="red"></rect></g></svg></div>
+            </div>
+          </div>
+        </div>
+      </div>`;
+    const preview = document.querySelector(".mermaid-editor-preview");
+    const svg = document.querySelector("svg");
+    if (!preview || !svg) {
+      throw new Error("fixture not mounted");
+    }
+
+    const rect = svg.getBoundingClientRect();
+    const hit = document.elementFromPoint(rect.x + rect.width / 2, rect.y + rect.height / 2);
+
+    expect(hit).toBe(preview);
+  });
+});

--- a/tauri-app/src/styles/editor.css
+++ b/tauri-app/src/styles/editor.css
@@ -103,6 +103,9 @@
   font-size: var(--font-size-0);
   line-height: 1;
   color: var(--app-text-muted);
+  /* 幅は nodeView が scrollWidth で実測して当てる。placeholder「言語」の
+     ぶんだけは空でもクリックできるよう下限を持つ */
+  min-width: 5ch;
 }
 
 .milkdown-editor .code-language-input:focus {

--- a/tauri-app/src/styles/editor.css
+++ b/tauri-app/src/styles/editor.css
@@ -71,6 +71,7 @@
    width: 100% の箱に padding 24px 22px)。Open Props の normalize が
    pre を max-inline-size: max-content で内容にフィットさせるので解除する */
 .milkdown-editor pre {
+  position: relative;
   max-inline-size: none;
   width: 100%;
   background: var(--app-surface-2);
@@ -87,22 +88,34 @@
   min-height: 1em;
 }
 
-/* 言語ラベル: code_block が pre に書き出す data-language を attr() で見せるだけ。
-   DOM ノードもプラグインも増やさない、いちばん軽い形 */
-.milkdown-editor pre[data-language] {
-  position: relative;
-}
-
-.milkdown-editor pre[data-language]::before {
-  content: attr(data-language);
+/* 言語入力: ラベルの見た目のまま、クリックすると datalist 補完つきで
+   編集できる(Notion の言語ドロップダウン相当。位置も Notion に合わせ左上)。
+   言語が空のときは placeholder しかないので、ホバー中と編集中だけ見せる */
+.milkdown-editor .code-language-input {
   position: absolute;
   top: var(--size-1);
-  right: var(--size-2);
+  left: var(--size-2);
+  border: none;
+  background: none;
+  padding: 0;
+  outline: none;
   font-family: var(--font-mono);
   font-size: var(--font-size-0);
   line-height: 1;
   color: var(--app-text-muted);
-  pointer-events: none;
+}
+
+.milkdown-editor .code-language-input:focus {
+  color: var(--app-text);
+}
+
+.milkdown-editor .code-language-input:placeholder-shown {
+  opacity: 0;
+}
+
+.milkdown-editor pre:hover .code-language-input:placeholder-shown,
+.milkdown-editor .code-language-input:focus {
+  opacity: 1;
 }
 
 /* コピー ボタン: 既定は非表示で、ブロックにホバーしている間だけ角に現れる
@@ -144,11 +157,6 @@
   width: 14px;
   height: 14px;
   fill: currentColor;
-}
-
-/* ホバー中の角はコピー操作に譲る。言語ラベルは情報なので一時退避 */
-.milkdown-editor pre[data-language]:hover::before {
-  opacity: 0;
 }
 
 /* mermaid のエディタ内プレビュー: コードブロックの直下に描いた図をぶら下げる。

--- a/tauri-app/src/styles/editor.css
+++ b/tauri-app/src/styles/editor.css
@@ -172,6 +172,19 @@
   color: var(--app-text-muted);
 }
 
+/* mermaid は図がメイン(Slite 流)。カーソルがブロック外にある間はソースを
+   隠して図だけを見せる。is-active はカーソルが触れているブロックに
+   code-block-active-plugin が付け、has-diagram は最新ソースを描けている間
+   だけ nodeView が立てる — 描画に失敗した壊れたソースは隠れない */
+.milkdown-editor .code-block-view.has-diagram:not(.is-active) pre {
+  display: none;
+}
+
+.milkdown-editor .code-block-view.has-diagram:not(.is-active) .mermaid-editor-preview {
+  margin-top: 0;
+  cursor: pointer;
+}
+
 .milkdown-editor blockquote {
   border-left: 3px solid var(--app-border);
   padding-left: var(--size-3);

--- a/tauri-app/src/styles/editor.css
+++ b/tauri-app/src/styles/editor.css
@@ -97,6 +97,52 @@
   pointer-events: none;
 }
 
+/* コピー ボタン: 既定は非表示で、ブロックにホバーしている間だけ角に現れる
+   (アクションはホバーで出す家風)。visibility も切るのは、透明なままだと
+   見えないボタンがクリックを吸ってしまうから */
+.milkdown-editor .code-copy-button {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  display: inline-flex;
+  align-items: center;
+  padding: var(--size-1);
+  border: none;
+  border-radius: var(--radius-1);
+  background: none;
+  color: var(--app-text-muted);
+  cursor: pointer;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.milkdown-editor pre:hover .code-copy-button {
+  visibility: visible;
+  opacity: 1;
+}
+
+.milkdown-editor .code-copy-button:hover {
+  color: var(--app-text);
+  background: var(--app-surface-3);
+}
+
+/* コピー直後のチェック表示。押した実感のための最小の変化 */
+.milkdown-editor .code-copy-button.is-copied {
+  color: var(--app-accent);
+}
+
+.milkdown-editor .code-copy-button svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+}
+
+/* ホバー中の角はコピー操作に譲る。言語ラベルは情報なので一時退避 */
+.milkdown-editor pre[data-language]:hover::before {
+  opacity: 0;
+}
+
 /* mermaid のエディタ内プレビュー: コードブロックの直下に描いた図をぶら下げる。
    幅に合わせて縮め、mermaid が SVG に付ける max-width(原寸)以上には広げない */
 .milkdown-editor .mermaid-editor-preview {

--- a/tauri-app/src/styles/editor.css
+++ b/tauri-app/src/styles/editor.css
@@ -103,9 +103,12 @@
   font-size: var(--font-size-0);
   line-height: 1;
   color: var(--app-text-muted);
-  /* 幅は nodeView が scrollWidth で実測して当てる。placeholder「言語」の
-     ぶんだけは空でもクリックできるよう下限を持つ */
-  min-width: 5ch;
+  /* 背景も枠も無い透明なラベルなので、幅は文字にフィットさせず余裕を持たせる。
+     実測フィット(size 属性 / ch / scrollWidth / canvas)はどれもフォント
+     フォールバックや非表示中のレイアウトとずれて末尾が欠けた。上限は
+     右上のコピー ボタンに届かない幅 */
+  width: 10em;
+  max-width: calc(100% - var(--size-8));
 }
 
 .milkdown-editor .code-language-input:focus {

--- a/tauri-app/src/styles/editor.css
+++ b/tauri-app/src/styles/editor.css
@@ -171,6 +171,9 @@
 .milkdown-editor .mermaid-editor-preview svg {
   max-width: 100%;
   height: auto;
+  /* ソースを開くクリックはコンテナで受ける。SVG の内部要素(図形や
+     foreignObject のラベル)にヒットテストを食わせない */
+  pointer-events: none;
 }
 
 /* まだ一度も描けていないときだけ出す控えめな知らせ */

--- a/tauri-app/src/styles/editor.css
+++ b/tauri-app/src/styles/editor.css
@@ -67,9 +67,14 @@
   font-size: 0.9em;
 }
 
+/* コードブロックは内容量と無関係な一定サイズから始める(sample の Notion は
+   width: 100% の箱に padding 24px 22px)。Open Props の normalize が
+   pre を max-inline-size: max-content で内容にフィットさせるので解除する */
 .milkdown-editor pre {
+  max-inline-size: none;
+  width: 100%;
   background: var(--app-surface-2);
-  padding: var(--size-3);
+  padding: var(--size-5);
   border-radius: var(--radius-2);
   overflow-x: auto;
 }
@@ -77,6 +82,9 @@
 .milkdown-editor pre code {
   background: none;
   padding: 0;
+  /* 空のブロックでも 1 行分の高さを保つ(Notion の leaf と同じ min-height) */
+  display: block;
+  min-height: 1em;
 }
 
 /* 言語ラベル: code_block が pre に書き出す data-language を attr() で見せるだけ。

--- a/tauri-app/src/styles/markdown-preview.css
+++ b/tauri-app/src/styles/markdown-preview.css
@@ -32,6 +32,10 @@
 }
 
 .markdown-preview pre {
+  /* normalize の max-content フィットを解除して本文幅に(editor.css と同じ理由)。
+     padding はタイムラインのカードが窮屈にならないよう既存のまま */
+  max-inline-size: none;
+  width: 100%;
   background: var(--app-surface-2);
   padding: var(--size-3);
   border-radius: var(--radius-2);


### PR DESCRIPTION
## 1. 概要

- コードブロックと mermaid の編集体験を、参考ページ(`sample/codeblock, mermaid/` の Notion と Slite の保存 HTML)に合わせて引き上げる。**初版で「不採用」とした 2 点(mermaid の表示切替、言語ドロップダウン)はレビューを受けて判断を覆し、採用した**(経緯は下記)
- **mermaid は図がメイン表示に(Slite/Typora 流)**: 初版は「コード常時表示+図」を Notion の分割モード相当と整理して切替 UI を却下したが、読み手にとってソースが常時ノイズになる点を見落としていた。Slite の参考ページは `data-type="diagram"` ブロックで**図だけ**をカード表示し、ソースは選択時のみ編集に出す。これに合わせ、カーソルがブロック外にある間はソースを隠して図だけを見せ、ブロックに入る(矢印キー/図クリック)とソースが開く。タブやドロップダウンの chrome は足さない(CLAUDE.md の「Inline Markdown live conversion (Typora-style)」に合致)。**描画に失敗している間はソースを隠さない** — 隠すと壊れた図を直せなくなる。実装は選択→ `is-active` node decoration + CSS で、nodeView に選択の配線を持ち込まず、カーソル・スクロールを壊さない(Editor Performance Principles 3)
- **言語ラベルを補完付き入力に格上げ(Notion の Open language dropdown 相当)**: 初版は「fence の info 文字列そのものが入力」としてラベル維持としたが、#101 で未知言語のハイライトを黙ってスキップするため、綴り違い(`Javascript`, `node` 等)が完全に無反応になる。その受け皿として、ラベルをクリックで編集できる小さな入力にし、highlighter の読込済み言語+エイリアス+mermaid を共有 datalist で補完する。確定は `setNodeMarkup` で info 文字列を書き換え、Enter で本文へ戻り、Escape で取り消す。位置は Notion に合わせ左上へ移動(右上はコピー ボタン)。言語が空の間はホバー時のみ表示で chrome を増やさない
- **ホバーで現れるコピー ボタン**(Notion の `Copy code to clipboard`): 既定は非表示、ブロックにホバー中だけ右上に表示。押すとチェックに変わり 1.5 秒で戻る。リセットのデバウンスと失敗時の沈黙は writeText 注入のコントローラに分離して単体テスト
- **コードブロックは内容量と無関係な一定サイズから始める**(Notion 同様): 従来は Open Props の normalize(`:where(pre) { max-inline-size: max-content }`)で内容にフィットして縮んでいた(実測: 552px 幅のエディタで 146px、空ブロックは 32×32px)。フィットを解除して本文幅いっぱいに、padding は Notion の箱の 24px 22px に合わせ `var(--size-5)`、空ブロックは Notion の leaf と同じ `min-height: 1em`。読み取り専用プレビューも幅のみ同修正
- **issue #101**(mermaid ブロックで Shiki が `Language mermaid not found` を console error)は**案 2「ハイライト対象外にする」で修正**。理由: (a) mermaid 文法は約 36KB のバンドル増で Lightweight に見合わない、(b) mermaid はブロック直下(今回からはメイン)に描画済みの図が出るためテキスト側の色付けの価値が薄い、(c) prosemirror-highlight は 1 ブロックの ShikiError で同じ走査内の後続ブロックのハイライトまで打ち切るため、未読込言語の素通しはエラー消し以上の直しになる。修正は mermaid 固定ではなく「読み込み済みの言語だけ委譲する」デコレータ(未読込の python 等も同様に静かになる)
- Tidy First: nodeView は既に全 code_block を持っていたので、機能を足す前に `mermaid-preview-plugin.ts` → `code-block-view-plugin.ts` の改名を構造変更コミットとして分離
- 実画面検証(agent-browser)で見つかった 2 件を修正済み: 言語ラベルの末尾欠け(size 属性 / ch / scrollWidth / canvas measureText のどれもフォントフォールバック後の実グリフ幅と一致しなかったため、実測フィットを諦めて固定の余裕幅 10em+コピー ボタン手前で cap。透明なラベルなので幅がぴったりである必要はない)と、図そのもののクリックでソースが開かない(SVG 内部要素がヒットテストを食う → svg を `pointer-events: none` にしてコンテナで受ける。elementFromPoint の実ヒットテストで回帰を固定)

Closes #101

## 2. 図解

緑枠が追加された要素。上が #101 のハイライト経路、下が code_block nodeView に足した部品。datalist の中身はハイライト経路と同じ「読込済み言語」+mermaid。

```mermaid
flowchart TD
  subgraph hlpath ["ハイライト経路 (#101)"]
    hl["Shiki highlighter"] --> guard["withKnownLanguages<br/>(未読込言語は素通し)"]
    guard -->|"読込済み言語のみ"| parser["prosemirror-highlight<br/>Shiki parser"]
  end
  subgraph nodeview ["code_block nodeView"]
    cb["code-block-view-plugin"] --> lang["code-language-input<br/>(datalist: 読込済み言語+mermaid<br/>確定は setNodeMarkup)"]
    cb --> btn["code-copy-button<br/>(ホバーで表示・1.5s チェック)"]
    cb --> fig["mermaid 図 (has-diagram)"]
  end
  parser ~~~ sel
  sel["codeBlockActivePlugin<br/>(選択 → is-active decoration)"] -.->|"is-active が無い間<br/>CSS がソース (pre) を隠す"| fig
  classDef added stroke:#3fb950,stroke-width:3px
  class guard,lang,btn,fig,sel added
```

## 3. 変更ファイル

| ファイル                                                     | 変更        | 理由                                                                     |
| ------------------------------------------------------------ | ----------- | ------------------------------------------------------------------------ |
| `tauri-app/src/lib/highlight-parser.ts` / `.test.ts`         | +79 / -0    | 読込済み言語だけ Shiki に委譲するデコレータ(#101)+ 4 ケース             |
| `tauri-app/src/lib/copy-feedback.ts` / `.test.ts`            | +153 / -0   | コピー済み表示の制御(成功時のみ・自動リセット・失敗時は沈黙)+ 4 ケース |
| `tauri-app/src/lib/active-code-block.ts` / `.test.ts`        | +81 / -0    | 選択範囲と code_block の交差判定(図メイン表示の判定部)+ 5 ケース       |
| `tauri-app/src/lib/code-block-active-plugin.ts`              | +29 / -0    | 選択が触れるブロックへ `is-active` node decoration を付ける              |
| `tauri-app/src/lib/language-suggestions.ts` / `.test.ts`     | +103 / -0   | 補完候補(読込済み言語+mermaid)・共有 datalist・ch 単位のラベル幅 + 6 ケース |
| `tauri-app/src/lib/mermaid-figure-click.test.ts`             | +38 / -0    | 図の上のクリックがコンテナに届くことの実ヒットテスト(elementFromPoint) |
| `code-block-view-plugin.ts`(旧 `mermaid-preview-plugin.ts`) | +302 / -148 | nodeView 本体: 言語入力・コピー ボタン・図メイン表示(has-diagram)      |
| `tauri-app/src/components/MilkdownEditor.tsx`                | +16 / -5    | パーサのデコレータ適用・datalist 設置・プラグイン登録                    |
| `tauri-app/src/styles/editor.css`                            | +89 / -11   | 固定サイズ開始・コピー ボタン・言語入力・図メイン表示の CSS              |
| `tauri-app/src/styles/markdown-preview.css`                  | +4 / -0     | プレビュー側も pre の内容フィットを解除(幅のみ)                        |
| `CLAUDE.md`                                                  | +14 / -13   | Milkdown Plugins 表を改名・追加プラグインに追随                          |

**合計:** 16 ファイル, +908 / -177(改名の旧・新パスを含む)

## 4. テスト

- [x] `just test` — tauri-app 27 ファイル / 239 件全通過(新規 20 件: highlight-parser 4 + copy-feedback 4 + active-code-block 5 + language-suggestions 6 + 図クリックのヒットテスト 1)。rust / workers も全通過
- [x] `just check` — oxlint / tsgo / knip(rust・workers 含む)すべてエラー・警告なし
- [x] `just verify`(nix fmt 含む)— 差分なし
- [x] `pnpm run build` — 成功。mermaid が分離チャンク(`mermaid.core-*.js`)のままであることを確認
- [x] コードブロックの寸法を vitest browser(chromium)で実測 — 修正前 146×63 / 空 32×32 → 修正後 552×76 / 空 552×64(コンテナ 552px、使い捨てテストのため未コミット)
- [ ] 実アプリでの目視確認(mermaid の図⇔ソース切替とカーソル挙動、言語補完の datalist 表示、コピー後のチェック表示、mermaid ブロックで console error が出ないこと)
