### PR TITLE
feat(note): add a per-note mindmap view rendered with markmap-view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,16 +14,16 @@ If a dependency adds weight, it must justify itself against lightness.
 
 ## Tech Stack
 
-| Layer            | Technology                                  |
-| ---------------- | ------------------------------------------- |
-| Core logic       | Rust (`core/` crate, framework-independent) |
-| Desktop app      | Tauri 2 + SolidJS                           |
-| Styling          | Open Props (CSS custom properties)          |
-| Icons            | Phosphor Icons (SVG files)                  |
-| Editor           | Milkdown (headless, SolidJS integration)    |
-| Syntax highlight | Shiki                                       |
-| Markdown         | markdown-it + Shiki                         |
-| Diagrams         | Mermaid (dynamic import)                    |
+| Layer            | Technology                                                           |
+| ---------------- | -------------------------------------------------------------------- |
+| Core logic       | Rust (`core/` crate, framework-independent)                          |
+| Desktop app      | Tauri 2 + SolidJS                                                    |
+| Styling          | Open Props (CSS custom properties)                                   |
+| Icons            | Phosphor Icons (SVG files)                                           |
+| Editor           | Milkdown (headless, SolidJS integration)                             |
+| Syntax highlight | Shiki                                                                |
+| Markdown         | markdown-it + Shiki                                                  |
+| Diagrams         | Mermaid (dynamic import)                                             |
 | Mindmap          | markmap-view (dynamic import) + own transform (`src/lib/mindmap.ts`) |
 
 ## Milkdown Plugins

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ If a dependency adds weight, it must justify itself against lightness.
 | Syntax highlight | Shiki                                       |
 | Markdown         | markdown-it + Shiki                         |
 | Diagrams         | Mermaid (dynamic import)                    |
+| Mindmap          | markmap-view (dynamic import) + own transform (`src/lib/mindmap.ts`) |
 
 ## Milkdown Plugins
 
@@ -57,6 +58,13 @@ Rejected plugins (with reasons):
 - **Frontmatter** (`time` / `tags` / `context`): a record of creation, preserved
   verbatim on every edit. `time` must stay the creation time because the list
   sorts by filename (= creation order); a moving `time` breaks date grouping
+- **Frontmatter `view`** (optional): per-note display mode (`mindmap`). Unlike
+  the keys above it is a viewing preference, not a record — but it lives in
+  frontmatter so the mode travels with the note across synced devices. The key
+  is omitted (not written as a default) so untouched notes stay byte-identical.
+  Any new frontmatter key must be a typed field on `NoteFrontmatter` in Rust
+  core: unknown keys are dropped on the next save because saving re-renders
+  the frontmatter from that struct
 - **The editor and preview only ever see the body.** Frontmatter routed through
   Milkdown gets serialized back as escaped plain text and corrupts the file
 

--- a/core/benches/fixture.rs
+++ b/core/benches/fixture.rs
@@ -115,6 +115,7 @@ fn write_notes(base: &Path, rng: &mut Lcg) {
             time,
             tags: vec!["memo".to_string(), rng.pick(SUBJECTS).to_string()],
             context: None,
+            view: None,
         };
         // preview は先頭 100 文字しか読まれない。本文はそれより十分長くする。
         let mut text = String::new();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,7 +14,7 @@ pub use error::CoreError;
 pub use note::error::NoteError;
 pub use note::{
     NoteSummary, create_draft_note, delete_note, list_notes, read_note, read_note_by_filename,
-    read_note_meta, repair_notes, update_note, update_note_meta,
+    read_note_meta, repair_notes, update_note, update_note_meta, update_note_view,
 };
 pub use search::{HitKind, SearchHit, search_all};
 pub use timeline::error::TimelineError;

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -69,6 +69,16 @@ pub fn update_note_meta(
     Notes::new(base_dir.to_path_buf()).update_meta(filename, time, tags)
 }
 
+/// 表示モードだけを差し替える。`None` で既定(エディタ)に戻す。
+/// time / tags / context / 本文には触れない。
+pub fn update_note_view(
+    base_dir: &Path,
+    filename: &NoteFilename,
+    view: Option<&str>,
+) -> Result<(), CoreError> {
+    Notes::new(base_dir.to_path_buf()).update_view(filename, view)
+}
+
 /// 過去の編集で本文に混入した化けメタデータを直す。直したファイル数を返す。
 pub fn repair_notes(base_dir: &Path) -> Result<usize, CoreError> {
     repair::repair_all(&crate::utils::paths::notes_dir(base_dir))
@@ -360,6 +370,85 @@ mod tests {
         assert!(matches!(result, Err(CoreError::Parse(_))));
         let content = fs::read_to_string(notes_dir.join("20260101_120000.md")).unwrap();
         assert_eq!(content, broken);
+    }
+
+    #[test]
+    fn update_note_view_sets_mindmap() {
+        let tmp = TempDir::new().unwrap();
+        let path = create_draft_note(tmp.path(), "body", &[], &mock_context()).unwrap();
+        let filename = filename_of(&path);
+
+        update_note_view(tmp.path(), &filename, Some("mindmap")).unwrap();
+
+        let meta = read_note_meta(tmp.path(), &filename).unwrap();
+        assert_eq!(meta.view, Some("mindmap".to_string()));
+    }
+
+    #[test]
+    fn update_note_view_none_clears_the_key() {
+        let tmp = TempDir::new().unwrap();
+        let path = create_draft_note(tmp.path(), "body", &[], &mock_context()).unwrap();
+        let filename = filename_of(&path);
+        update_note_view(tmp.path(), &filename, Some("mindmap")).unwrap();
+
+        update_note_view(tmp.path(), &filename, None).unwrap();
+
+        assert!(!fs::read_to_string(&path).unwrap().contains("view"));
+    }
+
+    /// 表示モードの切り替えで本文とメタデータの記録が動いてはいけない。
+    #[test]
+    fn update_note_view_keeps_body_time_and_context() {
+        let tmp = TempDir::new().unwrap();
+        let path = create_draft_note(tmp.path(), "# Title\nbody", &[], &mock_context()).unwrap();
+        let filename = filename_of(&path);
+        let before = read_note_meta(tmp.path(), &filename).unwrap();
+
+        update_note_view(tmp.path(), &filename, Some("mindmap")).unwrap();
+
+        assert_eq!(read_note(&path).unwrap(), "# Title\nbody");
+        let meta = read_note_meta(tmp.path(), &filename).unwrap();
+        assert_eq!(meta.time, before.time);
+        assert_eq!(meta.context.unwrap().battery, Some(50));
+    }
+
+    /// 本文の保存で表示モードが消えると、開き直すたびにエディタへ戻ってしまう。
+    #[test]
+    fn update_note_keeps_the_view_mode() {
+        let tmp = TempDir::new().unwrap();
+        let path = create_draft_note(tmp.path(), "original", &[], &mock_context()).unwrap();
+        let filename = filename_of(&path);
+        update_note_view(tmp.path(), &filename, Some("mindmap")).unwrap();
+
+        update_note(&path, "updated", &mock_context()).unwrap();
+
+        let meta = read_note_meta(tmp.path(), &filename).unwrap();
+        assert_eq!(meta.view, Some("mindmap".to_string()));
+    }
+
+    /// time/tags の編集でも表示モードは保たれる。
+    #[test]
+    fn update_note_meta_keeps_the_view_mode() {
+        let tmp = TempDir::new().unwrap();
+        let path = create_draft_note(tmp.path(), "body", &[], &mock_context()).unwrap();
+        let filename = filename_of(&path);
+        update_note_view(tmp.path(), &filename, Some("mindmap")).unwrap();
+
+        update_note_meta(tmp.path(), &filename, sample_time(), &[]).unwrap();
+
+        let meta = read_note_meta(tmp.path(), &filename).unwrap();
+        assert_eq!(meta.view, Some("mindmap".to_string()));
+    }
+
+    #[test]
+    fn update_note_view_not_found() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("data/notes")).unwrap();
+        let filename = NoteFilename::parse("nonexistent.md").unwrap();
+
+        let result = update_note_view(tmp.path(), &filename, Some("mindmap"));
+
+        assert!(matches!(result, Err(CoreError::NotFound(_))));
     }
 
     #[test]

