### PR TITLE
fix(ui): eliminate startup layout shift and note-switch flash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,17 @@ Rejected plugins (with reasons):
   name written back into the entry would make the record depend on which
   device, language and network resolved it
 
+## Browser Verification Harness
+
+`just tauri_app::dev-browser` (or `pnpm run dev:browser`) starts Vite with a
+Tauri IPC mock (`tauri-app/dev/ipc-mock.js`) injected into `index.html`, so the
+full UI runs in a plain browser — drive it with `agent-browser` for layout/CLS
+checks and e2e-style verification. The mock holds deterministic in-memory
+fixtures (timeline days, notes with code/mermaid/mindmap, delayed
+`resolve_places`). It is injected only when `BROWSER_MOCK=1` and never reaches
+production builds. When adding a Tauri command, add a handler to the mock too —
+unknown commands throw so the gap is visible in the console.
+
 ## Editor Performance Principles
 
 Three non-negotiable constraints for Markdown editor design:

--- a/tauri-app/dev/ipc-mock.js
+++ b/tauri-app/dev/ipc-mock.js
@@ -1,0 +1,268 @@
+/**
+ * ブラウザ単体で UI を検証するための Tauri IPC モック。
+ *
+ * `BROWSER_MOCK=1 pnpm vite` のときだけ vite.config.ts が index.html の先頭に
+ * インライン注入する。モジュールグラフより先に実行される普通の <script> なので、
+ * `@tauri-apps/api` が `window.__TAURI_INTERNALS__` を読む頃には必ず居る。
+ * プロダクションビルドには一切含まれない。
+ */
+(() => {
+  if (window.__TAURI_INTERNALS__) {
+    return;
+  }
+
+  // ---- タイムラインのつくりもの ----
+
+  const PLACES = [
+    { lat: 35.6812, lon: 139.7671, name: "千代田区丸の内" },
+    { lat: 35.659, lon: 139.7005, name: "渋谷区神南" },
+    { lat: 35.6284, lon: 139.7387, name: "品川区大崎" },
+  ];
+
+  const TEXTS = [
+    "朝の散歩で考えた設計メモ #design",
+    "コードレビューの指摘を反映した",
+    "mermaid の描画が重い気がするので後で測る #perf",
+    "買い物リスト: 牛乳、卵、コーヒー豆",
+    "同期の競合をどう見せるか検討 #sync",
+    "タイムラインの仮想化はまだ要らない、件数を先に測る",
+    "読書メモ: 設計の背景を残すことについて",
+    "ウィジェットからの起動導線を確認した",
+  ];
+
+  const pad = (n) => String(n).padStart(2, "0");
+
+  function contextFor(dayIndex, entryIndex) {
+    if ((dayIndex + entryIndex) % 3 === 2) {
+      return null;
+    }
+    const ctx = {
+      battery: 20 + ((dayIndex * 13 + entryIndex * 29) % 80),
+      is_charging: entryIndex % 4 === 0,
+      network_type: ["WiFi", "Mobile", "WiFi", "Ethernet"][entryIndex % 4],
+      os: entryIndex % 2 === 0 ? "macos" : "android",
+      os_version: entryIndex % 2 === 0 ? "15.5" : "15",
+      arch: "aarch64",
+    };
+    if ((dayIndex + entryIndex) % 2 === 0) {
+      const place = PLACES[(dayIndex + entryIndex) % PLACES.length];
+      ctx.location = {
+        latitude: place.lat + (entryIndex % 5) * 0.0004,
+        longitude: place.lon + (entryIndex % 7) * 0.0003,
+      };
+    }
+    return ctx;
+  }
+
+  /** date(ISO) -> raw 行の配列(古い順)。 */
+  const timeline = new Map();
+  const today = new Date();
+  for (let d = 0; d < 20; d += 1) {
+    const day = new Date(today.getFullYear(), today.getMonth(), today.getDate() - d);
+    const iso = `${day.getFullYear()}-${pad(day.getMonth() + 1)}-${pad(day.getDate())}`;
+    const lines = [];
+    const count = 4 + ((d * 7) % 5);
+    for (let i = 0; i < count; i += 1) {
+      const time = `${pad(8 + i * 2)}:${pad((i * 17) % 60)}:${pad((i * 23) % 60)}`;
+      const ctx = contextFor(d, i);
+      const suffix = ctx ? ` ${JSON.stringify(ctx)}` : "";
+      lines.push(`- [${time}] ${TEXTS[(d + i) % TEXTS.length]}${suffix}`);
+    }
+    timeline.set(iso, lines);
+  }
+
+  // ---- ノートのつくりもの ----
+
+  const codeSample = [
+    "```typescript",
+    "export function debounce<T extends unknown[]>(fn: (...args: T) => void, ms: number) {",
+    "  let timer: ReturnType<typeof setTimeout> | undefined;",
+    "  return (...args: T) => {",
+    "    if (timer) clearTimeout(timer);",
+    "    timer = setTimeout(() => fn(...args), ms);",
+    "  };",
+    "}",
+    "```",
+  ].join("\n");
+
+  const mermaidSample = [
+    "```mermaid",
+    "flowchart TD",
+    "  A[編集開始] --> B{保存済み?}",
+    "  B -- はい --> C[プレビュー]",
+    "  B -- いいえ --> D[1秒待って保存]",
+    "  D --> C",
+    "```",
+  ].join("\n");
+
+  const longSections = [];
+  for (let i = 1; i <= 30; i += 1) {
+    longSections.push(
+      `## セクション ${i}`,
+      "",
+      `本文の段落です。エディタとプレビューの描画コストを測るための行。行番号 ${i}。`,
+      "",
+    );
+  }
+
+  const notes = new Map([
+    [
+      "20260810_090000.md",
+      {
+        time: "2026-08-10T09:00:00+09:00",
+        tags: ["perf"],
+        view: null,
+        body: `# パフォーマンス検証ノート\n\nコードブロックと図の混ざった長文。\n\n${codeSample}\n\n${mermaidSample}\n\n${longSections.join("\n")}`,
+      },
+    ],
+    [
+      "20260812_140000.md",
+      {
+        time: "2026-08-12T14:00:00+09:00",
+        tags: ["design"],
+        view: "mindmap",
+        body: `# 設計の見取り図\n\n## UI\n\n- ヘッダ\n- タイムライン\n  - 入力バー\n  - 日付ジャンプ\n\n## コア\n\n- 保存\n- 同期\n  - 認証\n  - 競合`,
+      },
+    ],
+    [
+      "20260813_083000.md",
+      {
+        time: "2026-08-13T08:30:00+09:00",
+        tags: [],
+        view: null,
+        body: "# 短いメモ\n\n今日やることを 3 つだけ。",
+      },
+    ],
+  ]);
+
+  const noteList = () =>
+    [...notes.entries()]
+      .toSorted(([a], [b]) => b.localeCompare(a))
+      .map(([filename, note]) => ({
+        path: `/mock/data/${filename}`,
+        filename,
+        time: note.time,
+        tags: note.tags,
+        preview: note.body.slice(0, 120),
+      }));
+
+  // ---- コマンド実装 ----
+
+  const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  const placeKey = (lat, lon) => `${lat.toFixed(2)},${lon.toFixed(2)}`;
+
+  const commands = {
+    list_timeline_dates: () => [...timeline.keys()].toSorted().toReversed(),
+    read_timeline_by_date: ({ date }) => timeline.get(date) ?? [],
+    save_quick_capture: ({ text }) => {
+      const now = new Date();
+      const iso = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+      const line = `- [${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}] ${text}`;
+      timeline.set(iso, [...(timeline.get(iso) ?? []), line]);
+    },
+    update_timeline_entry: ({ date, index, text }) => {
+      const lines = timeline.get(date) ?? [];
+      const raw = lines[index] ?? "";
+      const head = raw.match(/^- \[\d{2}:\d{2}:\d{2}\] /)?.[0] ?? "- [00:00:00] ";
+      const tail = raw.includes(" {") ? raw.slice(raw.lastIndexOf(" {")) : "";
+      lines[index] = `${head}${text}${tail}`;
+    },
+    delete_timeline_entry: ({ date, index }) => {
+      const lines = timeline.get(date) ?? [];
+      lines.splice(index, 1);
+    },
+    // 実機のジオコーダは即答しない。名前が後から届く画面を再現する
+    resolve_places: async ({ coordinates }) => {
+      await delay(600);
+      const answers = [];
+      for (const [lat, lon] of coordinates) {
+        const hit = PLACES.find((p) => placeKey(p.lat, p.lon) === placeKey(lat, lon));
+        if (hit) {
+          answers.push([placeKey(lat, lon), hit.name]);
+        }
+      }
+      return answers;
+    },
+    search_all: () => [],
+    list_notes: () => noteList(),
+    read_note: async ({ filename }) => {
+      // ディスク読みの往復ぶん。ノート切替の描画順の検証に効く
+      await delay(30);
+      return notes.get(filename)?.body ?? "";
+    },
+    read_note_meta: async ({ filename }) => {
+      await delay(30);
+      const note = notes.get(filename);
+      if (!note) {
+        throw new Error("note not found");
+      }
+      return { time: note.time, tags: note.tags, ...(note.view ? { view: note.view } : {}) };
+    },
+    update_note_meta: ({ filename, time, tags }) => {
+      const note = notes.get(filename);
+      if (note) {
+        Object.assign(note, { time, tags });
+      }
+    },
+    set_note_view: ({ filename, view }) => {
+      const note = notes.get(filename);
+      if (note) {
+        note.view = view;
+      }
+    },
+    delete_note: ({ filename }) => {
+      notes.delete(filename);
+    },
+    create_draft: ({ body }) => {
+      const now = new Date();
+      const stamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}_${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+      const filename = `${stamp}.md`;
+      notes.set(filename, { time: now.toISOString(), tags: [], view: null, body });
+      return `/mock/data/${filename}`;
+    },
+    update_draft: ({ filePath, body }) => {
+      const filename = filePath.split("/").at(-1);
+      const note = notes.get(filename);
+      if (note) {
+        note.body = body;
+      }
+    },
+    save_document: () => {},
+    sync_start: () => {},
+    sync_status: () => ({}),
+    auth_login: () => {},
+    auth_status: () => true,
+    auth_logout: () => {},
+    get_sync_config: () => ({ workers_url: "https://mock.example", auto_sync: false }),
+    save_sync_config: () => {},
+    is_sync_config_editable: () => true,
+
+    "plugin:event|listen": () => 1,
+    "plugin:event|unlisten": () => null,
+    "plugin:deep-link|get_current": () => null,
+    "plugin:geolocation|check_permissions": () => ({
+      location: "denied",
+      coarseLocation: "denied",
+    }),
+  };
+
+  let callbackId = 0;
+
+  window.__TAURI_INTERNALS__ = {
+    invoke: async (cmd, args) => {
+      const handler = commands[cmd];
+      if (!handler) {
+        throw new Error(`mock: unknown command ${cmd}`);
+      }
+      return handler(args ?? {});
+    },
+    transformCallback: () => {
+      callbackId += 1;
+      return callbackId;
+    },
+    unregisterCallback: () => {},
+    convertFileSrc: (path) => path,
+    metadata: { currentWindow: { label: "main" }, currentWebview: { label: "main" } },
+  };
+})();

