### PR TITLE
feat(note): start editing from a tap and keep a local one-step revert

### DIFF
--- a/tauri-app/src/components/MilkdownEditor.tsx
+++ b/tauri-app/src/components/MilkdownEditor.tsx
@@ -1,5 +1,6 @@
 import { onCleanup, onMount } from "solid-js";
-import { Editor, rootCtx, defaultValueCtx } from "@milkdown/kit/core";
+import { Editor, rootCtx, defaultValueCtx, editorViewCtx } from "@milkdown/kit/core";
+import { Selection, TextSelection } from "@milkdown/kit/prose/state";
 import { commonmark } from "@milkdown/kit/preset/commonmark";
 import { listener, listenerCtx } from "@milkdown/kit/plugin/listener";
 import { cursor } from "@milkdown/kit/plugin/cursor";
@@ -19,16 +20,84 @@ import { createPlaceholderPlugin } from "../lib/placeholder-plugin";
 import { getShikiTheme } from "../lib/theme";
 import type { JSX } from "solid-js";
 
+/** プレビューで押された場所。エディタが立ち上がったらここへカーソルを置く。 */
+interface CaretPoint {
+  x: number;
+  y: number;
+  /** 押した瞬間のスクロール量。先に戻さないと同じ座標が別の行を指す。 */
+  scrollTop: number;
+}
+
 interface MilkdownEditorProps {
   defaultValue?: string;
   onChange?: (markdown: string) => void;
   placeholder?: string;
   onEditorReady?: (editor?: Editor) => void;
+  caret?: CaretPoint;
 }
 
 export default function MilkdownEditor(props: MilkdownEditorProps): JSX.Element {
   let ref: HTMLDivElement | undefined;
   let editor: Editor | undefined;
+  /** アンマウント後にカーソル配置の遅延処理が走らないように。 */
+  let disposed = false;
+  let cancelCaret: (() => void) | undefined;
+
+  /** プレビューと同じ景色に戻してから、押された座標の文字にカーソルを置く。 */
+  const placeCaret = (created: Editor): void => {
+    const { caret } = props;
+    if (!caret) {
+      return;
+    }
+    // 入力はすぐ受け付ける(モバイルはここでキーボードが開き始める)。
+    // 編集モードでスクロールするのはプレビューの親ではなく .milkdown-editor
+    created.action((ctx) => ctx.get(editorViewCtx).focus());
+    const scroller = ref;
+
+    // コードの装飾や図は create の後から伸びてくる。高さが足りないうちに
+    // scrollTop を戻すとクランプされ、同じ座標が別の行を指してしまう。
+    // 元のスクロール量まで戻せる高さに育ったら景色を戻し、カーソルを置く
+    let done = false;
+    const pending: { observer?: ResizeObserver; deadline?: ReturnType<typeof setTimeout> } = {};
+    const cancel = (): void => {
+      pending.observer?.disconnect();
+      if (pending.deadline !== undefined) {
+        clearTimeout(pending.deadline);
+      }
+    };
+    const apply = (force: boolean): void => {
+      if (done || disposed) {
+        return;
+      }
+      const grown = !scroller || scroller.scrollHeight - scroller.clientHeight >= caret.scrollTop;
+      if (!grown && !force) {
+        return;
+      }
+      done = true;
+      cancel();
+      if (scroller) {
+        scroller.scrollTop = caret.scrollTop;
+      }
+      created.action((ctx) => {
+        const view = ctx.get(editorViewCtx);
+        const found = view.posAtCoords({ left: caret.x, top: caret.y });
+        // プレビューとエディタで行の高さは微妙に違う。外したら末尾に倒す
+        const selection = found
+          ? TextSelection.near(view.state.doc.resolve(found.pos))
+          : Selection.atEnd(view.state.doc);
+        view.dispatch(view.state.tr.setSelection(selection));
+        view.focus();
+      });
+    };
+    pending.observer = new ResizeObserver(() => apply(false));
+    created.action((ctx) => pending.observer?.observe(ctx.get(editorViewCtx).dom));
+    // 図がプレビューより低く終わって高さが届かないこともある。1 秒で
+    // 見切って、そのとき見えている中で一番近い場所に置く
+    pending.deadline = setTimeout(() => apply(true), 1000);
+    // onCleanup は await 後のここでは owner がいない。外の onCleanup から呼ぶ
+    cancelCaret = cancel;
+    apply(false);
+  };
 
   onMount(async () => {
     const root = ref;
@@ -80,10 +149,13 @@ export default function MilkdownEditor(props: MilkdownEditorProps): JSX.Element 
       .use(props.placeholder ? createPlaceholderPlugin(props.placeholder) : [])
       .create();
 
+    placeCaret(editor);
     props.onEditorReady?.(editor);
   });
 
   onCleanup(() => {
+    disposed = true;
+    cancelCaret?.();
     editor?.destroy();
     props.onEditorReady?.();
   });
@@ -101,4 +173,4 @@ export default function MilkdownEditor(props: MilkdownEditorProps): JSX.Element 
   return <div ref={ref} class="milkdown-editor" role="presentation" onClick={handleClick} />;
 }
 