--- a/core/src/note/repair.rs
+++ b/core/src/note/repair.rs
@@ -32,8 +32,7 @@ pub(crate) fn repair_all(notes_dir: &Path) -> Result<usize, CoreError> {
         let filename = entry.file_name().to_string_lossy().to_string();
         let fixed = NoteFrontmatter {
             time: filename_time(&filename).unwrap_or(fm.time),
-            tags: fm.tags,
-            context: fm.context,
+            ..fm
         };
         write_atomic(&path, frontmatter::render(&fixed, &clean_body)?)?;
         repaired += 1;

--- a/core/src/note/repository.rs
+++ b/core/src/note/repository.rs
@@ -99,6 +99,7 @@ impl Notes {
                 time: Local::now().into(),
                 tags: Vec::new(),
                 context: Some(context.clone()),
+                view: None,
             },
             |(fm, _)| fm,
         );
@@ -133,6 +134,28 @@ impl Notes {
             time,
             tags: tags.to_vec(),
             context: existing.context,
+            view: existing.view,
+        };
+        write_atomic(&path, frontmatter::render(&fm, body)?)?;
+        Ok(())
+    }
+
+    /// 表示モードだけを差し替えて書き戻す。他のメタデータと本文には触れない。
+    ///
+    /// `update_meta` と同じく、frontmatter が読めないファイルには書かない。
+    /// 表示の好みのために壊れた記録を正当化するべきではない。
+    pub(crate) fn update_view(
+        &self,
+        filename: &NoteFilename,
+        view: Option<&str>,
+    ) -> Result<(), CoreError> {
+        let path = self.existing_note_path(filename)?;
+        let content = fs::read_to_string(&path)?;
+        let (existing, body) = frontmatter::parse::<NoteFrontmatter>(&content)?;
+
+        let fm = NoteFrontmatter {
+            view: view.map(str::to_string),
+            ..existing
         };
         write_atomic(&path, frontmatter::render(&fm, body)?)?;
         Ok(())

--- a/core/src/note/summary.rs
+++ b/core/src/note/summary.rs
@@ -68,6 +68,7 @@ mod tests {
                 is_charging: Some(false),
                 ..Context::default()
             }),
+            view: None,
         };
         let content = frontmatter::render(&fm, "# Title\nBody").unwrap();
         let summary = Summary::from_file(

--- a/core/src/utils/frontmatter.rs
+++ b/core/src/utils/frontmatter.rs
@@ -11,6 +11,11 @@ pub struct NoteFrontmatter {
     pub tags: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context: Option<Context>,
+    /// 表示モード(例: `mindmap`)。time/tags/context と違い「作成時の記録」では
+    /// なく閲覧の好みだが、ノート単位の設定はノートと一緒に同期されてほしいので
+    /// frontmatter に持つ。未指定・未知の値は読む側がエディタ表示に倒す。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub view: Option<String>,
 }
 
 pub fn render<T: Serialize>(fm: &T, body: &str) -> Result<String, CoreError> {
@@ -67,6 +72,7 @@ mod tests {
                 is_charging: Some(false),
                 ..Context::default()
             }),
+            view: None,
         };
         let rendered = render(&fm, "# Hello\nWorld").unwrap();
         let (parsed, body): (NoteFrontmatter, _) = parse(&rendered).unwrap();
@@ -75,11 +81,47 @@ mod tests {
     }
 
     #[test]