--- a/tauri-app/justfile
+++ b/tauri-app/justfile
@@ -20,6 +20,10 @@ test: setup
 dev: setup
   pnpm tauri dev
 
+# Tauri なしのブラウザ検証 (agent-browser 用)。IPC は dev/ipc-mock.js が受ける
+dev-browser: setup
+  pnpm run dev:browser
+
 android-init: setup
   pnpm tauri android init
 

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:browser": "BROWSER_MOCK=1 vite",
     "build": "tsgo -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",

--- a/tauri-app/src/components/Icon.test.tsx
+++ b/tauri-app/src/components/Icon.test.tsx
@@ -26,6 +26,28 @@ describe("Icon", () => {
     expect(svg.getAttribute("height")).toBe("16px");
   });
 
+  it("reserves the icon box before the SVG arrives", () => {
+    // SVG は動的 import で遅れて届く。それまで span が 0px だと、届いた瞬間に
+    // 周りのレイアウトが育って画面全体が揺れる(起動時 CLS の主因だった)
+    const { baseElement } = render(() => <Icon name="caret-left" size={18} />);
+    const span = baseElement.querySelector<HTMLSpanElement>(".icon");
+    if (!span) {
+      throw new Error("expected the icon span to render");
+    }
+    expect(span.style.width).toBe("18px");
+    expect(span.style.height).toBe("18px");
+  });
+
+  it("reserves the default 24px box when no size is given", () => {
+    const { baseElement } = render(() => <Icon name="caret-right" />);
+    const span = baseElement.querySelector<HTMLSpanElement>(".icon");
+    if (!span) {
+      throw new Error("expected the icon span to render");
+    }
+    expect(span.style.width).toBe("24px");
+    expect(span.style.height).toBe("24px");
+  });
+
   it("renders correctly on second render with the same icon name", async () => {
     const { baseElement: first } = render(() => <Icon name="sun" />);
     const screen1 = page.elementLocator(first);

--- a/tauri-app/src/components/Icon.tsx
+++ b/tauri-app/src/components/Icon.tsx
@@ -101,6 +101,18 @@ export default function Icon(props: IconProps): JSX.Element {
   });
 
   return (
-    <span ref={ref} class="icon" style={{ display: "inline-flex", "line-height": 0 }} {...rest} />
+    <span
+      ref={ref}
+      class="icon"
+      // SVG が動的 import で届く前から枠を予約しておく。空の span を 0px の
+      // ままにすると、届いた瞬間にヘッダやタブバーが育って画面全体が揺れる
+      style={{
+        display: "inline-flex",
+        "line-height": 0,
+        width: `${local.size ?? 24}px`,
+        height: `${local.size ?? 24}px`,
+      }}
+      {...rest}
+    />
   );
 }

