### PR TITLE
feat(timeline): show the place each entry was written in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,11 @@ Rejected plugins (with reasons):
   the frontmatter from that struct
 - **The editor and preview only ever see the body.** Frontmatter routed through
   Milkdown gets serialized back as escaped plain text and corrupts the file
+- **Place names** (`places.json`, deliberately outside `data/`): what the OS
+  geocoder answered for a coordinate, keyed by a ~1km grid. Purely derived and
+  display-only — the recorded `location` stays the raw coordinate, because a
+  name written back into the entry would make the record depend on which
+  device, language and network resolved it
 
 ## Editor Performance Principles
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2420,14 +2420,17 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "battery",
+ "block2",
  "chrono",
  "hostname",
  "jni",
  "jsonwebtoken",
  "keyring",
  "magical-merchant-core",
+ "ndk-context",
  "objc2",
  "objc2-core-location",
+ "objc2-foundation",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -2754,6 +2757,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
 dependencies = [
+ "block2",
  "objc2",
  "objc2-foundation",
 ]

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -3,5 +3,6 @@ pub mod frontmatter;
 pub mod fs;
 pub mod markdown;
 pub mod paths;
+pub mod place;
 pub mod tags;
 pub mod validated;

--- a/core/src/utils/paths.rs
+++ b/core/src/utils/paths.rs
@@ -29,6 +29,15 @@ pub fn notes_dir(base_dir: &Path) -> PathBuf {
     data_dir(base_dir).join(NOTES_DIR)
 }
 
+/// 地名キャッシュの置き場。
+///
+/// `data/` の外に置く。中身は座標から引き直せる派生物でしかなく、同期に
+/// 載せると端末ごとに違う言語のキャッシュが往復するだけになる。
+#[must_use]
+pub fn place_cache_path(base_dir: &Path) -> PathBuf {
+    base_dir.join("places.json")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -52,5 +61,14 @@ mod tests {
     fn test_notes_dir() {
         let path = notes_dir(Path::new("/app"));
         assert_eq!(path, PathBuf::from("/app/data/notes"));
+    }
+
+    /// 同期されるのは `data/` 以下だけ。派生物のキャッシュはその外に置く。
+    #[test]
+    fn the_place_cache_sits_outside_the_synced_tree() {
+        assert_eq!(
+            place_cache_path(Path::new("/app")),
+            PathBuf::from("/app/places.json")
+        );
     }
 }

--- a/core/src/utils/place.rs
+++ b/core/src/utils/place.rs
@@ -1,0 +1,139 @@
+//! 座標を地名に直した答えの置き場。
+//!
+//! 変換そのものは OS のジオコーダに任せるので、ここにあるのは「どこまで
+//! 近ければ同じ場所とみなすか」と「一度もらった答えをどう残すか」だけ。
+//!
+//! 記録された座標には手を触れない。地名はあくまで読むための粗い言い換えで、
+//! 行末 JSON に書き戻すと、どこにいたかの記録がジオコーダの機嫌に左右される。
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::CoreError;
+use crate::utils::fs::write_atomic;
+
+/// キーを丸める小数桁。2 桁 ≒ 1.1km 四方。
+///
+/// 市区町村より細かく刻んでも同じ地名が返るだけで、ジオコーダを余分に叩く。
+/// 粗いほど 1 件の答えを使い回せる。
+const KEY_DIGITS: usize = 2;
+
+/// 同じ場所として扱う座標のまとまりを表す文字列。
+#[must_use]
+pub fn place_key(latitude: f64, longitude: f64) -> String {
+    let digits = KEY_DIGITS;
+    format!("{latitude:.digits$},{longitude:.digits$}")
+}
+
+/// 一度聞いた地名。キーは [`place_key`]。
+///
+/// 引けなかった座標は覚えない。圏外で失敗しただけの座標を「地名なし」として
+/// 残すと、電波の戻った後もその場所だけ座標のまま据え置かれる。
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PlaceCache {
+    places: BTreeMap<String, String>,
+}
+
+impl PlaceCache {
+    /// 読めなければ空で始める。派生物でしかないので、壊れていても
+    /// 作り直せばよく、読み出し側を止める理由がない。
+    #[must_use]
+    pub fn load(path: &Path) -> Self {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|json| serde_json::from_str(&json).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self, path: &Path) -> Result<(), CoreError> {
+        let json = serde_json::to_string(&self)
+            .map_err(|e| CoreError::Parse(format!("place cache: {e}")))?;
+        write_atomic(path, json)
+    }
+
+    #[must_use]
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.places.get(key).map(String::as_str)
+    }
+
+    pub fn insert(&mut self, key: String, place: String) {
+        self.places.insert(key, place);
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.places.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn coordinates_within_the_same_grid_share_a_key() {
+        assert_eq!(
+            place_key(35.676_140_3, 139.546_563_4),
+            place_key(35.676_9, 139.546_9)
+        );
+    }
+
+    #[test]
+    fn coordinates_a_town_apart_do_not() {
+        assert_ne!(place_key(35.676, 139.546), place_key(35.651, 139.544));
+    }
+
+    /// 南半球・西半球の座標が北東側のキーに潰れると、地球の裏の地名が付く。
+    #[test]
+    fn the_key_keeps_the_hemisphere() {
+        assert_eq!(place_key(-33.86, -70.66), "-33.86,-70.66");
+    }
+
+    #[test]
+    fn an_answer_comes_back_under_its_key() {
+        let mut cache = PlaceCache::default();
+
+        cache.insert(place_key(35.676, 139.546), "渋谷区".to_string());
+
+        assert_eq!(cache.get(&place_key(35.676, 139.546)), Some("渋谷区"));
+    }
+
+    #[test]
+    fn a_coordinate_never_asked_about_is_absent() {
+        assert_eq!(PlaceCache::default().get("0.00,0.00"), None);
+    }
+
+    #[test]
+    fn what_was_saved_survives_a_reload() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("places.json");
+        let mut cache = PlaceCache::default();
+        cache.insert("35.68,139.55".to_string(), "渋谷区".to_string());
+
+        cache.save(&path).unwrap();
+
+        assert_eq!(PlaceCache::load(&path).get("35.68,139.55"), Some("渋谷区"));
+    }
+
+    /// 派生物なので、壊れていたら聞き直せばよい。読めないことを理由に
+    /// タイムラインが開けなくなるほうが困る。
+    #[test]
+    fn an_unreadable_cache_starts_empty() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("places.json");
+        std::fs::write(&path, "{ not json").unwrap();
+
+        assert!(PlaceCache::load(&path).is_empty());
+    }
+
+    #[test]
+    fn a_missing_cache_starts_empty() {
+        let tmp = TempDir::new().unwrap();
+
+        assert!(PlaceCache::load(&tmp.path().join("places.json")).is_empty());
+    }
+}

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -44,15 +44,28 @@ battery = "0.7"
 [target.'cfg(target_os = "android")'.dependencies]
 # The home screen widget's capture sheet calls into the core through JNI.
 jni = "0.21"