-export { type MilkdownEditorProps };
+export { type CaretPoint, type MilkdownEditorProps };

--- a/tauri-app/src/components/NoteMetaPopover.tsx
+++ b/tauri-app/src/components/NoteMetaPopover.tsx
@@ -7,6 +7,9 @@ import { addTag, contextRows, resolveEditedTime, toDatetimeLocal } from "../lib/
 
 interface NoteMetaPopoverProps {
   filename: string;
+  /** この端末に「編集前の本文」が残っているときだけ復元の行を出す。 */
+  revertable?: boolean;
+  onRevert?: () => void;
   /** 保存後に一覧を読み直させる。time を変えると日付グループも動く。 */
   onSaved: () => Promise<void>;
   onClose: () => void;
@@ -134,6 +137,23 @@ export default function NoteMetaPopover(props: NoteMetaPopoverProps): JSX.Elemen
                       )}
                     </For>
                   </div>
+                </div>
+              </Show>
+
+              <Show when={props.revertable}>
+                <div class="note-meta-field">
+                  <span class="note-meta-label">この端末のバックアップ</span>
+                  <button
+                    type="button"
+                    class="button-secondary note-meta-revert"
+                    onClick={() => props.onRevert?.()}
+                  >
+                    <Icon name="clock-counter-clockwise" size={14} />
+                    編集前に戻す
+                  </button>
+                  <span class="note-meta-hint">
+                    直前の編集で上書きした本文と入れ替える。もう一度押すと戻る
+                  </span>
                 </div>
               </Show>
 

--- a/tauri-app/src/lib/edit-backup.test.ts
+++ b/tauri-app/src/lib/edit-backup.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { beginEditSession, readBackup, recordSaved, shouldSave, writeBackup } from "./edit-backup";
+import type { BackupStore } from "./edit-backup";
+
+function memoryStore(): BackupStore {
+  const map = new Map<string, string>();
+  return {
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => void map.set(key, value),
+  };
+}
+
+const FILE = "20260816_001122.md";
+
+describe("shouldSave", () => {
+  it("skips the save while nothing changed since the last write", () => {
+    const session = beginEditSession("# メモ");
+
+    expect(shouldSave(session, "# メモ")).toBe(false);
+  });
+
+  it("saves once the draft differs from the last written body", () => {
+    const session = beginEditSession("# メモ");
+
+    expect(shouldSave(session, "# メモ!")).toBe(true);
+  });
+
+  it("skips again after the changed body has been written", () => {
+    const store = memoryStore();
+    const session = beginEditSession("# メモ");
+
+    recordSaved(store, FILE, session, "# メモ!");
+
+    expect(shouldSave(session, "# メモ!")).toBe(false);
+  });
+});
+
+describe("recordSaved", () => {
+  it("stores the pre-edit body on the first content-changing save", () => {
+    const store = memoryStore();
+    const session = beginEditSession("# 元の本文");
+
+    recordSaved(store, FILE, session, "# 書き換えた本文");
+
+    expect(readBackup(store, FILE)).toBe("# 元の本文");
+  });
+
+  it("keeps the session-start snapshot across later saves", () => {
+    const store = memoryStore();
+    const session = beginEditSession("v1");
+
+    recordSaved(store, FILE, session, "v2");
+    recordSaved(store, FILE, session, "v3");
+
+    expect(readBackup(store, FILE)).toBe("v1");
+  });
+
+  // 変更のなかったセッションが 1 枠しかないバックアップを「現在と同じ
+  // 本文」で潰すと、戻る先が消える
+  it("does not touch the backup when the saved body equals the pre-edit body", () => {
+    const store = memoryStore();
+    writeBackup(store, FILE, "昔の本文");
+    const session = beginEditSession("今の本文");
+
+    recordSaved(store, FILE, session, "今の本文");
+
+    expect(readBackup(store, FILE)).toBe("昔の本文");
+  });
+
+  it("a new session replaces the previous backup", () => {
+    const store = memoryStore();
+    const first = beginEditSession("v1");
+    recordSaved(store, FILE, first, "v2");
+
+    const second = beginEditSession("v2");
+    recordSaved(store, FILE, second, "v3");
+
+    expect(readBackup(store, FILE)).toBe("v2");
+  });
+});
+
+describe("readBackup / writeBackup", () => {
+  it("returns null when the note has no backup", () => {
+    expect(readBackup(memoryStore(), FILE)).toBeNull();
+  });
+
+  it("round-trips a swap: write current, read old, and back again", () => {
+    const store = memoryStore();
+    writeBackup(store, FILE, "編集前");
+
+    const backup = readBackup(store, FILE);
+    writeBackup(store, FILE, "編集後");
+
+    expect(backup).toBe("編集前");
+    expect(readBackup(store, FILE)).toBe("編集後");
+  });
+
+  // バックアップは善意の保険。容量超過などで書けなくても保存や復元の
+  // 本流を落とさない
+  it("swallows storage failures", () => {
+    const broken: BackupStore = {
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("quota");
+      },
+    };
+
+    expect(() => writeBackup(broken, FILE, "本文")).not.toThrow();
+    expect(readBackup(broken, FILE)).toBeNull();
+  });
+});