--- a/tauri-app/src/lib/note-view.test.ts
+++ b/tauri-app/src/lib/note-view.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveNoteView, toggledView, viewToFrontmatter } from "./note-view";
+import { readNoteContent, resolveNoteView, toggledView, viewToFrontmatter } from "./note-view";
 
 describe("resolveNoteView", () => {
   it("view キーが無いノートはエディタ表示", () => {
@@ -19,6 +19,33 @@ describe("toggledView", () => {
   it("エディタ ⇄ マインドマップを往復する", () => {
     expect(toggledView("editor")).toBe("mindmap");
     expect(toggledView("mindmap")).toBe("editor");
+  });
+});
+
+describe("readNoteContent", () => {
+  it("本文と表示モードを一度に返す(別々に届くと一瞬違うモードで描かれる)", async () => {
+    const content = await readNoteContent(
+      () => Promise.resolve("# 見取り図"),
+      () => Promise.resolve({ view: "mindmap" }),
+    );
+    expect(content).toEqual({ body: "# 見取り図", view: "mindmap" });
+  });
+
+  it("メタが読めないノートはエディタ表示で開く", async () => {
+    const content = await readNoteContent(
+      () => Promise.resolve("body"),
+      () => Promise.reject(new Error("broken frontmatter")),
+    );
+    expect(content).toEqual({ body: "body", view: "editor" });
+  });
+
+  it("本文が読めなければ失敗はそのまま伝える", async () => {
+    await expect(
+      readNoteContent(
+        () => Promise.reject(new Error("missing note")),
+        () => Promise.resolve({}),
+      ),
+    ).rejects.toThrow("missing note");
   });
 });
 

--- a/tauri-app/src/lib/note-view.ts
+++ b/tauri-app/src/lib/note-view.ts
@@ -21,3 +21,28 @@ export function toggledView(view: NoteView): NoteView {
 export function viewToFrontmatter(view: NoteView): string | null {
   return view === "mindmap" ? "mindmap" : null;
 }
+
+export interface NoteContent {
+  body: string;
+  view: NoteView;
+}
+
+/**
+ * 本文と表示モードを対で読む。別々に画面へ流すと、先に届いた本文が一瞬
+ * 違うモードで描かれる(マインドマップのノートが Markdown で光ってから
+ * 差し替わる)。メタの読み損ねは既定のエディタ表示に倒すが、本文の
+ * 読み損ねはごまかさない — 空のノートに見せるほうが害が大きい。
+ */
+export async function readNoteContent(
+  readBody: () => Promise<string>,
+  readMeta: () => Promise<{ view?: string }>,
+): Promise<NoteContent> {
+  const [body, view] = await Promise.all([
+    readBody(),
+    readMeta().then(
+      (meta) => resolveNoteView(meta.view),
+      () => "editor" as const,
+    ),
+  ]);
+  return { body, view };
+}

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -4,6 +4,7 @@ import {
   createMemo,
   createEffect,
   on,
+  batch,
   For,
   Show,
   lazy,
@@ -20,7 +21,7 @@ import { getDeviceSignals } from "../lib/client-context";
 import { useShell } from "../lib/shell";
 import { groupNotes, itemTitle, noteCreatedLabel, toNoteItems } from "../lib/items";
 import type { ItemGroup, NoteItem } from "../lib/items";
-import { resolveNoteView, toggledView, viewToFrontmatter } from "../lib/note-view";
+import { readNoteContent, toggledView, viewToFrontmatter } from "../lib/note-view";
 import type { NoteView } from "../lib/note-view";
 
 // Milkdown + ProseMirror は編集を始めるまで要らない。一覧とプレビューだけの
@@ -109,15 +110,29 @@ export default function Workspace(): JSX.Element {
       return;
     }
     void (async () => {
-      setNoteBody(await typedInvoke("read_note", { filename: item.filename }));
-    })();
-    void (async () => {
       try {
-        const meta = await typedInvoke("read_note_meta", { filename: item.filename });
-        setNoteView(resolveNoteView(meta.view));
+        const content = await readNoteContent(
+          () => typedInvoke("read_note", { filename: item.filename }),
+          () => typedInvoke("read_note_meta", { filename: item.filename }),
+        );
+        // 一覧を素早くたどると、遅い読みが速い読みを追い越して届く。
+        // いま選ばれているノートへの答えだけを画面に出す
+        if (selected()?.id !== item.id) {
+          return;
+        }
+        // 本文とモードは対で出す。バラすと一瞬だけ違うモードで描かれる
+        batch(() => {
+          setNoteBody(content.body);
+          setNoteView(content.view);
+        });
       } catch {
-        // frontmatter が読めないノートは既定のエディタ表示で開く
-        setNoteView("editor");
+        // 読めないノートを選んだまま、前のノートの本文を出し続けない
+        if (selected()?.id === item.id) {
+          batch(() => {
+            setNoteBody("");
+            setNoteView("editor");
+          });
+        }
       }
     })();
   });

--- a/tauri-app/vite.config.ts
+++ b/tauri-app/vite.config.ts
@@ -1,10 +1,37 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "vite";
 import solid from "vite-plugin-solid";
+import type { PluginOption } from "vite";
 
 const host = process.env.TAURI_DEV_HOST;
 
+/**
+ * `BROWSER_MOCK=1` の dev サーバーだけ、Tauri IPC のモックを index.html の
+ * 先頭にインライン注入する。agent-browser など普通のブラウザで UI を検証する
+ * ための入り口で、ビルド成果物には何も足さない。
+ */
+function browserMock(): PluginOption {
+  if (!process.env.BROWSER_MOCK) {
+    return false;
+  }
+  return {
+    name: "browser-ipc-mock",
+    apply: "serve",
+    transformIndexHtml: {
+      order: "pre",
+      handler: () => [
+        {
+          tag: "script",
+          children: readFileSync(new URL("dev/ipc-mock.js", import.meta.url), "utf8"),
+          injectTo: "head-prepend",
+        },
+      ],
+    },
+  };
+}
+
 export default defineConfig(async () => ({
-  plugins: [solid()],
+  plugins: [solid(), browserMock()],
 
   clearScreen: false,
   server: {


### PR DESCRIPTION
## なぜやるか

大規模改修が続いたので、画面の揺れ(レイアウトシフト)と性能の退行を疑って計測した。agent-browser + layout-shift observer で実測したところ、起動時 CLS が **0.258**(モバイル相当 390×844、"poor" 領域)あり、原因はアイコン SVG が動的 import で遅れて届いた瞬間にヘッダとタブバーが 0px から育つことだった。また、ノート切替時に `read_note` と `read_note_meta` が別々の IPC で競走しており、マインドマップのノートが一瞬 Markdown で描かれてから差し替わるフラッシュを確認した。

打鍵レイテンシ(24〜32ms/キー、long task なし)・起動 FCP(本番 68ms)・バンドル合計(改修前比 +1%)には退行がなく、修正はこの 2 点に絞った。

## やったこと

- `Icon` の span に `size` 分の width/height を最初から予約し、SVG 到着時の成長をなくした(本番ビルド実測で CLS 0.2582 → **0.0000**)
- `readNoteContent` で本文と表示モードを対で読み、`batch` で一度に反映。選択が変わった後に届いた遅い応答は捨てる(速い読みへの上書き防止)
- 検証に使った Tauri IPC モックを恒久的なブラウザ検証ハーネスとして整備(`BROWSER_MOCK=1` の dev サーバーだけに注入、本番ビルドには一切入らない。`just tauri_app::dev-browser` で起動し agent-browser で叩ける)

## やらなかったこと

- mermaid の図⇄ソース切替や場所名の座標→地名差し替えの揺れ: 意図された UX で、実測でも軽微(操作起因 0.027)なので触っていない
- タイムラインの仮想化・`dataVersion` 全再取得の見直し: 83 エントリで DOM 1,606 ノード、実測で問題が出ていないため
- Android 実機/エミュレータでの確認: 環境になし。モバイルはビューポート 390×844 の Chrome で代替(修正は純フロントエンド)

## 資料

- 計測方法: buffered `PerformanceObserver({type:'layout-shift'})` / event timing / 本番 dist をモック注入で配信して前後比較