+    fn test_note_frontmatter_view_roundtrip() {
+        let fm = NoteFrontmatter {
+            time: sample_datetime(),
+            tags: vec![],
+            context: None,
+            view: Some("mindmap".to_string()),
+        };
+        let rendered = render(&fm, "body").unwrap();
+        let (parsed, _body): (NoteFrontmatter, _) = parse(&rendered).unwrap();
+        assert_eq!(parsed.view, Some("mindmap".to_string()));
+    }
+
+    /// view を持たないノートの frontmatter は今までと 1 バイトも変わらない。
+    /// 余計なキーを書くと、同期(Syncthing)が全ノートを転送し直すことになる。
+    #[test]
+    fn test_render_omits_absent_view() {
+        let fm = NoteFrontmatter {
+            time: sample_datetime(),
+            tags: vec![],
+            context: None,
+            view: None,
+        };
+        let rendered = render(&fm, "body").unwrap();
+        assert!(!rendered.contains("view"));
+    }
+
+    /// view キーを知らない版のアプリが書いたノートも今まで通り読める。
+    #[test]
+    fn test_parse_defaults_view_to_none() {
+        let yaml = "---\ntime: 2026-03-20T14:30:45+09:00\ntags: []\n---\nbody";
+        let (fm, _body): (NoteFrontmatter, &str) = parse(yaml).unwrap();
+        assert_eq!(fm.view, None);
+    }
+
+    #[test]
     fn test_note_frontmatter_no_context() {
         let fm = NoteFrontmatter {
             time: sample_datetime(),
             tags: vec![],
             context: None,
+            view: None,
         };
         let rendered = render(&fm, "body").unwrap();
         let (parsed, _body): (NoteFrontmatter, _) = parse(&rendered).unwrap();
@@ -92,6 +134,7 @@ mod tests {
             time: sample_datetime(),
             tags: vec![],
             context: None,
+            view: None,
         };
         let rendered = render(&fm, "body").unwrap();
         assert!(rendered.starts_with("---\n"));

--- a/core/src/utils/markdown.rs
+++ b/core/src/utils/markdown.rs
@@ -71,6 +71,7 @@ pub fn format_note_markdown(
         time,
         tags: tags.to_vec(),
         context: Some(context.clone()),
+        view: None,
     };
     frontmatter::render(&fm, body)
 }

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -21,6 +21,7 @@
     "@tauri-apps/plugin-deep-link": "^2.4.9",
     "@tauri-apps/plugin-geolocation": "^2.3.2",
     "markdown-it": "^14.1.1",
+    "markmap-view": "^0.18.12",
     "mermaid": "^11.16.0",
     "open-props": "^1.7.23",
     "shiki": "^4.0.2",

--- a/tauri-app/pnpm-lock.yaml
+++ b/tauri-app/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 7.20.0(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.41.0)(typescript@5.9.3)
       '@milkdown/plugin-highlight':
         specifier: ^7.20.0
-        version: 7.20.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.0.2)(@types/hast@3.0.4)(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
+        version: 7.20.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.0.2)(@types/hast@3.0.4)(highlight.js@11.12.0)(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
       '@phosphor-icons/core':
         specifier: ^2.1.1
         version: 2.1.1
@@ -32,6 +32,9 @@ importers:
       markdown-it:
         specifier: ^14.1.1
         version: 14.1.1
+      markmap-view:
+        specifier: ^0.18.12
+        version: 0.18.12(markmap-common@0.18.9)
       mermaid:
         specifier: ^11.16.0
         version: 11.16.0
@@ -424,6 +427,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@gera2ld/jsx-dom@2.2.2':
+    resolution: {integrity: sha512-EOqf31IATRE6zS1W1EoWmXZhGfLAoO9FIlwTtHduSrBdud4npYBxYAkv8dZ5hudDPwJeeSjn40kbCL4wAzr8dA==}
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -1673,6 +1679,10 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  highlight.js@11.12.0:
+    resolution: {integrity: sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==}
+    engines: {node: '>=12.0.0'}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1786,6 +1796,14 @@ packages:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
     engines: {node: '>= 20'}
     hasBin: true
+
+  markmap-common@0.18.9:
+    resolution: {integrity: sha512-MV2HQO7IGIm3jWEJXSG8vmdpqf4WIDXcEyAEN52lrWR1qD53Zg5l81JwjXoZ2l0rY5mofKYqUFlmdM2fqTGMVg==}
+
+  markmap-view@0.18.12:
+    resolution: {integrity: sha512-D8bzT1YwIC/8rkbwm6WzigVUrpOAGv7ioEGTi1Lj+Oo8gO5sAm6hhli27jvTgUcZ9TwBeIWZ+dSUP+AupYUGlQ==}
+    peerDependencies:
+      markmap-common: '*'
 
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
@@ -1942,6 +1960,9 @@ packages:
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+
+  npm2url@0.2.4:
+    resolution: {integrity: sha512-arzGp/hQz0Ey+ZGhF64XVH7Xqwd+1Q/po5uGiBbzph8ebX6T0uvt3N7c1nBHQNsQVykQgHhqoRTX7JFcHecGuw==}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -2810,6 +2831,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@gera2ld/jsx-dom@2.2.2':
+    dependencies:
+      '@babel/runtime': 7.29.2
+
   '@iconify/types@2.0.0': {}
 
   '@iconify/utils@3.1.4':
@@ -2954,12 +2979,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@milkdown/plugin-highlight@7.20.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.0.2)(@types/hast@3.0.4)(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)':
+  '@milkdown/plugin-highlight@7.20.0(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.0.2)(@types/hast@3.0.4)(highlight.js@11.12.0)(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)':
     dependencies:
       '@milkdown/core': 7.20.0
       '@milkdown/ctx': 7.20.0
       '@milkdown/utils': 7.20.0
