### PR TITLE
fix(preview):
  show Milkdown's preserved empty lines as blank, not <br />

### DIFF
--- a/tauri-app/src/lib/items.test.ts
+++ b/tauri-app/src/lib/items.test.ts
@@ -66,6 +66,16 @@ describe("toNoteItems", () => {
     expect(toNoteItems([note({ preview: "   " })])[0].title).toBe("(空のメモ)");
   });
 
+  it("空行として保存された <br /> 行はタイトルに拾わない", () => {
+    // 本文の先頭で Enter を押したノートは <br /> 行から始まる。
+    // それをタイトルにすると一覧に「<br />」と並ぶ
+    expect(toNoteItems([note({ preview: "<br />\n見出し" })])[0].title).toBe("見出し");
+  });
+
+  it("空行 (<br />) しかないノートは空のメモ扱い", () => {
+    expect(toNoteItems([note({ preview: "<br />\n<br>" })])[0].title).toBe("(空のメモ)");
+  });
+
   it("splits the timestamp into a date and a time", () => {
     const [item] = toNoteItems([note()]);
     expect(item.date).toBe("2026-08-04");

--- a/tauri-app/src/lib/items.ts
+++ b/tauri-app/src/lib/items.ts
@@ -1,6 +1,7 @@
 import type { Note } from "./commands";
 import { formatNoteGroupLabel } from "./day-labels";
 import { parseTimelineEntry } from "./parse-timeline";
+import { isPreservedEmptyLine } from "./preserved-empty-line";
 import type { DeviceContext } from "./parse-timeline";
 
 export interface TimelineItem {
@@ -36,7 +37,8 @@ export interface ItemGroup {
 const UNTITLED = "(空のメモ)";
 
 function firstLine(text: string): string {
-  const line = text.split("\n").find((l) => l.trim().length > 0);
+  // Milkdown は空行を <br /> 行として保存する。タイトルはそれも読み飛ばす
+  const line = text.split("\n").find((l) => l.trim().length > 0 && !isPreservedEmptyLine(l));
   return line?.replace(/^#+\s*/, "").trim() ?? "";
 }
 

--- a/tauri-app/src/lib/markdown.test.ts
+++ b/tauri-app/src/lib/markdown.test.ts
@@ -46,6 +46,35 @@ describe("renderMarkdownSync", () => {
   });
 });
 
+describe("Milkdown の空行 (<br /> 行)", () => {
+  it("単独行の <br /> は文字ではなく空の段落として描く", () => {
+    const html = renderMarkdownSync("一段落目\n\n<br />\n\n二段落目");
+    expect(html).not.toContain("&lt;br");
+    // 空行は 1 行ぶんの高さを持つ空の段落になる
+    expect(html).toContain("<p>\u00A0</p>");
+  });
+
+  it("文中の <br> はこれまでどおりエスケープした文字のまま", () => {
+    const html = renderMarkdownSync("前 <br> 後");
+    expect(html).toContain("&lt;br&gt;");
+  });
+
+  it("コードフェンスの中の <br /> はコードのまま", async () => {
+    const source = ["```html", "<br />", "```"].join("\n");
+    const html = await renderMarkdown(source);
+    // Shiki は < を &#x3C; にエスケープする。コードとして残っていればよい
+    expect(html).toMatch(/&(?:lt|#x3C);/);
+    expect(html).not.toContain("<p>\u00A0</p>");
+  });
+
+  it("フェンス差し込みつきの描画でも空行になる", async () => {
+    const source = ["```ts", "const a = 1;", "```", "", "<br />", "", "本文"].join("\n");
+    const html = await renderMarkdown(source);
+    expect(html).not.toContain("&lt;br");
+    expect(html).toContain("<p>\u00A0</p>");
+  });
+});
+
 describe("renderMarkdown", () => {
   it("highlights every code block", async () => {
     const source = ["```ts", "const a = 1;", "```", "", "```rust", "let b = 2;", "```"].join("\n");

--- a/tauri-app/src/lib/markdown.ts
+++ b/tauri-app/src/lib/markdown.ts
@@ -1,7 +1,26 @@
 import MarkdownIt from "markdown-it";
 import { getHighlighter } from "./highlighter";
 import { renderDiagrams } from "./mermaid";
+import { isPreservedEmptyLine } from "./preserved-empty-line";
 import { tagPlugin } from "./tag-markdown";
+
+/**
+ * Milkdown が空行の保存に使う `<br />` 行を、1 行ぶんの高さを持つ空の段落に
+ * 変える。html: false のままだと文字どおり `<br />` と表示されてしまう。
+ * トークン列で見るのは、コードフェンスの中の同じ文字列を巻き込まないため。
+ */
+function preservedEmptyLinePlugin(markdownIt: MarkdownIt): void {
+  markdownIt.core.ruler.push("preserved_empty_line", (state) => {
+    for (const token of state.tokens) {
+      if (token.type === "inline" && isPreservedEmptyLine(token.content)) {
+        const space = new state.Token("text", "", 0);
+        // 普通の空白だと行ボックスが立たず、段落が高さ 0 に潰れるので nbsp
+        space.content = " ";
+        token.children = [space];
+      }
+    }
+  });
+}
 
 const md = new MarkdownIt({
   html: false,
@@ -10,6 +29,7 @@ const md = new MarkdownIt({
 });
 
 md.use(tagPlugin);
+md.use(preservedEmptyLinePlugin);
 
 export function renderMarkdownSync(source: string): string {
   return md.render(source);
@@ -31,6 +51,7 @@ const fenceMd = new MarkdownIt({
 });
 
 fenceMd.use(tagPlugin);
+fenceMd.use(preservedEmptyLinePlugin);
 
 /**
  * フェンスの描画結果を差し込む目印。markdown-it は CommonMark どおり入力中の U+0000 を

--- a/tauri-app/src/lib/preserved-empty-line.test.ts
+++ b/tauri-app/src/lib/preserved-empty-line.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { isPreservedEmptyLine } from "./preserved-empty-line";
+
+describe("isPreservedEmptyLine", () => {
+  it("空行の保存に使われる <br /> 行を空行と判定する", () => {
+    expect(isPreservedEmptyLine("<br />")).toBe(true);
+  });
+
+  it("揺れ(<br> <br/> <br > と前後の空白・大文字)も空行と判定する", () => {
+    expect(isPreservedEmptyLine("<br>")).toBe(true);
+    expect(isPreservedEmptyLine("<br/>")).toBe(true);
+    expect(isPreservedEmptyLine("<br >")).toBe(true);
+    expect(isPreservedEmptyLine("  <br />  ")).toBe(true);
+    expect(isPreservedEmptyLine("<BR />")).toBe(true);
+  });
+
+  it("本文の一部である行は空行にしない", () => {
+    expect(isPreservedEmptyLine("前 <br /> 後")).toBe(false);
+    expect(isPreservedEmptyLine("<brand>")).toBe(false);
+    expect(isPreservedEmptyLine("")).toBe(false);
+  });
+});

--- a/tauri-app/src/lib/preserved-empty-line.ts
+++ b/tauri-app/src/lib/preserved-empty-line.ts
@@ -1,0 +1,11 @@
+/**
+ * Milkdown は空の段落(見た目の空行)を `<br />` という HTML 行として
+ * Markdown に保存し、読み戻すときに空行へ復元する(remark-preserve-empty-line)。
+ * エディタの外 — プレビューや一覧のタイトル — がこの行を文字どおり
+ * `<br />` と見せないよう、判定を一箇所に寄せる。
+ *
+ * 揺れ(`<br>` `<br/>` `<br >`)も Milkdown の認識と同じく空行として扱う。
+ */
+export function isPreservedEmptyLine(line: string): boolean {
+  return /^<br[ \t]*\/?[ \t]*>$/i.test(line.trim());
+}


### PR DESCRIPTION
## なぜやるか

エディタでは見えないのに、閲覧(プレビュー)では `<br />` という文字が表示されるバグの修正。

Milkdown は空の段落(見た目の空行)を `<br />` という HTML 行として .md に保存し、読み戻すときに空行へ復元する(remark-preserve-empty-line)。一方プレビューの markdown-it は安全のため `html: false` で動かしており、この行がエスケープされて文字どおり表示されていた。本文が空行で始まるノートは、一覧のタイトルまで `<br />` になる。

## やったこと

- Milkdown が認識する 4 表記(`<br />` `<br>` `<br/>` `<br >`)の判定を `isPreservedEmptyLine()` に一箇所化
- プレビュー: markdown-it のトークン列で、単独行の `<br />` 段落を nbsp 入りの空段落(1 行ぶんの高さ)に変換。トークン列で見るのでコードフェンス内の同じ文字列は巻き込まない
- 一覧タイトル: 先頭の `<br />` 行を読み飛ばす
- ハーネス(agent-browser)で e2e 再現 → 修正後は空行として描画されることを確認

## やらなかったこと

- Milkdown 側で `<br />` を書かせない変更: 空行の保存は意図された機能で、外すと既存ノートの `<br />` がエディタに文字として現れ、開き直すたびに空行が消える。ファイル形式は変えず表示層で解釈する
- 文中(行の一部)の `<br>` の解釈: HTML 無効の方針どおりエスケープ表示のまま
- 検索スニペット(コマンドパレット)への同処理: 出現頻度が低く、必要になったら `isPreservedEmptyLine` を差すだけ