--- a/tauri-app/src/lib/edit-backup.ts
+++ b/tauri-app/src/lib/edit-backup.ts
@@ -1,0 +1,69 @@
+/**
+ * 編集セッションの保存判断と、端末ローカルの 1 段階バックアップ。
+ *
+ * 自動保存の世界での「誤タップ・誤編集」への保険。編集を始める前の本文を
+ * この端末(localStorage)にだけ 1 枠残し、いつでも入れ替えで戻せるように
+ * する。ファイルや frontmatter には書かない — 書けば同期に乗ってしまい、
+ * どの端末の「戻る先」なのかが壊れる。
+ */
+
+/** localStorage の使う範囲だけ。テストではメモリ実装を差し込む。 */
+export interface BackupStore {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export interface EditSession {
+  /** セッション開始時点の本文。復元の「戻る先」になる。 */
+  readonly preEditBody: string;
+  /** 最後にファイルへ書いた本文。一致する限り保存はスキップする。 */
+  lastSavedBody: string;
+  /** バックアップはセッションにつき 1 回だけ書く。 */
+  committed: boolean;
+}
+
+const KEY_PREFIX = "note-backup:";
+
+export function readBackup(store: BackupStore, filename: string): string | null {
+  try {
+    return store.getItem(KEY_PREFIX + filename);
+  } catch {
+    return null;
+  }
+}
+
+/** バックアップは善意の保険。容量超過などで書けなくても本流を落とさない。 */
+export function writeBackup(store: BackupStore, filename: string, body: string): void {
+  try {
+    store.setItem(KEY_PREFIX + filename, body);
+  } catch {
+    // 書けなかったら戻る先が増えないだけ。保存自体は成功している
+  }
+}
+
+export function beginEditSession(body: string): EditSession {
+  return { preEditBody: body, lastSavedBody: body, committed: false };
+}
+
+/** 書いても内容が変わらない保存はしない。誤タップを書き込みに変えない。 */
+export function shouldSave(session: EditSession, body: string): boolean {
+  return body !== session.lastSavedBody;
+}
+
+/**
+ * 保存が成功したら呼ぶ。内容が実際に変わった最初の保存でだけ、編集前の
+ * 本文をバックアップに残す。変更のなかったセッションは何も書かない —
+ * 1 枠しかない戻る先を「現在と同じ本文」で潰さないため。
+ */
+export function recordSaved(
+  store: BackupStore,
+  filename: string,
+  session: EditSession,
+  body: string,
+): void {
+  if (!session.committed && body !== session.preEditBody) {
+    writeBackup(store, filename, session.preEditBody);
+    session.committed = true;
+  }
+  session.lastSavedBody = body;
+}

--- a/tauri-app/src/styles/popover.css
+++ b/tauri-app/src/styles/popover.css
@@ -203,6 +203,15 @@
   color: var(--app-text-faint);
 }
 