-      prosemirror-highlight: 0.15.1(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.0.2)(@types/hast@3.0.4)(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
+      prosemirror-highlight: 0.15.1(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.0.2)(@types/hast@3.0.4)(highlight.js@11.12.0)(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
     transitivePeerDependencies:
       - '@lezer/common'
       - '@lezer/highlight'
@@ -4172,6 +4197,9 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  highlight.js@11.12.0:
+    optional: true
+
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.0
@@ -4290,6 +4318,18 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@16.4.2: {}
+
+  markmap-common@0.18.9:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@gera2ld/jsx-dom': 2.2.2
+      npm2url: 0.2.4
+
+  markmap-view@0.18.12(markmap-common@0.18.9):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      d3: 7.9.0
+      markmap-common: 0.18.9
 
   mdast-util-definitions@6.0.0:
     dependencies:
@@ -4644,6 +4684,8 @@ snapshots:
 
   node-releases@2.0.37: {}
 
+  npm2url@0.2.4: {}
+
   obug@2.1.1: {}
 
   oniguruma-parser@0.12.1: {}
@@ -4786,12 +4828,13 @@ snapshots:
       prosemirror-state: 1.4.4
       prosemirror-view: 1.41.8
 
-  prosemirror-highlight@0.15.1(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.0.2)(@types/hast@3.0.4)(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8):
+  prosemirror-highlight@0.15.1(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@shikijs/types@4.0.2)(@types/hast@3.0.4)(highlight.js@11.12.0)(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8):
     optionalDependencies:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@shikijs/types': 4.0.2
       '@types/hast': 3.0.4
+      highlight.js: 11.12.0
       prosemirror-model: 1.25.4
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -120,6 +120,15 @@ fn update_note_meta(
         .map_err(|e| e.to_string())
 }
 
+/// 表示モードだけを書き換える。`None` で既定(エディタ)に戻す。
+#[tauri::command]
+fn set_note_view(handle: AppHandle, filename: String, view: Option<String>) -> Result<(), String> {
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    let filename = NoteFilename::parse(&filename).map_err(|e| e.to_string())?;
+    magical_merchant_core::update_note_view(&base_dir, &filename, view.as_deref())
+        .map_err(|e| e.to_string())
+}
+
 #[tauri::command]
 fn read_timeline(handle: AppHandle) -> Result<Vec<String>, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
@@ -258,6 +267,7 @@ pub fn run() {
             read_note,
             read_note_meta,
             update_note_meta,
+            set_note_view,
             read_timeline,
             list_timeline_dates,
             read_timeline_by_date,

--- a/tauri-app/src/components/Icon.tsx
+++ b/tauri-app/src/components/Icon.tsx
@@ -48,6 +48,7 @@ const ICONS = {
   circle: () => import("@phosphor-icons/core/assets/regular/circle.svg?raw"),
   "check-circle": () => import("@phosphor-icons/core/assets/regular/check-circle.svg?raw"),
   "file-text": () => import("@phosphor-icons/core/assets/regular/file-text.svg?raw"),
+  "tree-structure": () => import("@phosphor-icons/core/assets/regular/tree-structure.svg?raw"),
   "caret-left": () => import("@phosphor-icons/core/assets/regular/caret-left.svg?raw"),
 } as const;
 

--- a/tauri-app/src/components/MindmapView.test.tsx
+++ b/tauri-app/src/components/MindmapView.test.tsx
@@ -1,0 +1,35 @@
+import { render, cleanup } from "@solidjs/testing-library";
+import { page } from "vitest/browser";
+import { describe, it, expect, afterEach } from "vitest";
+import MindmapView from "./MindmapView";
+
+const OUTLINE = ["# 計画", "- 買い出し", "- 仕込み", "## 当日", "- 集合"].join("\n");
+
+describe("MindmapView", () => {
+  afterEach(() => cleanup());
+
+  it("見出しとリストの構造をマインドマップに描く", async () => {
+    const { baseElement } = render(() => <MindmapView source={OUTLINE} />);
+    const screen = page.elementLocator(baseElement);
+
+    await expect
+      .element(screen.locator(".mindmap-view svg g.markmap-node").first())
+      .toBeInTheDocument();
+    await expect.element(screen.locator(".mindmap-view svg")).toHaveTextContent("買い出し");
+    await expect.element(screen.locator(".mindmap-view svg")).toHaveTextContent("当日");
+  });
+
+  it("本文が変わったら描き直す", async () => {
+    const [source, setSource] = await import("solid-js").then((m) =>
+      m.createSignal("# 前の本文"),
+    );
+    const { baseElement } = render(() => <MindmapView source={source()} />);
+    const screen = page.elementLocator(baseElement);
+
+    await expect.element(screen.locator(".mindmap-view svg")).toHaveTextContent("前の本文");
+
+    setSource("# 後の本文");
+
+    await expect.element(screen.locator(".mindmap-view svg")).toHaveTextContent("後の本文");
+  });
+});

--- a/tauri-app/src/components/MindmapView.test.tsx
+++ b/tauri-app/src/components/MindmapView.test.tsx
@@ -20,9 +20,7 @@ describe("MindmapView", () => {
   });
 
   it("本文が変わったら描き直す", async () => {
-    const [source, setSource] = await import("solid-js").then((m) =>
-      m.createSignal("# 前の本文"),
-    );
+    const [source, setSource] = await import("solid-js").then((m) => m.createSignal("# 前の本文"));
     const { baseElement } = render(() => <MindmapView source={source()} />);
     const screen = page.elementLocator(baseElement);
 

--- a/tauri-app/src/components/MindmapView.tsx
+++ b/tauri-app/src/components/MindmapView.tsx
@@ -1,0 +1,53 @@
+import { createEffect, onCleanup } from "solid-js";
+import type { JSX } from "solid-js";
+import { Markmap } from "markmap-view";
+import { outlineToTree } from "../lib/mindmap";
+
+interface MindmapViewProps {
+  source: string;
+}
+
+/**
+ * 本文の見出し・リスト構造をマインドマップとして描く読み取り専用ビュー。
+ * このコンポーネントは Workspace から lazy import される。markmap-view は
+ * d3 を連れてくる重い依存なので、mermaid と同じく使うノートだけに払わせる。
+ */
+export default function MindmapView(props: MindmapViewProps): JSX.Element {
+  let svgRef: SVGSVGElement | undefined;
+  let markmap: Markmap | undefined;
+
+  createEffect(() => {
+    const root = outlineToTree(props.source);
+    if (!svgRef) {
+      return;
+    }
+    // duration: 0 — 開いた瞬間に全体が見えてほしい。枝が生えていく
+    // アニメーションは読むだけのビューには飾りで、破棄後に d3 の transition が
+    // 宙に残る原因にもなる。
+    // データは create に渡さない。渡すと markmap の内部で setData → fit が
+    // つながり、破棄後でも fit が走って取り外された SVG の寸法を読もうとする
+    markmap ??= Markmap.create(svgRef, { duration: 0 });
+    const current = markmap;
+    void (async () => {
+      // 全消し + 作り直しではなく差分更新。ユーザーが畳んだ枝はここで保たれる
+      await current.setData(root);
+      if (markmap === current) {
+        await current.fit();
+      }
+    })();
+  });
+
+  onCleanup(() => {
+    // fit() の遷移が残ったまま SVG を外すと、d3 が取り外された要素の寸法を
+    // 読もうとして落ちる。destroy は遷移までは止めてくれない
+    markmap?.svg.interrupt();
+    markmap?.destroy();
+    markmap = undefined;
+  });
+
+  return (
+    <div class="mindmap-view">
+      <svg ref={svgRef} />
+    </div>
+  );
+}

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -30,6 +30,8 @@ interface NoteMeta {
   time: string;
   tags: string[];
   context?: NoteContext;
+  /** 表示モード。`"mindmap"` 以外の値の解釈は `note-view.ts` に寄せてある。 */
+  view?: string;
 }
 
 type HitKind = "timeline" | "note";
@@ -71,6 +73,7 @@ interface CommandMap {
   read_note: { args: { filename: string }; result: string };
   read_note_meta: { args: { filename: string }; result: NoteMeta };
   update_note_meta: { args: { filename: string; time: string; tags: string[] }; result: void };
+  set_note_view: { args: { filename: string; view: string | null }; result: void };
   delete_note: { args: { filename: string }; result: void };
   save_document: { args: { body: string; tags: string[] } & ClientArgs; result: void };
   sync_start: { args: void; result: void };
@@ -93,6 +96,7 @@ const MUTATING: ReadonlySet<CommandName> = new Set<CommandName>([
   "create_draft",
   "update_draft",
   "update_note_meta",
+  "set_note_view",
   "delete_note",
   "save_document",
 ]);

--- a/tauri-app/src/lib/mindmap.test.ts
+++ b/tauri-app/src/lib/mindmap.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { outlineToTree } from "./mindmap";
+
+function contents(nodes: { content: string }[]): string[] {
+  return nodes.map((n) => n.content);
+}
+
+describe("outlineToTree", () => {
+  it("空の本文は空のルートになる", () => {
+    expect(outlineToTree("")).toEqual({ content: "", children: [] });
+  });
+
+  it("ただ 1 つの見出しはルートに昇格する", () => {
+    const root = outlineToTree("# 計画");
+    expect(root.content).toBe("計画");
+    expect(root.children).toEqual([]);
+  });
+
+  it("見出しの下のリストが枝になる", () => {
+    const root = outlineToTree(["# 計画", "- 買い出し", "- 仕込み"].join("\n"));
+    expect(root.content).toBe("計画");
+    expect(contents(root.children)).toEqual(["買い出し", "仕込み"]);
+  });
+
+  it("リストの入れ子は枝の入れ子になる", () => {
+    const root = outlineToTree(["# 計画", "- 買い出し", "  - 野菜", "  - 肉"].join("\n"));
+    const [item] = root.children;
+    expect(item.content).toBe("買い出し");
+    expect(contents(item.children)).toEqual(["野菜", "肉"]);
+  });
+
+  /**
+   * markmap-lib はこの形でリストを捨てる(見出しとリストが同じ親の下に並ぶと
+   * 見出しだけが残る)。ノートは「H1 と `-` の混在」が普通なので、両方を保つ。
+   */
+  it("同じ見出しの下でリストと小見出しが共存する", () => {
+    const root = outlineToTree(["# 計画", "- 買い出し", "## 当日", "- 集合"].join("\n"));
+    expect(root.content).toBe("計画");
+    expect(contents(root.children)).toEqual(["買い出し", "当日"]);
+    expect(contents(root.children[1].children)).toEqual(["集合"]);
+  });
+
+  it("見出しの階層が枝の階層になる", () => {
+    const root = outlineToTree(["# A", "## B", "### C", "## D"].join("\n"));
+    expect(root.content).toBe("A");
+    expect(contents(root.children)).toEqual(["B", "D"]);
+    expect(contents(root.children[0].children)).toEqual(["C"]);
+  });
+
+  it("トップレベルが複数あるときは空のルートでまとめる", () => {
+    const root = outlineToTree(["# A", "# B"].join("\n"));
+    expect(root.content).toBe("");
+    expect(contents(root.children)).toEqual(["A", "B"]);
+  });
+
+  it("階層を飛ばした見出し(H1 の次に H3)も直近の親につく", () => {
+    const root = outlineToTree(["# A", "### C"].join("\n"));
+    expect(contents(root.children)).toEqual(["C"]);
+  });
+
+  it("リスト項目の段落以外(本文の地の文)は構造に含めない", () => {
+    const root = outlineToTree(["# 計画", "地の文の段落。", "- 買い出し"].join("\n"));
+    expect(contents(root.children)).toEqual(["買い出し"]);
+  });
+
+  it("強調などのインライン記法は HTML として保つ", () => {
+    const root = outlineToTree("# **大事**な計画");
+    expect(root.content).toBe("<strong>大事</strong>な計画");
+  });
+
+  it("生の HTML はエスケープされる(同期で降ってきたノートかもしれない)", () => {
+    const root = outlineToTree("# <script>alert(1)</script>");
+    expect(root.content).not.toContain("<script>");
+  });
+});

--- a/tauri-app/src/lib/mindmap.ts
+++ b/tauri-app/src/lib/mindmap.ts
@@ -1,0 +1,103 @@
+/**
+ * 本文の見出し・リスト構造をマインドマップの木にする。
+ *
+ * markmap-lib を使わないのは 2 つの理由から:
+ * - 変換器(markmap-html-parser)は、見出しとリストが同じ親の下に並ぶと
+ *   リストを捨てる。ノートは「H1 の下に `-` と小見出しが混在」が普通の形で、
+ *   枝が黙って消えるのは受け入れられない
+ * - HTML 経由の変換のために cheerio を丸ごと連れてくる。トークン列から
+ *   直接組めば、既にある markdown-it だけで足りる
+ *
+ * 描画(markmap-view)にはこの木をそのまま渡す。
+ */
+
+import MarkdownIt from "markdown-it";
+import type Token from "markdown-it/lib/token.mjs";
+
+export interface MindmapNode {
+  content: string;
+  children: MindmapNode[];
+}
+
+// html: false(既定)のまま使う。ノートは同期先から降ってくることもあり、
+// 生の HTML はエスケープして文字として見せる
+const md = new MarkdownIt();
+
+function renderInline(token: Token): string {
+  return md.renderer.renderInline(token.children ?? [], md.options, {});
+}
+
+function headingLevel(tag: string): number {
+  return Number(tag.slice(1));
+}
+
+/**
+ * 見出し(H1〜H6)とリスト項目だけを拾って木を組む。地の文の段落や
+ * コードブロックは構造ではなく中身なので、マップには出さない。
+ */
+export function outlineToTree(markdown: string): MindmapNode {
+  const root: MindmapNode = { content: "", children: [] };
+  // 見出しの階層。先頭は常にルート(レベル 0)なので空にはならない
+  const headings: { node: MindmapNode; level: number }[] = [{ node: root, level: 0 }];
+  const currentHeading = (): MindmapNode => headings.at(-1)?.node ?? root;
+  // 入れ子リストの親。bullet_list_open で積み、close で下ろす
+  const listParents: MindmapNode[] = [];
+  let lastItem: MindmapNode | undefined;
+  let itemDepth = 0;
+
+  const tokens = md.parse(markdown, {});
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    switch (token.type) {
+      case "heading_open": {
+        const level = headingLevel(token.tag);
+        while ((headings.at(-1)?.level ?? 0) >= level) {
+          headings.pop();
+        }
+        const node: MindmapNode = { content: renderInline(tokens[i + 1]), children: [] };
+        currentHeading().children.push(node);
+        headings.push({ node, level });
+        i += 2; // inline と heading_close を読み飛ばす
+        break;
+      }
+      case "bullet_list_open":
+      case "ordered_list_open": {
+        listParents.push(itemDepth > 0 && lastItem ? lastItem : currentHeading());
+        break;
+      }
+      case "bullet_list_close":
+      case "ordered_list_close": {
+        listParents.pop();
+        break;
+      }
+      case "list_item_open": {
+        const node: MindmapNode = { content: "", children: [] };
+        (listParents.at(-1) ?? currentHeading()).children.push(node);
+        lastItem = node;
+        itemDepth += 1;
+        break;
+      }
+      case "list_item_close": {
+        itemDepth -= 1;
+        break;
+      }
+      case "inline": {
+        // リスト項目の最初の行だけが項目の名前。2 段落目以降は中身とみなす
+        if (itemDepth > 0 && lastItem && lastItem.content === "") {
+          lastItem.content = renderInline(token);
+        }
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+  }
+
+  // トップレベルが 1 つだけなら、それをルートに昇格させる。空のルートを
+  // 真ん中に置くと、中心に名無しの丸だけが浮かぶ
+  if (root.children.length === 1) {
+    return root.children[0];
+  }
+  return root;
+}

--- a/tauri-app/src/lib/note-view.test.ts
+++ b/tauri-app/src/lib/note-view.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { resolveNoteView, toggledView, viewToFrontmatter } from "./note-view";
+
+describe("resolveNoteView", () => {
+  it("view キーが無いノートはエディタ表示", () => {
+    expect(resolveNoteView()).toBe("editor");
+  });
+
+  it("mindmap はマインドマップ表示", () => {
+    expect(resolveNoteView("mindmap")).toBe("mindmap");
+  });
+
+  it("知らない値はエディタ表示に倒す(新しい版のアプリが書いたノートかもしれない)", () => {
+    expect(resolveNoteView("kanban")).toBe("editor");
+  });
+});
+
+describe("toggledView", () => {
+  it("エディタ ⇄ マインドマップを往復する", () => {
+    expect(toggledView("editor")).toBe("mindmap");
+    expect(toggledView("mindmap")).toBe("editor");
+  });
+});
+
+describe("viewToFrontmatter", () => {
+  it("既定のエディタ表示は null(キーを書かない)", () => {
+    expect(viewToFrontmatter("editor")).toBeNull();
+  });
+
+  it("マインドマップは mindmap を書く", () => {
+    expect(viewToFrontmatter("mindmap")).toBe("mindmap");
+  });
+});

--- a/tauri-app/src/lib/note-view.ts
+++ b/tauri-app/src/lib/note-view.ts
@@ -1,0 +1,23 @@
+/**
+ * ノートの表示モード。frontmatter の `view` キーとの相互変換を一箇所に寄せる。
+ *
+ * キーは「書いてあるときだけ意味を持つ」約束にしてある。既定のエディタ表示を
+ * わざわざ書くと、切り替えたことのないノートまで frontmatter が書き換わり、
+ * 同期(Syncthing)が無変更のノートを転送し直すことになる。
+ */
+
+export type NoteView = "editor" | "mindmap";
+
+/** frontmatter の `view` の値を表示モードに解決する。未知の値はエディタに倒す。 */
+export function resolveNoteView(view?: string): NoteView {
+  return view === "mindmap" ? "mindmap" : "editor";
+}
+
+export function toggledView(view: NoteView): NoteView {
+  return view === "mindmap" ? "editor" : "mindmap";
+}
+
+/** frontmatter に書く値。既定のエディタ表示はキーごと消す(null)。 */
+export function viewToFrontmatter(view: NoteView): string | null {
+  return view === "mindmap" ? "mindmap" : null;
+}

--- a/tauri-app/src/styles/workspace.css
+++ b/tauri-app/src/styles/workspace.css
@@ -397,3 +397,26 @@
     display: none;
   }
 }
+
+/* ---- マインドマップ表示 ---- */
+
+.mindmap-view {
+  height: 100%;
+}
+
+.mindmap-view svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* markmap は SVG の中に <style> を差し込む。色はカスタムプロパティで
+   開けてあるので、アプリのトークンをそこへ流し込む(セレクタは注入側の
+   `.markmap` より詳細度を上げておく) */
+.mindmap-view .markmap {
+  --markmap-text-color: var(--app-text);
+  --markmap-font: 400 14px/1.6 var(--font-sans);
+  --markmap-circle-open-bg: var(--app-surface);
+  --markmap-code-bg: var(--app-surface-2);
+  --markmap-code-color: var(--app-text);
+}

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -319,7 +319,10 @@ export default function Workspace(): JSX.Element {
                       aria-pressed={noteView() === "mindmap"}
                       onClick={() => void toggleNoteView(item())}
                     >
-                      <Icon name={noteView() === "mindmap" ? "file-text" : "tree-structure"} size={17} />
+                      <Icon
+                        name={noteView() === "mindmap" ? "file-text" : "tree-structure"}
+                        size={17}
+                      />
                     </button>
                   </Show>
                   <button

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -20,11 +20,15 @@ import { getDeviceSignals } from "../lib/client-context";
 import { useShell } from "../lib/shell";
 import { groupNotes, itemTitle, noteCreatedLabel, toNoteItems } from "../lib/items";
 import type { ItemGroup, NoteItem } from "../lib/items";
+import { resolveNoteView, toggledView, viewToFrontmatter } from "../lib/note-view";
+import type { NoteView } from "../lib/note-view";
 
 // Milkdown + ProseMirror は編集を始めるまで要らない。一覧とプレビューだけの
 // 表示をこの重さから切り離す
 const MilkdownEditor = lazy(() => import("../components/MilkdownEditor"));
 const MarkdownToolbar = lazy(() => import("../components/MarkdownToolbar"));
+// markmap-view は d3 を連れてくる。マインドマップにしたノートを開くまで読まない
+const MindmapView = lazy(() => import("../components/MindmapView"));
 
 const UNDO_MS = 5000;
 const SAVE_DEBOUNCE_MS = 1000;
@@ -60,6 +64,7 @@ export default function Workspace(): JSX.Element {
   const [saveStatus, setSaveStatus] = createSignal<"idle" | "saving" | "saved">("idle");
   const [hidden, setHidden] = createSignal<string[]>([]);
   const [noteBody, setNoteBody] = createSignal("");
+  const [noteView, setNoteView] = createSignal<NoteView>("editor");
   /** タッチ端末のツールバーが叩く先。編集をやめると undefined に戻る。 */
   const [markdownEditor, setMarkdownEditor] = createSignal<Editor | undefined>();
 
@@ -95,17 +100,42 @@ export default function Workspace(): JSX.Element {
     ),
   );
 
-  // ---- 選択中ノートの本文を読む ----
+  // ---- 選択中ノートの本文と表示モードを読む ----
   createEffect(() => {
     const item = selected();
     if (!item) {
       setNoteBody("");
+      setNoteView("editor");
       return;
     }
     void (async () => {
       setNoteBody(await typedInvoke("read_note", { filename: item.filename }));
     })();
+    void (async () => {
+      try {
+        const meta = await typedInvoke("read_note_meta", { filename: item.filename });
+        setNoteView(resolveNoteView(meta.view));
+      } catch {
+        // frontmatter が読めないノートは既定のエディタ表示で開く
+        setNoteView("editor");
+      }
+    })();
   });
+
+  const toggleNoteView = async (item: NoteItem): Promise<void> => {
+    const next = toggledView(noteView());
+    // 保存を待たずに切り替える。書き込みは frontmatter が壊れたノートで
+    // 失敗し得るので、そのときは表示だけ戻す
+    setNoteView(next);
+    try {
+      await typedInvoke("set_note_view", {
+        filename: item.filename,
+        view: viewToFrontmatter(next),
+      });
+    } catch {
+      setNoteView(toggledView(next));
+    }
+  };
 
   const select = (item: NoteItem): void => {
     shell.closePopovers();
@@ -278,6 +308,20 @@ export default function Workspace(): JSX.Element {
                 </span>
 
                 <div class="detail-actions">
+                  <Show when={!editing()}>
+                    <button
+                      type="button"
+                      class="icon-button"
+                      title={noteView() === "mindmap" ? "エディタで表示" : "マインドマップで表示"}
+                      aria-label={
+                        noteView() === "mindmap" ? "エディタで表示" : "マインドマップで表示"
+                      }
+                      aria-pressed={noteView() === "mindmap"}
+                      onClick={() => void toggleNoteView(item())}
+                    >
+                      <Icon name={noteView() === "mindmap" ? "file-text" : "tree-structure"} size={17} />
+                    </button>
+                  </Show>
                   <button
                     type="button"
                     class="icon-button detail-meta-button"
@@ -335,7 +379,17 @@ export default function Workspace(): JSX.Element {
               </Show>
 
               <div class="detail-body">
-                <Show when={editing()} fallback={<MarkdownPreview source={noteBody()} />}>
+                <Show
+                  when={editing()}
+                  fallback={
+                    <Show
+                      when={noteView() === "mindmap"}
+                      fallback={<MarkdownPreview source={noteBody()} />}
+                    >
+                      <MindmapView source={noteBody()} />
+                    </Show>
+                  }
+                >
                   <MilkdownEditor
                     placeholder="ノートを書く…"
                     defaultValue={draft()}


### PR DESCRIPTION
## Summary

- issue #35「マインドマップを作ってみる」の技術検証と最初の実装。本文の H1〜H6 と `-` リストの構造を、ノートごとにエディタ表示 ⇄ マインドマップ表示で切り替えられるようにする(切替はディテールのアクション列、読み取り専用)
- 表示モードは frontmatter の `view: mindmap` キーで永続化。**現状の core は保存のたびに型付き struct から frontmatter を再構築するため、未知キーは黙って消える**。フロントエンドから直接キーを書く案は成立せず、Rust core の `NoteFrontmatter` に型付きフィールドを足す形で採用した(検証の詳細は下)
- 描画は markmap-view(d3)を採用し、Milkdown・mermaid と同じく lazy import。**変換には markmap-lib を使っていない**: 見出しの下にリストと小見出しが並ぶと markmap-lib はリストを黙って捨てる(このノートアプリの本文はまさにその形)。markdown-it(既存依存)のトークン列から自前で木を組んだ
- リスク: `view` キーを知らない旧バージョンのアプリで同じノートを本文編集すると、キーは保存時に落ちる。表示が既定(エディタ)に戻るだけで本文・他のメタデータは壊れない

## 技術検証

### frontmatter に表示モードを持てるか → 持てる(ただし Rust core 側の対応が必須)

- `Notes::update`(本文保存)と `Notes::update_meta`(time/tags 編集)はどちらも `NoteFrontmatter` 構造体に parse してから render し直す。struct に無いキーは deserialize で無視され、render で書かれない。**つまりフロントエンドだけで `view:` を書き足しても、次の 1 秒 debounce 保存で消える**
- 対応: `NoteFrontmatter` に `view: Option<String>` を追加(`skip_serializing_if` 付き)。本文保存・メタ編集・修復(repair)の全経路でキーが生き残ることをテストで固定した
- キーを使わないノートの frontmatter は 1 バイトも変わらない(既定値を書き込まない)。Syncthing が無変更ノートを転送し直すことはない
- アプリ設定(ファイル名キーのマップ)案と比較して frontmatter を採用した理由: ノート単位の設定はノート本体と一緒に同期されてほしい。端末ローカルの設定では同じノートが端末ごとに違う顔で開き、ノート削除時のゴミ掃除も別途必要になる

### markmap は要件をどこまで満たすか

| 要件 | 評価 |
| --- | --- |
| H1 / `-` リストの構造をマインドマップ化 | ○ markmap-view の描画で実現。ただし markmap-lib の変換器は「見出しの下にリストと小見出しが混在」でリストを捨てるバグ的挙動(markmap-html-parser が親ごとに 1 種類のレベルしか保持しない)があり、変換は自前実装に差し替えた |
| ノートごとの表示切替・永続化 | ○ frontmatter `view` キーで実現 |
| 構造が同じでもランダムに多方面へ枝が生える | × **markmap では満たせない**。レイアウトは決定的な左→右ツリー(flextree)で、放射状・ランダム配置のオプションは存在しない。mermaid の mindmap は放射状だが、これも決定的で毎回同じ形になる。ランダム多方向レイアウトは d3 の力学レイアウト等による自作が必要で、別 issue に切り出すのを提案したい |

### バンドルサイズへの影響(`pnpm build` 前後)

| 指標 | before | after |
| --- | --- | --- |
| 初期ロード(index chunk) | 358.08 kB / gzip 108.19 kB | 358.08 kB / gzip 108.19 kB(変化なし) |
| Workspace chunk | 286.06 kB | 287.46 kB(+1.4 kB: 切替 UI ぶん) |
| MindmapView chunk(新規・lazy) | — | 32.83 kB / gzip 11.61 kB |
| dist 合計 | 5,152 KB | 5,208 KB(+56 KB, +1.1%) |

markmap-view + d3 はマインドマップ表示のノートを開いた瞬間に初めて読み込まれる。markmap-lib を採用していたらこの chunk に cheerio ベースの HTML パーサが同乗していた。

## Diagram

切替から永続化までの流れ。緑枠が新規、既存ノードへの変更はエッジのラベルに書いた。

```mermaid
flowchart LR
  subgraph app["tauri-app (SolidJS)"]
    ws["views/Workspace.tsx"]
    nv["lib/note-view.ts<br/>view 値の解決・反転"]
    prev["MarkdownPreview"]
    mmv["MindmapView.tsx<br/>markmap-view + d3 (lazy)"]
    tree["lib/mindmap.ts<br/>markdown-it トークン → 木"]
  end
  subgraph rust["Rust core"]
    cmd["set_note_view<br/>(tauri command)"]
    repo["note/repository.rs<br/>update_view"]
    fm["utils/frontmatter.rs<br/>NoteFrontmatter"]
  end
  ws -->|"view=editor"| prev
  ws -->|"view=mindmap"| mmv
  mmv --> tree
  ws --> nv
  nv -->|"切替を保存"| cmd
  cmd --> repo
  repo -->|"view キーを追加"| fm

  classDef added stroke:#3fb950,stroke-width:3px
  class nv,mmv,tree,cmd,repo added
```

## Files changed

| ファイル | 変更 | 内容 |
| --- | --- | --- |
| `core/src/utils/frontmatter.rs` | +43 | `NoteFrontmatter` に `view: Option<String>` を追加。未設定なら書かない(既存ノートはバイト単位で不変) |
| `core/src/note/repository.rs` | +23 | `update_view` を追加。`update_meta` が `view` を引き継ぐように |
| `core/src/note.rs` | +89 | `update_note_view` API と、本文保存・メタ編集で `view` が生き残ることを固定するテスト |
| `core/src/lib.rs` ほか構築箇所 4 ファイル | +6 / -5 | re-export と `NoteFrontmatter` 構築箇所の追随(repair は `..fm` で全フィールド引き継ぎに) |
| `tauri-app/src-tauri/src/lib.rs` | +10 | `set_note_view` コマンド(`None` で既定に戻す) |
| `tauri-app/src/lib/commands.ts` | +4 | コマンド型定義と MUTATING 登録(ファイルが変わるので auto-sync の対象) |
| `tauri-app/src/lib/note-view.ts` (+test) | +56 | `view` 値の解決・反転・書き戻し値の純関数。未知の値はエディタに倒す |
| `tauri-app/src/lib/mindmap.ts` (+test) | +178 | markdown-it トークンから見出し・リストの木を組む変換。markmap-lib がリストを捨てるケースをテストで固定 |
| `tauri-app/src/components/MindmapView.tsx` (+test) | +88 | markmap-view による読み取り専用描画。破棄後に d3 の transition が残らないよう fit をガード |
| `tauri-app/src/views/Workspace.tsx` | +55 / -3 | 切替ボタン(アクション列)、表示分岐、選択時の view 読み込み |
| `tauri-app/src/components/Icon.tsx` | +1 | tree-structure(Phosphor)を追加 |
| `tauri-app/src/styles/workspace.css` | +23 | マインドマップ表示のレイアウトと、markmap のカスタムプロパティへのトークン接続 |
| `tauri-app/package.json` / `pnpm-lock.yaml` | +52 / -1 | markmap-view を追加(markmap-lib は入れない) |
| `CLAUDE.md` | +8 | 技術スタックと「frontmatter の新キーは Rust core の型付きフィールド必須」の記録 |

**Total:** 22 files, +632 / -9

## Test plan

- [x] `cargo test --workspace` — 173 + 44 passed(view の往復・保存経路での保持・NotFound/壊れた frontmatter の拒否を含む)
- [x] `just check` — clippy `-D warnings` / oxlint / tsgo / knip すべて exit 0
- [x] `just test` — フロントエンド 238 passed(実 Chromium で markmap 描画・再描画を含む)/ workers 33 passed
- [x] `pnpm build` — 成功。チャンク構成と初期ロード不変を上記の通り確認
- [ ] `just dev` での実機確認(このセッションでは GUI を起動していない)

Refs #35