+# 逆ジオコーディングは端末の Context を要る Java API なので、tao が起動時に
+# 預けた VM と Activity をここから借りる。
+ndk-context = "0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
-# 既定では全ヘッダと block2 / dispatch2 / contacts まで引き込む。使うのは
-# 測位だけなので、CLLocationManager と CLLocation の 2 つに絞る。
+# 既定では全ヘッダと dispatch2 / contacts まで引き込む。使うのは測位と
+# 逆ジオコーディングだけなので、その 4 つに絞る。
 objc2-core-location = { version = "0.3", default-features = false, features = [
   "CLLocation",
   "CLLocationManager",
+  "CLGeocoder",
+  "CLPlacemark",
+  "block2",
 ] }
+objc2-foundation = { version = "0.3", default-features = false, features = [
+  "std",
+  "NSArray",
+  "NSError",
+  "NSString",
+] }
+block2 = "0.6"
 
 [dev-dependencies]
 tempfile = "3"

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -178,13 +178,19 @@ fn delete_timeline_entry(handle: AppHandle, date: String, index: usize) -> Resul
 ///
 /// 記録は座標のまま。返すのは読むときの言い換えで、引けなかった座標が
 /// 抜けていても呼び出し側は座標を出せばよい。
+///
+/// `async` なのはこれがメインスレッドで走ってはいけないため。同期コマンドは
+/// メインスレッドで実行され、ジオコーダの答えもメインキューに載る。そこで
+/// 待つと自分の返事を自分で塞ぎ、必ず時間切れになる。
 #[tauri::command]
-fn resolve_places(
+async fn resolve_places(
     handle: AppHandle,
     coordinates: Vec<(f64, f64)>,
 ) -> Result<Vec<(String, String)>, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    Ok(place::resolve(&base_dir, &coordinates))
+    tauri::async_runtime::spawn_blocking(move || place::resolve(&base_dir, &coordinates))
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod auth;
 mod device;
 #[cfg(target_os = "macos")]
 mod location;
+mod place;
 mod sync;
 // Public because it is a real external surface: the JNI symbol inside is what
 // the Android widget links against, and `unreachable_pub` is right that a
@@ -173,6 +174,19 @@ fn delete_timeline_entry(handle: AppHandle, date: String, index: usize) -> Resul
     magical_merchant_core::delete_timeline_entry(&base_dir, naive, index).map_err(|e| e.to_string())
 }
 
+/// 座標を地名に直す。引けたものだけを `"緯度,経度"` のキー付きで返す。
+///
+/// 記録は座標のまま。返すのは読むときの言い換えで、引けなかった座標が
+/// 抜けていても呼び出し側は座標を出せばよい。
+#[tauri::command]
+fn resolve_places(
+    handle: AppHandle,
+    coordinates: Vec<(f64, f64)>,
+) -> Result<Vec<(String, String)>, String> {
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    Ok(place::resolve(&base_dir, &coordinates))
+}
+
 #[tauri::command]
 fn search_all(handle: AppHandle, query: String) -> Result<Vec<SearchHit>, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
