### PR TITLE
fix(editor): make code blocks manageable from the touch toolbar

### DIFF
--- a/tauri-app/index.html
+++ b/tauri-app/index.html
@@ -3,7 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <!-- interactive-widget=resizes-content: キーボードがレイアウトごと縮める。
+         対応 WebView では fixed のツールバーが JS の追従なしでキーボードに乗り、
+         スクロール時に遅れてフワっと動く挙動が消える。非対応でも従来の
+         visualViewport 追従(MarkdownToolbar)がフォールバックとして効く -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
+    />
     <title>Magical Merchant</title>
   </head>
   <body>

--- a/tauri-app/src/components/Icon.tsx
+++ b/tauri-app/src/components/Icon.tsx
@@ -13,6 +13,7 @@ const ICONS = {
   "caret-right": () => import("@phosphor-icons/core/assets/regular/caret-right.svg?raw"),
   "caret-down": () => import("@phosphor-icons/core/assets/regular/caret-down.svg?raw"),
   "arrow-left": () => import("@phosphor-icons/core/assets/regular/arrow-left.svg?raw"),
+  "arrow-line-down": () => import("@phosphor-icons/core/assets/regular/arrow-line-down.svg?raw"),
   "clock-counter-clockwise": () =>
     import("@phosphor-icons/core/assets/regular/clock-counter-clockwise.svg?raw"),
   pencil: () => import("@phosphor-icons/core/assets/regular/pencil.svg?raw"),

--- a/tauri-app/src/components/MarkdownToolbar.test.tsx
+++ b/tauri-app/src/components/MarkdownToolbar.test.tsx
@@ -41,6 +41,15 @@ describe("MarkdownToolbar", () => {
     expect(screen.getByLabelText("ブロックを削除")).toBeDefined();
   });
 
+  it("hides the bottom tabs only while the toolbar is up", () => {
+    const editor = createMockEditor();
+    const { unmount } = render(() => <MarkdownToolbar editor={editor} />);
+
+    expect(document.body.classList.contains("md-toolbar-open")).toBe(true);
+    unmount();
+    expect(document.body.classList.contains("md-toolbar-open")).toBe(false);
+  });
+
   it("calls editor.action when a button is clicked", () => {
     const editor = createMockEditor();
     render(() => <MarkdownToolbar editor={editor} />);

--- a/tauri-app/src/components/MarkdownToolbar.test.tsx
+++ b/tauri-app/src/components/MarkdownToolbar.test.tsx
@@ -21,7 +21,7 @@ describe("MarkdownToolbar", () => {
     expect(screen.queryByRole("toolbar")).toBeNull();
   });
 
-  it("renders 4 buttons when editor is provided", () => {
+  it("renders 6 buttons when editor is provided", () => {
     const editor = createMockEditor();
     render(() => <MarkdownToolbar editor={editor} />);
 
@@ -29,12 +29,16 @@ describe("MarkdownToolbar", () => {
     expect(toolbar).toBeDefined();
 
     const buttons = screen.getAllByRole("button");
-    expect(buttons).toHaveLength(4);
+    expect(buttons).toHaveLength(6);
 
     expect(screen.getByLabelText("Outdent")).toBeDefined();
     expect(screen.getByLabelText("Indent")).toBeDefined();
     expect(screen.getByLabelText("Code block")).toBeDefined();
     expect(screen.getByLabelText("Horizontal rule")).toBeDefined();
+    // スマホには Mod-Enter も範囲選択もない。ブロックの脱出と削除は
+    // ツールバーだけが入口になる
+    expect(screen.getByLabelText("ブロックから抜ける")).toBeDefined();
+    expect(screen.getByLabelText("ブロックを削除")).toBeDefined();
   });
 
   it("calls editor.action when a button is clicked", () => {

--- a/tauri-app/src/components/MarkdownToolbar.tsx
+++ b/tauri-app/src/components/MarkdownToolbar.tsx
@@ -40,6 +40,14 @@ export function keyboardTop(
 export default function MarkdownToolbar(props: MarkdownToolbarProps): JSX.Element {
   const [toolbarTop, setToolbarTop] = createSignal<number | undefined>();
 
+  // ツールバーが出ている間(=編集中)は下部タブを隠す。fixed のツールバーが
+  // タブに重なって Timeline / Notes が押せない・誤タップでモードが変わる、の
+  // 両方をここで断つ
+  onMount(() => {
+    document.body.classList.add("md-toolbar-open");
+    onCleanup(() => document.body.classList.remove("md-toolbar-open"));
+  });
+
   onMount(() => {
     const vv = window.visualViewport;
     if (!vv) {

--- a/tauri-app/src/components/MarkdownToolbar.tsx
+++ b/tauri-app/src/components/MarkdownToolbar.tsx
@@ -1,13 +1,15 @@
 import { Show, createSignal, onMount, onCleanup } from "solid-js";
 import { Portal } from "solid-js/web";
 import type { Editor } from "@milkdown/kit/core";
-import { commandsCtx, rootCtx } from "@milkdown/kit/core";
+import { commandsCtx, editorViewCtx, rootCtx } from "@milkdown/kit/core";
 import {
   sinkListItemCommand,
   liftListItemCommand,
   createCodeBlockCommand,
   insertHrCommand,
 } from "@milkdown/kit/preset/commonmark";
+import type { Command } from "@milkdown/kit/prose/state";
+import { deleteCurrentBlock, exitCodeBlock } from "../lib/block-commands";
 import Icon from "./Icon";
 import type { JSX } from "solid-js";
 
@@ -69,6 +71,16 @@ export default function MarkdownToolbar(props: MarkdownToolbarProps): JSX.Elemen
     });
   };
 
+  /** Milkdown のコマンド登録を介さない、素の ProseMirror コマンドを撃つ。 */
+  const execCommand = (command: Command) => {
+    exec((e) =>
+      e.action((ctx) => {
+        const view = ctx.get(editorViewCtx);
+        command(view.state, view.dispatch);
+      }),
+    );
+  };
+
   const top = () => toolbarTop();
 
   return (
@@ -127,6 +139,24 @@ export default function MarkdownToolbar(props: MarkdownToolbarProps): JSX.Elemen
             title="Horizontal rule"
           >
             <Icon name="minus" size={18} />
+          </button>
+          <button
+            type="button"
+            onPointerDown={(e) => e.preventDefault()}
+            onClick={() => execCommand(exitCodeBlock)}
+            aria-label="ブロックから抜ける"
+            title="ブロックから抜ける"
+          >
+            <Icon name="arrow-line-down" size={18} />
+          </button>
+          <button
+            type="button"
+            onPointerDown={(e) => e.preventDefault()}
+            onClick={() => execCommand(deleteCurrentBlock)}
+            aria-label="ブロックを削除"
+            title="ブロックを削除"
+          >
+            <Icon name="trash" size={18} />
           </button>
         </div>
       </Portal>

--- a/tauri-app/src/lib/block-commands.test.ts
+++ b/tauri-app/src/lib/block-commands.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { Schema } from "@milkdown/kit/prose/model";
+import { EditorState, TextSelection, NodeSelection } from "@milkdown/kit/prose/state";
+import type { Node } from "@milkdown/kit/prose/model";
+import { deleteCurrentBlock, exitCodeBlock } from "./block-commands";
+
+// 本物の commonmark スキーマは Milkdown の初期化ごと必要になる。コマンドが
+// 見るのはノード名と入れ子だけなので、その形だけを再現した最小スキーマで足りる。
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: { group: "block", content: "text*" },
+    code_block: { group: "block", content: "text*", code: true },
+    hr: { group: "block" },
+    bullet_list: { group: "block", content: "list_item+" },
+    list_item: { content: "paragraph block*" },
+    text: {},
+  },
+});
+
+const p = (text?: string): Node =>
+  schema.nodes.paragraph.create(null, text ? schema.text(text) : undefined);
+const code = (text: string): Node => schema.nodes.code_block.create(null, schema.text(text));
+
+/** pos にカーソルを置いた state。 */
+function stateAt(doc: Node, pos: number): EditorState {
+  return EditorState.create({ doc, selection: TextSelection.create(doc, pos) });
+}
+
+function apply(state: EditorState, command: typeof deleteCurrentBlock): EditorState {
+  let next = state;
+  command(state, (tr) => {
+    next = state.apply(tr);
+  });
+  return next;
+}
+
+describe("deleteCurrentBlock", () => {
+  it("removes the whole code block the cursor is in", () => {
+    const doc = schema.nodes.doc.create(null, [p("before"), code("fn main() {}"), p("after")]);
+    // "before"(8) + 開始タグで code 内の先頭は 9
+    const state = stateAt(doc, 10);
+
+    const next = apply(state, deleteCurrentBlock);
+
+    expect(next.doc.childCount).toBe(2);
+    expect(next.doc.textContent).toBe("beforeafter");
+  });
+
+  it("removes only the paragraph the cursor is in", () => {
+    const doc = schema.nodes.doc.create(null, [p("one"), p("two")]);
+    const state = stateAt(doc, 2);
+
+    const next = apply(state, deleteCurrentBlock);
+
+    expect(next.doc.childCount).toBe(1);
+    expect(next.doc.textContent).toBe("two");
+  });
+
+  it("removes a node selection such as a horizontal rule", () => {
+    const doc = schema.nodes.doc.create(null, [p("a"), schema.nodes.hr.create(), p("b")]);
+    const state = EditorState.create({ doc, selection: NodeSelection.create(doc, 3) });
+
+    const next = apply(state, deleteCurrentBlock);
+
+    expect(next.doc.childCount).toBe(2);
+    expect(next.doc.firstChild?.type.name).toBe("paragraph");
+  });
+
+  it("leaves an empty paragraph instead of an empty document", () => {
+    const doc = schema.nodes.doc.create(null, [code("only block")]);
+    const state = stateAt(doc, 1);
+
+    const next = apply(state, deleteCurrentBlock);
+
+    expect(next.doc.childCount).toBe(1);
+    expect(next.doc.firstChild?.type.name).toBe("paragraph");
+    expect(next.doc.textContent).toBe("");
+  });
+
+  it("takes the surrounding list item along when its only paragraph goes", () => {
+    const li = schema.nodes.list_item.create(null, p("item"));
+    const doc = schema.nodes.doc.create(null, [schema.nodes.bullet_list.create(null, li), p("x")]);
+    const state = stateAt(doc, 3);
+
+    const next = apply(state, deleteCurrentBlock);
+
+    expect(next.doc.textContent).toBe("x");
+  });
+});
+
+describe("exitCodeBlock", () => {
+  it("puts the cursor into a fresh paragraph after the code block", () => {
+    const doc = schema.nodes.doc.create(null, [code("code")]);
+    const state = stateAt(doc, 1);
+
+    const next = apply(state, exitCodeBlock);
+
+    expect(next.doc.childCount).toBe(2);
+    expect(next.doc.lastChild?.type.name).toBe("paragraph");
+    expect(next.selection.$from.parent.type.name).toBe("paragraph");
+  });
+
+  it("does nothing outside a code block", () => {
+    const doc = schema.nodes.doc.create(null, [p("plain")]);
+    const state = stateAt(doc, 2);
+
+    expect(exitCodeBlock(state)).toBe(false);
+  });
+});

--- a/tauri-app/src/lib/block-commands.ts
+++ b/tauri-app/src/lib/block-commands.ts
@@ -1,0 +1,58 @@
+import { NodeSelection, TextSelection } from "@milkdown/kit/prose/state";
+import type { Command } from "@milkdown/kit/prose/state";
+
+/**
+ * カーソルのあるブロックを丸ごと消す。キーボードだけなら範囲選択して消せるが、
+ * スマホではコードブロックの全選択も水平線の選択も現実的にできないため、
+ * ツールバーの入口として用意する。
+ *
+ * - 水平線などを選んだ NodeSelection はその選択を消す
+ * - コードブロック・段落はブロックごと消す。リスト項目の唯一の段落なら
+ *   `deleteRange` が項目ごと畳んでくれる
+ * - 最後の 1 ブロックは消すと文書が空になれないので、空の段落に置き換える
+ */
+export const deleteCurrentBlock: Command = (state, dispatch) => {
+  const { selection, tr } = state;
+
+  if (selection instanceof NodeSelection) {
+    tr.deleteSelection();
+  } else {
+    const { $from } = selection;
+    if ($from.depth === 0) {
+      return false;
+    }
+    const from = $from.before($from.depth);
+    const to = $from.after($from.depth);
+    if (from === 0 && to === state.doc.content.size) {
+      tr.replaceWith(from, to, state.schema.nodes.paragraph.create());
+      tr.setSelection(TextSelection.create(tr.doc, 1));
+    } else {
+      tr.deleteRange(from, to);
+    }
+  }
+
+  dispatch?.(tr.scrollIntoView());
+  return true;
+};
+
+/**
+ * コードブロックの直後に段落を作ってカーソルを移す。キーボードでは
+ * Mod-Enter に割り当てているが、スマホには修飾キーがないので
+ * ツールバーからも同じコマンドを呼べるようにしておく。
+ */
+export const exitCodeBlock: Command = (state, dispatch) => {
+  const { $from } = state.selection;
+  if ($from.parent.type.name !== "code_block") {
+    return false;
+  }
+  if (!dispatch) {
+    return true;
+  }
+
+  const endOfBlock = $from.after($from.depth);
+  const { tr } = state;
+  tr.insert(endOfBlock, state.schema.nodes.paragraph.create());
+  tr.setSelection(TextSelection.near(tr.doc.resolve(endOfBlock + 1)));
+  dispatch(tr.scrollIntoView());
+  return true;
+};

--- a/tauri-app/src/lib/exit-code-block-plugin.ts
+++ b/tauri-app/src/lib/exit-code-block-plugin.ts
@@ -1,30 +1,14 @@
 import { $prose } from "@milkdown/kit/utils";
-import { TextSelection } from "@milkdown/kit/prose/state";
 import { keymap } from "@milkdown/kit/prose/keymap";
+import { exitCodeBlock } from "./block-commands";
 
 /**
  * Exit a code block by pressing Mod+Enter (Cmd+Enter on Mac).
- * Inserts a new paragraph after the code block and moves the cursor there.
+ * The command itself lives in block-commands.ts so the touch toolbar,
+ * which has no modifier keys to offer, can call the same thing.
  */
 export const exitCodeBlockPlugin = $prose(() =>
   keymap({
-    "Mod-Enter": (state, dispatch) => {
-      const { $from } = state.selection;
-      const node = $from.node($from.depth);
-      if (node.type.name !== "code_block") {
-        return false;
-      }
-
-      if (!dispatch) {
-        return true;
-      }
-      const endOfBlock = $from.after($from.depth);
-      const { tr } = state;
-      const paragraphType = state.schema.nodes.paragraph;
-      tr.insert(endOfBlock, paragraphType.create());
-      tr.setSelection(TextSelection.near(tr.doc.resolve(endOfBlock + 1)));
-      dispatch(tr);
-      return true;
-    },
+    "Mod-Enter": exitCodeBlock,
   }),
 );

--- a/tauri-app/src/styles/markdown-toolbar.css
+++ b/tauri-app/src/styles/markdown-toolbar.css
@@ -37,4 +37,10 @@
     color: var(--app-text);
     background: var(--app-surface);
   }
+
+  /* 編集中はツールバーが下端を使う。タブを残すと fixed のツールバーが上に
+     重なって押せないボタンが並ぶだけなので、場所ごと譲ってもらう */
+  body.md-toolbar-open .bottom-tabs {
+    display: none;
+  }
 }


### PR DESCRIPTION
## 1. 概要

- スマホではコードブロックを丸ごと範囲選択する手段も Mod-Enter もないため、一度作った ``` ブロックから抜けることも消すこともできなかった。「ブロックから抜ける」「ブロックを削除」の 2 ボタンをタッチツールバーに追加する
- コマンドは素の ProseMirror コマンドとして `block-commands.ts` に置き、既存の Mod-Enter キーマップと同じ実装を共有する。削除はタップで選んだ水平線(NodeSelection)にも効き、最後の 1 ブロックを消すときは空段落に置き換えて不正な空ドキュメントを作らない
- fixed のツールバーが下部タブ(Timeline / Notes)の真上に重なり、押せないボタンが並んで編集中の誤タップも誘っていた。ツールバー表示中(=編集中)は `body` クラスでタブを隠し、下端をツールバーに譲る
- スクロール時にツールバーが遅れてフワっと追従する件は、viewport meta に `interactive-widget=resizes-content` を追加。対応 WebView ではキーボードがレイアウトごと縮めるため JS 追従(visualViewport)が発火せず、非対応環境では従来の JS がフォールバックとして残る

## 2. 図解

ブロック操作の入口。緑枠が追加要素で、キーボードとツールバーが同じコマンド実装を共有する。

```mermaid
flowchart LR
  keymap["Mod-Enter キーマップ<br/>(exit-code-block-plugin)"] --> cmds["block-commands.ts<br/>exitCodeBlock / deleteCurrentBlock"]
  toolbar["タッチツールバー"] --> cmds
  cmds --> pm["ProseMirror ドキュメント"]
  toolbar -.->|"表示中は body.md-toolbar-open"| tabs["bottom-tabs 非表示"]
  classDef added stroke:#3fb950,stroke-width:3px
  class cmds,tabs added
```

## 3. 変更ファイル

| ファイル                                        | 変更      | 理由                                                         |
| ----------------------------------------------- | --------- | ------------------------------------------------------------ |
| `tauri-app/src/lib/block-commands.ts`           | +58 / -0  | 削除・脱出コマンド本体(キーマップとツールバーで共有)         |
| `tauri-app/src/lib/block-commands.test.ts`      | +110 / -0 | 最小スキーマでの 7 ケース(code/段落/hr/最終ブロック/リスト)  |
| `tauri-app/src/lib/exit-code-block-plugin.ts`   | +4 / -20  | 実装を block-commands へ移し、キーマップ登録だけ残す         |
| `tauri-app/src/components/MarkdownToolbar.tsx`  | +39 / -1  | 2 ボタン追加と、表示中の `body.md-toolbar-open` 付与         |
| `tauri-app/src/components/MarkdownToolbar.test.tsx` | +15 / -2 | 6 ボタンとクラスの付け外しを検証                            |
| `tauri-app/src/styles/markdown-toolbar.css`     | +6 / -0   | 編集中に bottom-tabs を隠す                                  |
| `tauri-app/index.html`                          | +8 / -1   | `interactive-widget=resizes-content`(JS 追従の無効化)        |
| `tauri-app/src/components/Icon.tsx`             | +1 / -0   | 脱出ボタン用の `arrow-line-down` 登録                        |

**合計:** 8 ファイル, +241 / -24

## 4. テスト

- [x] `block-commands` 単体 7 件 — Red → Green を確認(コードブロック丸ごと削除・段落のみ削除・hr の NodeSelection 削除・最終ブロックは空段落化・リスト項目は項目ごと・脱出の段落挿入とカーソル移動・コードブロック外では no-op)
- [x] `pnpm test` 227 件 / `tsgo -b` / `oxlint` 0 件 / `pnpm knip` / `nix fmt` 差分なし
- [x] agent-browser(実ブラウザ): 「ブロックを削除」で rust ブロックだけが消える・「ブロックから抜ける」で直後の新段落に入力が入る・水平線のタップ選択→削除・編集中は bottom-tabs が消えツールバーが下端を占有(スクリーンショット確認)
- [ ] Android 実機: `interactive-widget=resizes-content` のキーボード挙動(エミュレーションでは仮想キーボードを再現できないため。非対応でも従来挙動に落ちる設計)