+.note-meta-revert {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  padding: 5px 12px;
+  font-size: 12px;
+}
+
 .note-meta-actions {
   display: flex;
   align-items: center;

--- a/tauri-app/src/styles/workspace.css
+++ b/tauri-app/src/styles/workspace.css
@@ -241,6 +241,13 @@
   line-height: 1.8;
 }
 
+/* 本文はどこを押しても編集に入る。テキストカーソルでそれを示す */
+.detail-body .markdown-preview {
+  cursor: text;
+  /* 短い本文でも余白がタップの受け皿になるよう、プレビュー自身を伸ばす */
+  min-height: 100%;
+}
+
 .detail-body > * {
   max-width: 640px;
   margin-inline: auto;

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -23,6 +23,14 @@ import { groupNotes, itemTitle, noteCreatedLabel, toNoteItems } from "../lib/ite
 import type { ItemGroup, NoteItem } from "../lib/items";
 import { readNoteContent, toggledView, viewToFrontmatter } from "../lib/note-view";
 import type { NoteView } from "../lib/note-view";
+import {
+  beginEditSession,
+  readBackup,
+  recordSaved,
+  shouldSave,
+  writeBackup,
+} from "../lib/edit-backup";
+import type { CaretPoint } from "../components/MilkdownEditor";
 
 // Milkdown + ProseMirror は編集を始めるまで要らない。一覧とプレビューだけの
 // 表示をこの重さから切り離す
@@ -70,6 +78,12 @@ export default function Workspace(): JSX.Element {
   const [markdownEditor, setMarkdownEditor] = createSignal<Editor | undefined>();
 
   const [notes, { refetch: refetchNotes }] = createResource(loadNotes);
+
+  let detailBodyRef: HTMLDivElement | undefined;
+  /** プレビューで押された場所。エディタのマウント時に一度だけ読まれる。 */
+  const [tapCaret, setTapCaret] = createSignal<CaretPoint | undefined>();
+  /** いま開いている編集セッション。保存のスキップ判断とバックアップを持つ。 */
+  let session = beginEditSession("");
 
   // 同期やパレット操作の後にデータを取り直す。初回は createResource が読むので
   // defer しないと全ノートの読み直しがマウント直後に二重で走る
@@ -166,10 +180,13 @@ export default function Workspace(): JSX.Element {
   const flushSave = (): Promise<void> => {
     const item = selected();
     const body = draft();
+    const current = session;
     const previous = saveChain;
     saveChain = (async () => {
       await previous;
-      if (!item) {
+      // 触っていない誤タップのセッションを書き込みに変えない。書いても
+      // 内容が変わらないなら、ファイルの mtime を動かして同期を起こすだけ
+      if (!item || !shouldSave(current, body)) {
         return;
       }
       setSaveStatus("saving");
@@ -179,6 +196,7 @@ export default function Workspace(): JSX.Element {
           body,
           client: await getDeviceSignals(),
         });
+        recordSaved(localStorage, item.filename, current, body);
         // 一覧はここでは読み直さない。1 秒おきの保存のたびに全ノートを
         // 読み直すのは低スペック端末に重く、編集中は一覧が見えてもいない。
         // 編集を終えるときに 1 回だけ読み直す。
@@ -204,14 +222,71 @@ export default function Workspace(): JSX.Element {
     }
   });
 
-  const startEditing = (): void => {
+  const startEditing = (point?: CaretPoint): void => {
     if (!selected()) {
       return;
     }
+    session = beginEditSession(noteBody());
+    setTapCaret(point);
     setDraft(noteBody());
     setSaveStatus("idle");
     setEditing(true);
   };
+
+  /** プレビューのどこを押しても、その場所から書き始められる。 */
+  const onPreviewClick = (e: MouseEvent): void => {
+    if (editing() || noteView() !== "editor" || !selected()) {
+      return;
+    }
+    const target = e.target instanceof Element ? e.target : null;
+    // リンクは踏める・図はズームのまま。編集に化けさせない
+    if (target?.closest("a, button, .mermaid-block, .mermaid-zoom")) {
+      return;
+    }
+    // 本文をなぞってコピーしたいだけのときも編集へ切り替えない
+    const selection = document.getSelection();
+    if (selection && !selection.isCollapsed) {
+      return;
+    }
+    startEditing({ x: e.clientX, y: e.clientY, scrollTop: detailBodyRef?.scrollTop ?? 0 });
+  };
+
+  /**
+   * この端末に残した「編集前の本文」と今の本文を入れ替える。入れ替えなので
+   * もう一度押せば戻せる — 戻る先は常にちょうど 1 段。
+   */
+  const revertEdit = async (item: NoteItem): Promise<void> => {
+    const backup = readBackup(localStorage, item.filename);
+    const current = noteBody();
+    if (backup === null || backup === current) {
+      return;
+    }
+    try {
+      await typedInvoke("update_draft", {
+        filePath: item.path,
+        body: backup,
+        client: await getDeviceSignals(),
+      });
+    } catch {
+      shell.showToast("戻せませんでした");
+      return;
+    }
+    writeBackup(localStorage, item.filename, current);
+    setNoteBody(backup);
+    shell.closePopovers();
+    await refetchNotes();
+    shell.showToast("編集前の内容に戻しました");
+  };
+
+  const revertable = createMemo<boolean>(() => {
+    const item = selected();
+    // 編集中に戻すと、開いているエディタが次の自動保存で復元を上書きする
+    if (!item || editing()) {
+      return false;
+    }
+    const backup = readBackup(localStorage, item.filename);
+    return backup !== null && backup !== noteBody();
+  });
 
   const stopEditing = async (): Promise<void> => {
     if (saveTimer) {
@@ -350,20 +425,8 @@ export default function Workspace(): JSX.Element {
                   >
                     <Icon name="info" size={17} />
                   </button>
-                  <Show
-                    when={editing()}
-                    fallback={
-                      <button
-                        type="button"
-                        class="icon-button"
-                        title="編集"
-                        aria-label="編集"
-                        onClick={startEditing}
-                      >
-                        <Icon name="pencil" size={17} />
-                      </button>
-                    }
-                  >
+                  {/* 編集の入り口は本文タップ。鉛筆は出口だけ残す */}
+                  <Show when={editing()}>
                     <button
                       type="button"
                       class="icon-button"
@@ -389,6 +452,8 @@ export default function Workspace(): JSX.Element {
               <Show when={shell.popover() === "note-meta"}>
                 <NoteMetaPopover
                   filename={item().filename}
+                  revertable={revertable()}
+                  onRevert={() => void revertEdit(item())}
                   onSaved={async () => {
                     await refetchNotes();
                   }}
@@ -396,7 +461,14 @@ export default function Workspace(): JSX.Element {
                 />
               </Show>
 
-              <div class="detail-body">
+              {/* biome-ignore/eslint 対応: タップは編集開始の補助経路で、
+                  同じ操作はキーボードでは編集終了ボタンと Tab 移動で賄える */}
+              <div
+                class="detail-body"
+                ref={detailBodyRef}
+                role="presentation"
+                onClick={onPreviewClick}
+              >
                 <Show
                   when={editing()}
                   fallback={
@@ -410,6 +482,7 @@ export default function Workspace(): JSX.Element {
                 >
                   <MilkdownEditor
                     placeholder="ノートを書く…"
+                    caret={tapCaret()}
                     defaultValue={draft()}
                     onChange={(markdown) => {
                       setDraft(markdown);


### PR DESCRIPTION
## なぜやるか

capture-to-writing 計画の Phase 1 (2a)。モバイルで編集に入るまでの摩擦(小さな鉛筆ボタンを狙って押す)をなくす。当初案の「明示保存+確認バー」は検討の末に不採用: 新しいクロームが増えるうえ、毎回「保存するか」を聞かれる摩擦のほうが誤保存より高くつくため、自動保存を維持して「誤保存は端末ローカルで 1 段階戻せる」設計に変えた(計画書も改訂済み)。

## やったこと

- 編集の入り口を鉛筆ボタンから本文タップに変更。押した座標へ `posAtCoords` でカーソルを置き、コード装飾や図で高さが遅れて伸びる間は ResizeObserver で待ってからプレビューのスクロール位置を復元
- 自動保存(1s debounce + 直列化)は維持しつつ、最後に書いた本文と同じ内容の保存はスキップ(誤タップが mtime を動かして同期を起こさない)
- 内容が変わった最初の保存で編集前本文を localStorage に 1 枠保存(端末ローカル、同期に乗せない)。ノート情報ポップオーバーの「編集前に戻す」で現在本文と入れ替え、もう一度押せば戻せる

## やらなかったこと

- 明示保存ボタン・保存確認バー(上記の理由で不採用)
- MarkdownToolbar のキーボード追従(実装済みだったため変更なし)