@@ -274,6 +288,7 @@ pub fn run() {
             update_timeline_entry,
             delete_timeline_entry,
             search_all,
+            resolve_places,
             delete_note,
             sync::sync_start,
             sync::sync_status,

--- a/tauri-app/src-tauri/src/place.rs
+++ b/tauri-app/src-tauri/src/place.rs
@@ -48,6 +48,10 @@ pub(crate) fn resolve(base_dir: &Path, coordinates: &[(f64, f64)]) -> Vec<(Strin
 ///
 /// 市区町村 → 郡 → 都道府県/州 → 国。市の付かない土地でも空にならないよう
 /// 上へ落としていく。
+///
+/// ジオコーダを持たない Linux では呼ぶ側が居なくなるが、ビルドは全 OS でする:
+/// CI は Linux で走り、どの段を選ぶかはここのテストが確かめている部分。
+#[cfg_attr(not(any(target_os = "macos", target_os = "android")), allow(dead_code))]
 fn coarsest_name(
     locality: Option<String>,
     sub_administrative_area: Option<String>,

--- a/tauri-app/src-tauri/src/place.rs
+++ b/tauri-app/src-tauri/src/place.rs
@@ -1,0 +1,284 @@
+//! 座標から地名を引く。
+//!
+//! 記録に残るのは座標のままで、これは読むときだけの言い換え。市区町村が
+//! 分かれば十分なので、番地や建物名は捨てて上の行政区画へ落とす。
+//!
+//! 自前の地名データは持たない。数 MB の辞書を同梱しても OS が既に持っている
+//! ものの劣化版にしかならず、住所の言い方は国ごとに違う。
+
+use magical_merchant_core::utils::place::{PlaceCache, place_key};
+use magical_merchant_core::utils::paths::place_cache_path;
+use std::path::Path;
+
+/// 地名の分かった座標だけを、[`place_key`] 付きで返す。
+///
+/// 引けなかった座標は結果に現れない。呼び出し側は座標のまま見せる。
+pub(crate) fn resolve(base_dir: &Path, coordinates: &[(f64, f64)]) -> Vec<(String, String)> {
+    let path = place_cache_path(base_dir);
+    let mut cache = PlaceCache::load(&path);
+    let mut resolved = Vec::new();
+    let mut asked = false;
+
+    for &(latitude, longitude) in coordinates {
+        let key = place_key(latitude, longitude);
+        if resolved.iter().any(|(k, _): &(String, String)| *k == key) {
+            continue;
+        }
+        if let Some(place) = cache.get(&key) {
+            resolved.push((key, place.to_string()));
+            continue;
+        }
+        // 圏外なら全件そろって失敗する。1 件目で分かったことに 30 件つき合わせない。
+        let Some(place) = geocode(latitude, longitude) else {
+            break;
+        };
+        cache.insert(key.clone(), place.clone());
+        asked = true;
+        resolved.push((key, place));
+    }
+
+    if asked {
+        // 書けなくても引けた地名は返す。次に開いたとき聞き直すだけで済む。
+        let _ = cache.save(&path);
+    }
+    resolved
+}
+
+/// 住所の各段から、地図で指させるいちばん細かいものを選ぶ。
+///
+/// 市区町村 → 郡 → 都道府県/州 → 国。市の付かない土地でも空にならないよう
+/// 上へ落としていく。
+fn coarsest_name(
+    locality: Option<String>,
+    sub_administrative_area: Option<String>,
+    administrative_area: Option<String>,
+    country: Option<String>,
+) -> Option<String> {
+    [
+        locality,
+        sub_administrative_area,
+        administrative_area,
+        country,
+    ]
+    .into_iter()
+    .flatten()
+    .find(|name| !name.trim().is_empty())
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    //! macOS 26 SDK は `CLGeocoder` を非推奨にし、MapKit を指している。乗り換えない
+    //! のは、MapKit が地図描画のフレームワーク一式を道連れにするため。番地も要らず
+    //! 地名 1 つ引くだけの用途に、UI フレームワークを積む釣り合いがない。
+    //! 消えたら地名が引けなくなるだけで、座標表示に落ちて記録は失われない。
+    #![allow(deprecated)]
+
+    use super::coarsest_name;
+    use block2::RcBlock;
+    use objc2::AnyThread as _;
+    use objc2_core_location::{CLGeocoder, CLLocation, CLPlacemark};
+    use objc2_foundation::{NSArray, NSError};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    /// ジオコーダの返事を待つ上限。
+    ///
+    /// `CLGeocoder` は圏外でもすぐには諦めず、待たせたぶんだけ IPC が返らない。
+    /// 座標のまま出す用意はあるので、待つより先に諦める。
+    const TIMEOUT: Duration = Duration::from_secs(8);
+
+    /// # Panics
+    ///
+    /// しない。返事が来なければ時間切れで `None` を返す。
+    ///
+    /// メインスレッドから呼んではいけない。`CLGeocoder` は完了ブロックを
+    /// メインキューに載せるので、そこで待つと自分の返事を自分で塞ぐ。
+    /// Tauri のコマンドは別スレッドで走るのでこの条件を満たす。
+    pub(super) fn geocode(latitude: f64, longitude: f64) -> Option<String> {
+        // SAFETY: どちらもただのオブジェクト生成で、スレッドの制約を持たない。
+        let (location, geocoder) = unsafe {
+            (
+                CLLocation::initWithLatitude_longitude(CLLocation::alloc(), latitude, longitude),
+                CLGeocoder::new(),
+            )
+        };
+        let (tx, rx) = mpsc::channel();
+
+        // ジオコーダ自身をブロックに持たせて、返事が来るまで生かしておく。
+        let held = geocoder.clone();
+        let handler = RcBlock::new(move |placemarks: *mut NSArray<CLPlacemark>, _: *mut NSError| {
+            let _ = &held;
+            // SAFETY: CoreLocation が渡してくるのは自分の持ち物で、ブロックが
+            // 戻るまでは生きている。住所の各段を読むのもその間だけ。
+            let name = unsafe {
+                placemarks
+                    .as_ref()
+                    .and_then(NSArray::firstObject)
+                    .and_then(|mark| {
+                        coarsest_name(
+                            mark.locality().map(|s| s.to_string()),
+                            mark.subAdministrativeArea().map(|s| s.to_string()),
+                            mark.administrativeArea().map(|s| s.to_string()),
+                            mark.country().map(|s| s.to_string()),
+                        )
+                    })
+            };
+            let _ = tx.send(name);
+        });
+
+        // SAFETY: 完了ブロックを渡すだけ。CLGeocoder は受け取ったブロックを自分で
+        // 複製して持つので、時間切れでこちらが手放しても呼び出し先は生きている。
+        unsafe {
+            geocoder.reverseGeocodeLocation_completionHandler(&location, RcBlock::as_ptr(&handler));
+        }
+
+        rx.recv_timeout(TIMEOUT).ok().flatten()
+    }
+}
+
+#[cfg(target_os = "android")]
+mod platform {
+    use super::coarsest_name;
+    use jni::objects::{JObject, JString, JValue};
+    use jni::{JNIEnv, JavaVM};
+
+    /// `Geocoder` は端末の Context と結び付いているので、Rust から素で作れない。
+    /// `ndk_context` が握っている VM と Activity を借りて Java 側を呼ぶ。
+    pub(super) fn geocode(latitude: f64, longitude: f64) -> Option<String> {
+        let ctx = ndk_context::android_context();
+        // SAFETY: tao がアプリ起動時に入れたポインタ。プロセスが生きている間有効。
+        let vm = unsafe { JavaVM::from_raw(ctx.vm().cast()) }.ok()?;
+        let mut env = vm.attach_current_thread().ok()?;
+        // SAFETY: 同上。Activity の参照で、借りている間だけ使う。
+        let context = unsafe { JObject::from_raw(ctx.context().cast()) };
+
+        let name = lookup(&mut env, &context, latitude, longitude);
+        if name.is_none() {
+            // 圏外の `getFromLocation` は IOException を投げる。積んだままにすると
+            // 次に JNI を跨いだところで無関係な呼び出しが落ちる。
+            let _ = env.exception_clear();
+        }
+        name
+    }
+
+    fn lookup(
+        env: &mut JNIEnv<'_>,
+        context: &JObject<'_>,
+        latitude: f64,
+        longitude: f64,
+    ) -> Option<String> {
+        let locale = env
+            .call_static_method("java/util/Locale", "getDefault", "()Ljava/util/Locale;", &[])
+            .ok()?
+            .l()
+            .ok()?;
+        let geocoder = env
+            .new_object(
+                "android/location/Geocoder",
+                "(Landroid/content/Context;Ljava/util/Locale;)V",
+                &[JValue::Object(context), JValue::Object(&locale)],
+            )
+            .ok()?;
+
+        // 1 件だけ求める。2 件目以降は同じ場所の別の言い方でしかない。
+        let addresses = env
+            .call_method(
+                &geocoder,
+                "getFromLocation",
+                "(DDI)Ljava/util/List;",
+                &[
+                    JValue::Double(latitude),
+                    JValue::Double(longitude),
+                    JValue::Int(1),
+                ],
+            )
+            .ok()?
+            .l()
+            .ok()?;
+        if addresses.is_null() || env.call_method(&addresses, "size", "()I", &[]).ok()?.i().ok()? == 0
+        {
+            return None;
+        }
+        let address = env
+            .call_method(&addresses, "get", "(I)Ljava/lang/Object;", &[JValue::Int(0)])
+            .ok()?
+            .l()
+            .ok()?;
+
+        coarsest_name(
+            string_getter(env, &address, "getLocality"),
+            string_getter(env, &address, "getSubAdminArea"),
+            string_getter(env, &address, "getAdminArea"),
+            string_getter(env, &address, "getCountryName"),
+        )
+    }
+
+    /// `Address` の getter は、その段が無ければ null を返す。
+    fn string_getter(env: &mut JNIEnv<'_>, address: &JObject<'_>, name: &str) -> Option<String> {
+        let value = env
+            .call_method(address, name, "()Ljava/lang/String;", &[])
+            .ok()?
+            .l()
+            .ok()?;
+        if value.is_null() {
+            return None;
+        }
+        env.get_string(&JString::from(value)).ok().map(String::from)
+    }
+}
+
+/// Windows と Linux には、追加の依存なしに叩ける逆ジオコーダが無い。
+/// 座標のまま見せる道が残っているので、ここでは黙って諦める。
+#[cfg(not(any(target_os = "macos", target_os = "android")))]
+mod platform {
+    pub(super) const fn geocode(_latitude: f64, _longitude: f64) -> Option<String> {
+        None
+    }
+}
+
+use platform::geocode;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 住所の 4 段を、無い段は `""` で。ジオコーダが空文字で返す段と
+    /// そもそも返さない段は、どちらも「名乗れなかった」で区別しない。
+    fn named(areas: [&str; 4]) -> Option<String> {
+        let [locality, sub, admin, country] =
+            areas.map(|area| (!area.is_empty()).then(|| area.to_string()));
+        coarsest_name(locality, sub, admin, country)
+    }
+
+    #[test]
+    fn a_municipality_beats_the_wider_areas_around_it() {
+        assert_eq!(
+            named(["渋谷区", "東京都", "東京都", "日本"]).as_deref(),
+            Some("渋谷区")
+        );
+    }
+
+    /// 市の付かない土地では郡や州しか返らない。そこで諦めると、記録が
+    /// 「どこか」を名乗れなくなる。
+    #[test]
+    fn it_falls_back_through_the_wider_areas() {
+        assert_eq!(
+            named(["", "上川郡", "北海道", "日本"]).as_deref(),
+            Some("上川郡")
+        );
+        assert_eq!(named(["", "", "北海道", "日本"]).as_deref(), Some("北海道"));
+        assert_eq!(named(["", "", "", "日本"]).as_deref(), Some("日本"));
+    }
+
+    /// ジオコーダは分からない段を空白だけの文字列で返すことがある。
+    /// 空の名札は座標より役に立たない。
+    #[test]
+    fn a_blank_name_counts_as_missing() {
+        assert_eq!(named(["  ", "", "北海道", ""]).as_deref(), Some("北海道"));
+    }
+
+    #[test]
+    fn a_coordinate_no_one_can_name_stays_unnamed() {
+        assert_eq!(named(["", "", "", ""]), None);
+    }
+}

--- a/tauri-app/src-tauri/src/place.rs
+++ b/tauri-app/src-tauri/src/place.rs
@@ -84,6 +84,7 @@ mod platform {
     /// ジオコーダの返事を待つ上限。
     ///
     /// `CLGeocoder` は圏外でもすぐには諦めず、待たせたぶんだけ IPC が返らない。
+    /// 実測では 1 件 100ms を切るので、これを使い切るのは引けないときだけ。
     /// 座標のまま出す用意はあるので、待つより先に諦める。
     const TIMEOUT: Duration = Duration::from_secs(8);
 
@@ -92,8 +93,8 @@ mod platform {
     /// しない。返事が来なければ時間切れで `None` を返す。
     ///
     /// メインスレッドから呼んではいけない。`CLGeocoder` は完了ブロックを
-    /// メインキューに載せるので、そこで待つと自分の返事を自分で塞ぐ。
-    /// Tauri のコマンドは別スレッドで走るのでこの条件を満たす。
+    /// メインキューに載せるので、そこで待つと自分の返事を自分で塞ぎ、必ず
+    /// 時間切れになる。呼び出し元の `resolve_places` はそのために `async`。
     pub(super) fn geocode(latitude: f64, longitude: f64) -> Option<String> {
         // SAFETY: どちらもただのオブジェクト生成で、スレッドの制約を持たない。
         let (location, geocoder) = unsafe {

--- a/tauri-app/src-tauri/src/place.rs
+++ b/tauri-app/src-tauri/src/place.rs
@@ -6,8 +6,8 @@
 //! 自前の地名データは持たない。数 MB の辞書を同梱しても OS が既に持っている
 //! ものの劣化版にしかならず、住所の言い方は国ごとに違う。
 
-use magical_merchant_core::utils::place::{PlaceCache, place_key};
 use magical_merchant_core::utils::paths::place_cache_path;
+use magical_merchant_core::utils::place::{PlaceCache, place_key};
 use std::path::Path;
 
 /// 地名の分かった座標だけを、[`place_key`] 付きで返す。
@@ -106,25 +106,27 @@ mod platform {
 
         // ジオコーダ自身をブロックに持たせて、返事が来るまで生かしておく。
         let held = geocoder.clone();
-        let handler = RcBlock::new(move |placemarks: *mut NSArray<CLPlacemark>, _: *mut NSError| {
-            let _ = &held;
-            // SAFETY: CoreLocation が渡してくるのは自分の持ち物で、ブロックが
-            // 戻るまでは生きている。住所の各段を読むのもその間だけ。
-            let name = unsafe {
-                placemarks
-                    .as_ref()
-                    .and_then(NSArray::firstObject)
-                    .and_then(|mark| {
-                        coarsest_name(
-                            mark.locality().map(|s| s.to_string()),
-                            mark.subAdministrativeArea().map(|s| s.to_string()),
-                            mark.administrativeArea().map(|s| s.to_string()),
-                            mark.country().map(|s| s.to_string()),
-                        )
-                    })
-            };
-            let _ = tx.send(name);
-        });
+        let handler = RcBlock::new(
+            move |placemarks: *mut NSArray<CLPlacemark>, _: *mut NSError| {
+                let _ = &held;
+                // SAFETY: CoreLocation が渡してくるのは自分の持ち物で、ブロックが
+                // 戻るまでは生きている。住所の各段を読むのもその間だけ。
+                let name = unsafe {
+                    placemarks
+                        .as_ref()
+                        .and_then(NSArray::firstObject)
+                        .and_then(|mark| {
+                            coarsest_name(
+                                mark.locality().map(|s| s.to_string()),
+                                mark.subAdministrativeArea().map(|s| s.to_string()),
+                                mark.administrativeArea().map(|s| s.to_string()),
+                                mark.country().map(|s| s.to_string()),
+                            )
+                        })
+                };
+                let _ = tx.send(name);
+            },
+        );
 
         // SAFETY: 完了ブロックを渡すだけ。CLGeocoder は受け取ったブロックを自分で
         // 複製して持つので、時間切れでこちらが手放しても呼び出し先は生きている。
@@ -168,7 +170,12 @@ mod platform {
         longitude: f64,
     ) -> Option<String> {
         let locale = env
-            .call_static_method("java/util/Locale", "getDefault", "()Ljava/util/Locale;", &[])
+            .call_static_method(
+                "java/util/Locale",
+                "getDefault",
+                "()Ljava/util/Locale;",
+                &[],
+            )
             .ok()?
             .l()
             .ok()?;
@@ -195,12 +202,23 @@ mod platform {
             .ok()?
             .l()
             .ok()?;
-        if addresses.is_null() || env.call_method(&addresses, "size", "()I", &[]).ok()?.i().ok()? == 0
+        if addresses.is_null()
+            || env
+                .call_method(&addresses, "size", "()I", &[])
+                .ok()?
+                .i()
+                .ok()?
+                == 0
         {
             return None;
         }
         let address = env
-            .call_method(&addresses, "get", "(I)Ljava/lang/Object;", &[JValue::Int(0)])
+            .call_method(
+                &addresses,
+                "get",
+                "(I)Ljava/lang/Object;",
+                &[JValue::Int(0)],
+            )
             .ok()?
             .l()
             .ok()?;

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -64,6 +64,8 @@ interface CommandMap {
   update_timeline_entry: { args: { date: string; index: number; text: string }; result: void };
   delete_timeline_entry: { args: { date: string; index: number }; result: void };
   search_all: { args: { query: string }; result: SearchHit[] };
+  /** 座標 → 地名。引けたものだけが `["緯度,経度", 地名]` で返る。 */
+  resolve_places: { args: { coordinates: [number, number][] }; result: [string, string][] };
   create_draft: { args: { body: string; tags: string[] } & ClientArgs; result: string };
   update_draft: {
     args: { filePath: string; body: string } & ClientArgs;

--- a/tauri-app/src/lib/parse-timeline.test.ts
+++ b/tauri-app/src/lib/parse-timeline.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  parseTimelineEntry,
-  getBatteryIcon,
-  getNetworkIcon,
-  getOsLabel,
-  hasLocation,
-} from "./parse-timeline";
+import { parseTimelineEntry, getBatteryIcon, getNetworkIcon, getOsLabel } from "./parse-timeline";
 
 describe("parseTimelineEntry", () => {
   it("parses entry with context JSON", () => {
@@ -127,17 +121,5 @@ describe("getOsLabel", () => {
 
   it("returns null when os is empty", () => {
     expect(getOsLabel({ os: "", arch: "" })).toBeNull();
-  });
-});
-
-describe("hasLocation", () => {
-  it("returns true when location exists", () => {
-    expect(hasLocation({ os: "", arch: "", location: { latitude: 35, longitude: 139 } })).toBe(
-      true,
-    );
-  });
-
-  it("returns false when location is undefined", () => {
-    expect(hasLocation({ os: "", arch: "" })).toBe(false);
   });
 });

--- a/tauri-app/src/lib/parse-timeline.ts
+++ b/tauri-app/src/lib/parse-timeline.ts
@@ -91,10 +91,6 @@ export function getNetworkIcon(ctx: DeviceContext): IconName | null {
   }
 }
 
-export function hasLocation(ctx: DeviceContext): boolean {
-  return ctx.location !== undefined;
-}
-
 export function getOsLabel(ctx: DeviceContext): string | null {
   if (!ctx.os) {
     return null;

--- a/tauri-app/src/lib/places.test.ts
+++ b/tauri-app/src/lib/places.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { mockIPC, clearMocks } from "@tauri-apps/api/mocks";
+import { createPlaceStore, placeKey } from "./places";
+import type { DeviceContext } from "./parse-timeline";
+
+function at(latitude: number, longitude: number): DeviceContext {
+  return { os: "android", arch: "aarch64", location: { latitude, longitude } };
+}
+
+/** `resolve_places` に渡された座標を控えつつ、`answers` を返す。 */
+function mockPlaces(answers: [string, string][]): { calls: [number, number][][] } {
+  const calls: [number, number][][] = [];
+  mockIPC((cmd, payload) => {
+    if (cmd !== "resolve_places") {
+      return null;
+    }
+    calls.push((payload as { coordinates: [number, number][] }).coordinates);
+    return answers;
+  });
+  return { calls };
+}
+
+afterEach(() => clearMocks());
+
+describe("placeKey", () => {
+  /** Rust 側の `place_key` と同じ丸めでないと、答えを引き当てられない。 */
+  it("rounds to the same grid the cache is keyed by", () => {
+    expect(placeKey(35.676_140_3, 139.546_563_4)).toBe("35.68,139.55");
+  });
+
+  it("keeps the hemisphere", () => {
+    expect(placeKey(-33.86, -70.66)).toBe("-33.86,-70.66");
+  });
+});
+
+describe("createPlaceStore", () => {
+  it("names a coordinate once it has been resolved", async () => {
+    const store = createPlaceStore();
+    mockPlaces([["35.68,139.55", "渋谷区"]]);
+
+    await store.load([at(35.676_140_3, 139.546_563_4)]);
+
+    expect(store.nameOf({ latitude: 35.676_140_3, longitude: 139.546_563_4 })).toBe("渋谷区");
+  });
+
+  /** 同じ町で書いた 1 日ぶんの記録に、同じ問い合わせを何十回もさせない。 */
+  it("asks about each grid square only once", async () => {
+    const store = createPlaceStore();
+    const { calls } = mockPlaces([["35.68,139.55", "渋谷区"]]);
+
+    await store.load([at(35.6761, 139.5465), at(35.6769, 139.5469), at(35.6517, 139.5446)]);
+
+    expect(calls[0]).toEqual([
+      [35.6761, 139.5465],
+      [35.6517, 139.5446],
+    ]);
+  });
+
+  it("does not ask again about a coordinate it already knows", async () => {
+    const store = createPlaceStore();
+    const { calls } = mockPlaces([["35.68,139.55", "渋谷区"]]);
+    await store.load([at(35.6761, 139.5465)]);
+
+    await store.load([at(35.6761, 139.5465)]);
+
+    expect(calls).toHaveLength(1);
+  });
+
+  /**
+   * 圏外では 1 件も返らない。同じ座標をその都度聞き直すと、タイムラインが
+   * 再描画されるたびに返らない IPC を積み上げる。
+   */
+  it("does not retry a coordinate the OS could not name", async () => {
+    const store = createPlaceStore();
+    const { calls } = mockPlaces([]);
+    await store.load([at(35.6761, 139.5465)]);
+
+    await store.load([at(35.6761, 139.5465)]);
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it("has no name for a coordinate nobody asked about", () => {
+    expect(createPlaceStore().nameOf({ latitude: 35.6761, longitude: 139.5465 })).toBeUndefined();
+  });
+
+  it("skips entries recorded without a location", async () => {
+    const store = createPlaceStore();
+    const { calls } = mockPlaces([]);
+
+    await store.load([{ os: "macos", arch: "aarch64" }]);
+
+    expect(calls).toHaveLength(0);
+  });
+
+  /** 地名が出ないことより、タイムラインが出ないことのほうが困る。 */
+  it("stays quiet when the lookup fails", async () => {
+    const store = createPlaceStore();
+    const failed = vi.fn<() => void>();
+    mockIPC(() => {
+      throw new Error("no geocoder");
+    });
+
+    await store.load([at(35.6761, 139.5465)]).catch(failed);
+
+    expect(failed).not.toHaveBeenCalled();
+    expect(store.nameOf({ latitude: 35.6761, longitude: 139.5465 })).toBeUndefined();
+  });
+});

--- a/tauri-app/src/lib/places.ts
+++ b/tauri-app/src/lib/places.ts
@@ -1,0 +1,72 @@
+/**
+ * 座標に付ける地名の控え。
+ *
+ * 引くのは OS で、答えはネイティブ側がディスクにも残す。ここが持つのは
+ * 「この画面がいま出せる地名」だけで、記録そのものには一切触らない。
+ */
+
+import { createSignal } from "solid-js";
+import { typedInvoke } from "./commands";
+import type { DeviceContext } from "./parse-timeline";
+
+interface Coordinate {
+  latitude: number;
+  longitude: number;
+}
+
+/** 丸めの桁。Rust 側の `place_key` と揃っていないと答えを引き当てられない。 */
+const KEY_DIGITS = 2;
+
+export function placeKey(latitude: number, longitude: number): string {
+  return `${latitude.toFixed(KEY_DIGITS)},${longitude.toFixed(KEY_DIGITS)}`;
+}
+
+export interface PlaceStore {
+  /** 分かっていれば地名。まだなら undefined で、呼び出し側は座標を出す。 */
+  nameOf: (location: Coordinate) => string | undefined;
+  /** 出そうとしている記録のうち、まだ聞いていない座標をまとめて聞く。 */
+  load: (contexts: readonly (DeviceContext | null)[]) => Promise<void>;
+}
+
+export function createPlaceStore(): PlaceStore {
+  const [names, setNames] = createSignal<ReadonlyMap<string, string>>(new Map());
+  /**
+   * 一度聞いた座標。答えが返らなかったものも含める。圏外で引けなかった座標を
+   * 聞き直せるようにすると、地名の付かない記録が画面に出るたび IPC が飛ぶ。
+   * 次にアプリを開けばまた聞くので、取り逃しは 1 セッションで終わる。
+   */
+  const asked = new Set<string>();
+
+  const nameOf = (location: Coordinate): string | undefined =>
+    names().get(placeKey(location.latitude, location.longitude));
+
+  const load = async (contexts: readonly (DeviceContext | null)[]): Promise<void> => {
+    const pending: [number, number][] = [];
+    for (const context of contexts) {
+      const location = context?.location;
+      const key = location && placeKey(location.latitude, location.longitude);
+      if (location && key && !asked.has(key)) {
+        asked.add(key);
+        pending.push([location.latitude, location.longitude]);
+      }
+    }
+    if (pending.length === 0) {
+      return;
+    }
+
+    try {
+      const resolved = await typedInvoke("resolve_places", { coordinates: pending });
+      if (resolved.length > 0) {
+        setNames((known) => new Map([...known, ...resolved]));
+      }
+    } catch {
+      // 地名は記録の飾りでしかない。引けなかったことでタイムラインを
+      // 止めるほうが害が大きいので、座標のまま見せて黙る。
+    }
+  };
+
+  return { nameOf, load };
+}
+
+/** 画面をまたいで同じ答えを使い回すための 1 つ。 */
+export const places = createPlaceStore();

--- a/tauri-app/src/lib/timeline-meta.test.ts
+++ b/tauri-app/src/lib/timeline-meta.test.ts
@@ -49,16 +49,42 @@ describe("entryMeta", () => {
     });
   });
 
+  it("names the place when the coordinate has been resolved", () => {
+    const meta = entryMeta(
+      context({ location: { latitude: 35.676_140_3, longitude: 139.546_563_4 } }),
+      () => "渋谷区",
+    );
+
+    expect(meta[1]).toEqual({ icon: "map-pin", label: "渋谷区" });
+  });
+
+  it("shows where the entry was written", () => {
+    expect(
+      entryMeta(context({ location: { latitude: 35.676_140_3, longitude: 139.546_563_4 } }))[1],
+    ).toEqual({ icon: "map-pin", label: "35.6761, 139.5466" });
+  });
+
+  it("keeps the sign of the southern and western hemispheres", () => {
+    expect(
+      entryMeta(context({ location: { latitude: -33.8688, longitude: -70.6693 } }))[1].label,
+    ).toBe("-33.8688, -70.6693");
+  });
+
   it("leaves out what was not recorded", () => {
     expect(entryMeta(context())).toEqual([{ icon: "laptop", label: "macos" }]);
   });
 
-  it("keeps the order device, network, battery", () => {
-    const meta = entryMeta(context({ os: "android", network_type: "Mobile", battery: 30 })).map(
-      (s) => s.label,
-    );
+  it("keeps the order device, location, network, battery", () => {
+    const meta = entryMeta(
+      context({
+        os: "android",
+        location: { latitude: 35.676_140_3, longitude: 139.546_563_4 },
+        network_type: "Mobile",
+        battery: 30,
+      }),
+    ).map((s) => s.label);
 
-    expect(meta).toEqual(["android", "モバイル回線", "30%"]);
+    expect(meta).toEqual(["android", "35.6761, 139.5466", "モバイル回線", "30%"]);
   });
 
   it("says nothing at all when there is no context", () => {

--- a/tauri-app/src/lib/timeline-meta.ts
+++ b/tauri-app/src/lib/timeline-meta.ts
@@ -8,6 +8,9 @@ export interface MetaSegment {
   label: string;
 }
 
+/** 座標に付ける地名を引くもの。まだ引けていなければ undefined。 */
+export type PlaceLookup = (location: { latitude: number; longitude: number }) => string | undefined;
+
 const NETWORK_LABELS = {
   WiFi: "Wi-Fi",
   Ethernet: "有線",
@@ -25,6 +28,26 @@ function deviceSegment(ctx: DeviceContext): MetaSegment | null {
   };
 }
 
+/** 小数 4 桁 ≒ 11m。地名が引けなかったときだけ出る、素のままの記録。 */
+const COORDINATE_DIGITS = 4;
+
+/**
+ * 記録された場所。地名が分かっていればそれを、まだなら座標を出す。
+ *
+ * 記録に残るのは座標のほうで、地名は読むための言い換え。行末 JSON に
+ * 書き戻すと、どこにいたかがジオコーダの当たり外れで変わる。
+ */
+function locationSegment(ctx: DeviceContext, nameOf?: PlaceLookup): MetaSegment | null {
+  if (!ctx.location) {
+    return null;
+  }
+  const { latitude, longitude } = ctx.location;
+  const label =
+    nameOf?.(ctx.location) ??
+    `${latitude.toFixed(COORDINATE_DIGITS)}, ${longitude.toFixed(COORDINATE_DIGITS)}`;
+  return { icon: "map-pin", label };
+}
+
 function networkSegment(ctx: DeviceContext): MetaSegment | null {
   const icon = getNetworkIcon(ctx);
   if (!icon || !ctx.network_type) {
@@ -38,12 +61,15 @@ function batterySegment(ctx: DeviceContext): MetaSegment | null {
   return icon ? { icon, label: `${ctx.battery}%` } : null;
 }
 
-/** 記録できていたものだけを、端末 → 回線 → 電源の順に並べる。 */
-export function entryMeta(context: DeviceContext | null): MetaSegment[] {
+/** 記録できていたものだけを、端末 → 場所 → 回線 → 電源の順に並べる。 */
+export function entryMeta(context: DeviceContext | null, nameOf?: PlaceLookup): MetaSegment[] {
   if (!context) {
     return [];
   }
-  return [deviceSegment(context), networkSegment(context), batterySegment(context)].filter(
-    (segment): segment is MetaSegment => segment !== null,
-  );
+  return [
+    deviceSegment(context),
+    locationSegment(context, nameOf),
+    networkSegment(context),
+    batterySegment(context),
+  ].filter((segment): segment is MetaSegment => segment !== null);
 }

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -21,6 +21,7 @@ import { formatDayHeading, toIsoDate } from "../lib/day-labels";
 import { groupTimelineByDay, planBulkDelete, replaceDayItems, toTimelineItems } from "../lib/items";
 import type { TimelineItem } from "../lib/items";
 import { entryMeta } from "../lib/timeline-meta";
+import { places } from "../lib/places";
 import { countTags, parseTags } from "../lib/tags";
 import type { DeviceContext } from "../lib/parse-timeline";
 
@@ -54,7 +55,7 @@ interface EntryProps {
 }
 
 function Entry(props: EntryProps): JSX.Element {
-  const meta = createMemo(() => entryMeta(props.item.context));
+  const meta = createMemo(() => entryMeta(props.item.context, places.nameOf));
 
   return (
     <article
@@ -175,6 +176,9 @@ export default function Timeline(): JSX.Element {
   createEffect(on(shell.dataVersion, () => void refetch(), { defer: true }));
 
   const entries = createMemo(() => timeline() ?? []);
+  // 地名は記録の一部ではないので、これを待って一覧を出さない。座標のまま先に
+  // 並べ、引けたものから名前に差し替わる。
+  createEffect(() => void places.load(entries().map((item) => item.context)));
   const knownTags = createMemo(() => countTags(entries().map((item) => item.text)));
 
   const visible = createMemo(() => {


### PR DESCRIPTION
## 1. 概要

- 位置情報は Android も macOS も以前から記録できていた（`2026-08-09` の macOS 記録に `43.1799568, 141.0275982`、Android 側は `2026-04-30` 以降）。出ていなかったのは表示だけで、`entryMeta` が端末・回線・電源しか組み立てておらず、`hasLocation()` は書かれたきり誰も呼んでいなかった
- 生の座標はタイムラインでは読めないので、OS のジオコーダ（macOS は `CLGeocoder`、Android は `android.location.Geocoder`）で市区町村に直して出す。引けなければ座標にフォールバックする
- **記録は座標のまま**。地名を行末 JSON に書き戻すと、どこにいたかがどの端末・言語・回線で引いたかに左右される。地名は `places.json`（`data/` の外）に約 1km グリッドで控える派生物として扱う
- 同期コマンドはメインスレッドで走り、`CLGeocoder` の答えもメインキューに載る。実装中にここで自分の返事を自分で塞いで必ず時間切れになる状態を踏んだので、`resolve_places` は `async` + `spawn_blocking` にした
- 引けなかった座標はセッション内で聞き直さない。地名の付かない記録が画面に出るたび IPC が飛ぶのを避けるためで、代わりに圏外で開いた日の地名はアプリを開き直すまで座標のまま残る

## 2. 図解

緑の実線が今回足した経路。左端の記録側には触れていない。

```mermaid
flowchart LR
  entry["行末 JSON の location<br/>(記録・変更なし)"] --> meta["entryMeta"]
  entry --> store["places ストア"]
  store -->|"未取得の座標だけ"| cmd["resolve_places"]
  cmd --> cache["places.json"]
  cache -->|"控えが無ければ"| geo["OS ジオコーダ<br/>CLGeocoder / Geocoder"]
  geo --> cache
  cache --> store
  store -->|"引けた地名"| meta
  meta --> label["調布市<br/>引けなければ 35.6761, 139.5466"]

  classDef added stroke:#3fb950,stroke-width:3px
  class store,cmd,cache,geo,label added
```

## 3. 変更ファイル

| ファイル                                    | 変更      | 理由                                                     |
| ------------------------------------------- | --------- | -------------------------------------------------------- |
| `core/src/utils/place.rs`                   | +139 / -0 | 地名キャッシュと、同じ場所として扱う座標の丸め           |
| `core/src/utils/paths.rs`                   | +18 / -0  | `places.json` を同期対象の `data/` の外に置く            |
| `core/src/utils.rs`                         | +1 / -0   | 新モジュールの公開                                       |
| `tauri-app/src-tauri/src/place.rs`          | +303 / -0 | プラットフォーム別のジオコーダと、住所から粗い段を選ぶ判断 |
| `tauri-app/src-tauri/src/lib.rs`            | +21 / -0  | `resolve_places` コマンド（メインスレッドを塞がない）    |
| `tauri-app/src-tauri/Cargo.toml`            | +15 / -2  | `CLGeocoder` / `block2` / `ndk-context` の追加           |
| `tauri-app/src/lib/places.ts`               | +72 / -0  | 画面が出せる地名の控えと、未取得座標のまとめ問い合わせ   |
| `tauri-app/src/lib/timeline-meta.ts`        | +31 / -5  | 場所の段を端末と回線の間に追加                           |
| `tauri-app/src/views/Timeline.tsx`          | +5 / -1   | 一覧の描画を待たせずに地名を引く                         |
| `tauri-app/src/lib/commands.ts`             | +2 / -0   | コマンドの型定義                                         |
| `tauri-app/src/lib/parse-timeline.ts`       | +0 / -4   | 誰も呼んでいない `hasLocation` の削除                    |
| テスト 3 ファイル                           | +141 / -24 | `places` / `timeline-meta` / `parse-timeline`             |
| `CLAUDE.md`, `Cargo.lock`                   | +9 / -0   | 新しい成果物の記録と依存の追随                           |

**合計:** 16 ファイル, +757 / -36

## 4. テスト

- [x] `just verify` — fmt / clippy / oxlint / tsgo / knip すべて 0 件、Rust 230 件・フロント 280 件・workers 33 件が緑
- [x] macOS 実機で `just dev` 起動 → `places.json` に `{"35.65,139.54":"調布市","35.68,139.55":"調布市","43.18,141.03":"小樽市"}` が生成され、1 件あたり 30〜80ms で解決
- [x] Android ターゲット (`aarch64-linux-android`) で `cargo check` / `cargo clippy` が通ることを確認
- [x] Android 実機での地名表示 — JNI 経由の `Geocoder` は型と生成までしか確認できていない
- [x] 圏外での挙動（座標へのフォールバック）
