### PR TITLE
feat(timeline): promote an entry into a note linked by origin

### DIFF
--- a/core/benches/fixture.rs
+++ b/core/benches/fixture.rs
@@ -116,6 +116,7 @@ fn write_notes(base: &Path, rng: &mut Lcg) {
             tags: vec!["memo".to_string(), rng.pick(SUBJECTS).to_string()],
             context: None,
             view: None,
+            origin: None,
         };
         // preview は先頭 100 文字しか読まれない。本文はそれより十分長くする。
         let mut text = String::new();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,8 +13,9 @@ pub mod search;
 pub use error::CoreError;
 pub use note::error::NoteError;
 pub use note::{
-    NoteSummary, create_draft_note, delete_note, list_notes, read_note, read_note_by_filename,
-    read_note_meta, repair_notes, update_note, update_note_meta, update_note_view,
+    NoteSummary, create_draft_note, create_note_from_entry, delete_note, list_notes, read_note,
+    read_note_by_filename, read_note_meta, repair_notes, update_note, update_note_meta,
+    update_note_view,
 };
 pub use search::{HitKind, SearchHit, search_all};
 pub use timeline::error::TimelineError;

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -19,7 +19,19 @@ pub fn create_draft_note(
     tags: &[String],
     context: &Context,
 ) -> Result<PathBuf, CoreError> {
-    Notes::new(base_dir.to_path_buf()).create(body, tags, context)
+    Notes::new(base_dir.to_path_buf()).create(body, tags, context, None)
+}
+
+/// タイムラインエントリを昇格させてノートを作る。frontmatter の `origin` に
+/// 元エントリの日時を刻む以外は `create_draft_note` と同じ。
+pub fn create_note_from_entry(
+    base_dir: &Path,
+    body: &str,
+    tags: &[String],
+    context: &Context,
+    origin: &str,
+) -> Result<PathBuf, CoreError> {
+    Notes::new(base_dir.to_path_buf()).create(body, tags, context, Some(origin))
 }
 
 pub fn update_note(file_path: &Path, body: &str, context: &Context) -> Result<(), CoreError> {
@@ -100,9 +112,37 @@ mod tests {
     }
 
     #[test]
+    fn test_create_note_from_entry_records_origin() {
+        let tmp = TempDir::new().unwrap();
+        let path = create_note_from_entry(
+            tmp.path(),
+            "エントリ本文 #memo",
+            &["memo".to_string()],
+            &mock_context(),
+            "2026-08-13T08:30:00",
+        )
+        .unwrap();
+
+        let meta = read_note_meta(
+            tmp.path(),
+            &NoteFilename::parse(path.file_name().unwrap().to_str().unwrap()).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(meta.origin, Some("2026-08-13T08:30:00".to_string()));
+
+        // 一覧にも乗る。タイムラインのチップはここから導出される
+        let listed = list_notes(tmp.path()).unwrap();
+        assert_eq!(listed[0].origin, Some("2026-08-13T08:30:00".to_string()));
+    }
+
+    #[test]
     fn test_create_draft_note_returns_path() {
         let tmp = TempDir::new().unwrap();
         let path = create_draft_note(tmp.path(), "draft body", &[], &mock_context()).unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+        // origin はエントリ由来のノートだけの記録。普通の新規ノートに書くと
+        // 全ノートが「どこかのエントリから来た」ことになってしまう
+        assert!(!content.contains("origin"));
         assert!(path.exists());
         let content = fs::read_to_string(&path).unwrap();
         assert!(content.contains("draft body"));

--- a/core/src/note/repository.rs
+++ b/core/src/note/repository.rs
@@ -31,12 +31,13 @@ impl Notes {
         body: &str,
         tags: &[String],
         context: &Context,
+        origin: Option<&str>,
     ) -> Result<PathBuf, CoreError> {
         let now = Local::now();
         let file_path = note_file_path(&self.base_dir, now);
         ensure_dir(&file_path)?;
 
-        let markdown = format_note_markdown(body, tags, now, context)?;
+        let markdown = format_note_markdown(body, tags, now, context, origin)?;
         write_atomic(&file_path, markdown)?;
         Ok(file_path)
     }
@@ -100,6 +101,7 @@ impl Notes {
                 tags: Vec::new(),
                 context: Some(context.clone()),
                 view: None,
+                origin: None,
             },
             |(fm, _)| fm,
         );
@@ -135,6 +137,7 @@ impl Notes {
             tags: tags.to_vec(),
             context: existing.context,
             view: existing.view,
+            origin: existing.origin,
         };
         write_atomic(&path, frontmatter::render(&fm, body)?)?;
         Ok(())

--- a/core/src/note/summary.rs
+++ b/core/src/note/summary.rs
@@ -13,18 +13,21 @@ pub struct Summary {
     pub time: Option<DateTime<FixedOffset>>,
     pub tags: Vec<String>,
     pub preview: String,
+    /// 昇格元エントリの日時。タイムラインが日毎のチップ表示を導出するのに使う。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin: Option<String>,
 }
 
 impl Summary {
     #[must_use]
     pub fn from_file(path: PathBuf, filename: String, content: &str) -> Self {
-        let (time, mut tags, body) =
+        let (time, mut tags, body, origin) =
             if let Ok((fm, body)) = frontmatter::parse::<NoteFrontmatter>(content) {
-                (Some(fm.time), fm.tags, body)
+                (Some(fm.time), fm.tags, body, fm.origin)
             } else {
                 // parse に失敗しても frontmatter の区切りは剥がす。壊れた
                 // メタデータを本文扱いすると、一覧のタイトルとプレビューに YAML が出る。
-                (None, Vec::new(), frontmatter::strip(content))
+                (None, Vec::new(), frontmatter::strip(content), None)
             };
 
         // 本文に書かれた `#タグ` が今の入力方法。frontmatter に残っているのは
@@ -43,6 +46,7 @@ impl Summary {
             time,
             tags,
             preview,
+            origin,
         }
     }
 }
@@ -69,6 +73,7 @@ mod tests {
                 ..Context::default()
             }),
             view: None,
+            origin: None,
         };
         let content = frontmatter::render(&fm, "# Title\nBody").unwrap();
         let summary = Summary::from_file(
@@ -79,6 +84,29 @@ mod tests {
         assert!(summary.time.is_some());
         assert_eq!(summary.tags, vec!["a", "b"]);
         assert!(summary.preview.contains("# Title"));
+    }
+
+    /// origin はタイムラインのチップ表示が使う。一覧に乗らないと、昇格した
+    /// ノートがどの日のものか誰にも分からない。
+    #[test]
+    fn test_from_file_carries_origin() {
+        let fm = NoteFrontmatter {
+            time: FixedOffset::east_opt(9 * 3600)
+                .unwrap()
+                .with_ymd_and_hms(2026, 8, 13, 9, 0, 0)
+                .unwrap(),
+            tags: vec![],
+            context: None,
+            view: None,
+            origin: Some("2026-08-13T08:30:00".to_string()),
+        };
+        let content = frontmatter::render(&fm, "body").unwrap();
+        let summary = Summary::from_file(
+            PathBuf::from("/test/note.md"),
+            "note.md".to_string(),
+            &content,
+        );
+        assert_eq!(summary.origin, Some("2026-08-13T08:30:00".to_string()));
     }
 
     /// frontmatter が YAML として壊れているノート。時刻とタグは諦めるが、

--- a/core/src/utils/frontmatter.rs
+++ b/core/src/utils/frontmatter.rs
@@ -16,6 +16,11 @@ pub struct NoteFrontmatter {
     /// frontmatter に持つ。未指定・未知の値は読む側がエディタ表示に倒す。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub view: Option<String>,
+    /// 昇格元タイムラインエントリの日時(`YYYY-MM-DDTHH:MM:SS`)。エントリから
+    /// 作ったノートだけが持つ出自の記録で、タイムライン側のチップ表示は
+    /// この値から毎回導出する(エントリ側のファイルには何も書かない)。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin: Option<String>,
 }
 
 pub fn render<T: Serialize>(fm: &T, body: &str) -> Result<String, CoreError> {
@@ -73,6 +78,7 @@ mod tests {
                 ..Context::default()
             }),
             view: None,
+            origin: None,
         };
         let rendered = render(&fm, "# Hello\nWorld").unwrap();
         let (parsed, body): (NoteFrontmatter, _) = parse(&rendered).unwrap();
@@ -87,6 +93,7 @@ mod tests {
             tags: vec![],
             context: None,
             view: Some("mindmap".to_string()),
+            origin: None,
         };
         let rendered = render(&fm, "body").unwrap();
         let (parsed, _body): (NoteFrontmatter, _) = parse(&rendered).unwrap();
@@ -102,6 +109,7 @@ mod tests {
             tags: vec![],
             context: None,
             view: None,
+            origin: None,
         };
         let rendered = render(&fm, "body").unwrap();
         assert!(!rendered.contains("view"));
@@ -116,12 +124,50 @@ mod tests {
     }
 
     #[test]
+    fn test_note_frontmatter_origin_roundtrip() {
+        let fm = NoteFrontmatter {
+            time: sample_datetime(),
+            tags: vec![],
+            context: None,
+            view: None,
+            origin: Some("2026-08-13T08:30:00".to_string()),
+        };
+        let rendered = render(&fm, "body").unwrap();
+        let (parsed, _body): (NoteFrontmatter, _) = parse(&rendered).unwrap();
+        assert_eq!(parsed.origin, Some("2026-08-13T08:30:00".to_string()));
+    }
+
+    /// origin を持たないノートの frontmatter は今までと 1 バイトも変わらない。
+    /// view と同じ約束: 書いていないキーは書かない。
+    #[test]
+    fn test_render_omits_absent_origin() {
+        let fm = NoteFrontmatter {
+            time: sample_datetime(),
+            tags: vec![],
+            context: None,
+            view: None,
+            origin: None,
+        };
+        let rendered = render(&fm, "body").unwrap();
+        assert!(!rendered.contains("origin"));
+    }
+
+    /// origin キーを知らない版のアプリが書いたノートも今まで通り読める。
+    #[test]
+    fn test_parse_defaults_origin_to_none() {
+        let yaml = "---\ntime: 2026-03-20T14:30:45+09:00\ntags: []\n---\nbody";
+        let (fm, _body): (NoteFrontmatter, &str) = parse(yaml).unwrap();
+        assert_eq!(fm.origin, None);
+    }
+
+    #[test]
     fn test_note_frontmatter_no_context() {
         let fm = NoteFrontmatter {
             time: sample_datetime(),
             tags: vec![],
             context: None,
             view: None,
+            origin: None,
         };
         let rendered = render(&fm, "body").unwrap();
         let (parsed, _body): (NoteFrontmatter, _) = parse(&rendered).unwrap();
@@ -135,6 +181,7 @@ mod tests {
             tags: vec![],
             context: None,
             view: None,
+            origin: None,
         };
         let rendered = render(&fm, "body").unwrap();
         assert!(rendered.starts_with("---\n"));

--- a/core/src/utils/markdown.rs
+++ b/core/src/utils/markdown.rs
@@ -65,6 +65,7 @@ pub fn format_note_markdown(
     tags: &[String],
     timestamp: DateTime<Local>,
     context: &Context,
+    origin: Option<&str>,
 ) -> Result<String, CoreError> {
     let time: DateTime<FixedOffset> = timestamp.into();
     let fm = NoteFrontmatter {
@@ -72,6 +73,7 @@ pub fn format_note_markdown(
         tags: tags.to_vec(),
         context: Some(context.clone()),
         view: None,
+        origin: origin.map(str::to_string),
     };
     frontmatter::render(&fm, body)
 }
@@ -130,9 +132,14 @@ mod tests {
     #[test]
     fn test_format_note_markdown() {
         let tags = vec!["rust".to_string(), "memo".to_string()];
-        let result =
-            format_note_markdown("# Hello\nWorld", &tags, fixed_timestamp(), &test_context())
-                .unwrap();
+        let result = format_note_markdown(
+            "# Hello\nWorld",
+            &tags,
+            fixed_timestamp(),
+            &test_context(),
+            None,
+        )
+        .unwrap();
 
         let (fm, body): (NoteFrontmatter, &str) = frontmatter::parse(&result).unwrap();
         assert_eq!(fm.tags, vec!["rust", "memo"]);
@@ -145,7 +152,8 @@ mod tests {
 
     #[test]
     fn test_format_note_markdown_empty_tags() {
-        let result = format_note_markdown("body", &[], fixed_timestamp(), &test_context()).unwrap();
+        let result =
+            format_note_markdown("body", &[], fixed_timestamp(), &test_context(), None).unwrap();
         let (fm, _body): (NoteFrontmatter, &str) = frontmatter::parse(&result).unwrap();
         assert!(fm.tags.is_empty());
     }
@@ -157,7 +165,7 @@ mod tests {
             is_charging: Some(true),
             ..Context::default()
         };
-        let result = format_note_markdown("body", &[], fixed_timestamp(), &ctx).unwrap();
+        let result = format_note_markdown("body", &[], fixed_timestamp(), &ctx, None).unwrap();
         let (fm, _body): (NoteFrontmatter, &str) = frontmatter::parse(&result).unwrap();
         let context = fm.context.unwrap();
         assert_eq!(context.battery, Some(100));

--- a/tauri-app/dev/ipc-mock.js
+++ b/tauri-app/dev/ipc-mock.js
@@ -73,6 +73,12 @@
 
   // ---- ノートのつくりもの ----
 
+  /** タイムラインは実時刻基準で作られるので、origin も同じ基準で合わせる。 */
+  const isoDaysAgo = (days) => {
+    const day = new Date(today.getFullYear(), today.getMonth(), today.getDate() - days);
+    return `${day.getFullYear()}-${pad(day.getMonth() + 1)}-${pad(day.getDate())}`;
+  };
+
   const codeSample = [
     "```typescript",
     "export function debounce<T extends unknown[]>(fn: (...args: T) => void, ms: number) {",
@@ -131,6 +137,8 @@
         tags: [],
         view: null,
         body: "# 短いメモ\n\n今日やることを 3 つだけ。",
+        // 昇格ノートのチップ検証用。3 日前のエントリから育ったことにする
+        origin: `${isoDaysAgo(3)}T08:00:00`,
       },
     ],
   ]);
@@ -144,6 +152,7 @@
         time: note.time,
         tags: note.tags,
         preview: note.body.slice(0, 120),
+        ...(note.origin ? { origin: note.origin } : {}),
       }));
 
   // ---- コマンド実装 ----
@@ -214,11 +223,17 @@
     delete_note: ({ filename }) => {
       notes.delete(filename);
     },
-    create_draft: ({ body }) => {
+    create_draft: ({ body, tags, origin }) => {
       const now = new Date();
       const stamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}_${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
       const filename = `${stamp}.md`;
-      notes.set(filename, { time: now.toISOString(), tags: [], view: null, body });
+      notes.set(filename, {
+        time: now.toISOString(),
+        tags: tags ?? [],
+        view: null,
+        body,
+        ...(origin ? { origin } : {}),
+      });
       return `/mock/data/${filename}`;
     },
     update_draft: ({ filePath, body }) => {

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -60,10 +60,20 @@ fn create_draft(
     body: String,
     tags: Vec<String>,
     client: ClientContext,
+    origin: Option<String>,
 ) -> Result<String, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
     let context = device::get_context(client);
-    let path = magical_merchant_core::create_draft_note(&base_dir, &body, &tags, &context)
+    // origin 付きはタイムラインエントリからの昇格。出自を frontmatter に刻む
+    let path = origin
+        .map_or_else(
+            || magical_merchant_core::create_draft_note(&base_dir, &body, &tags, &context),
+            |origin| {
+                magical_merchant_core::create_note_from_entry(
+                    &base_dir, &body, &tags, &context, &origin,
+                )
+            },
+        )
         .map_err(|e| e.to_string())?;
     Ok(path.to_string_lossy().to_string())
 }

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -7,6 +7,8 @@ export interface Note {
   time?: string;
   tags: string[];
   preview: string;
+  /** 昇格元エントリの日時(`YYYY-MM-DDTHH:MM:SS`)。エントリ由来のノートだけ持つ。 */
+  origin?: string;
 }
 
 /**
@@ -66,7 +68,10 @@ interface CommandMap {
   search_all: { args: { query: string }; result: SearchHit[] };
   /** 座標 → 地名。引けたものだけが `["緯度,経度", 地名]` で返る。 */
   resolve_places: { args: { coordinates: [number, number][] }; result: [string, string][] };
-  create_draft: { args: { body: string; tags: string[] } & ClientArgs; result: string };
+  create_draft: {
+    args: { body: string; tags: string[]; origin?: string } & ClientArgs;
+    result: string;
+  };
   update_draft: {
     args: { filePath: string; body: string } & ClientArgs;
     result: void;

--- a/tauri-app/src/lib/items.test.ts
+++ b/tauri-app/src/lib/items.test.ts
@@ -7,6 +7,7 @@ import {
   itemMeta,
   itemTitle,
   noteCreatedLabel,
+  notesByOriginDate,
   replaceDayItems,
   planBulkDelete,
 } from "./items";
@@ -86,6 +87,28 @@ describe("toNoteItems", () => {
     const [item] = toNoteItems([note({ time: undefined })]);
     expect(item.date).toBe("");
     expect(item.time).toBe("");
+  });
+
+  it("carries the origin of a promoted note", () => {
+    const [item] = toNoteItems([note({ origin: "2026-08-03T08:30:00" })]);
+    expect(item.origin).toBe("2026-08-03T08:30:00");
+  });
+});
+
+describe("notesByOriginDate", () => {
+  it("returns an empty map when no note has an origin", () => {
+    expect(notesByOriginDate(toNoteItems([note()])).size).toBe(0);
+  });
+
+  it("groups promoted notes under the day of their origin entry", () => {
+    const items = toNoteItems([
+      note({ filename: "a.md", origin: "2026-08-03T08:30:00" }),
+      note({ filename: "b.md", origin: "2026-08-03T21:00:00" }),
+      note({ filename: "c.md", origin: "2026-08-01T07:00:00" }),
+    ]);
+    const map = notesByOriginDate(items);
+    expect(map.get("2026-08-03")?.map((n) => n.filename)).toEqual(["a.md", "b.md"]);
+    expect(map.get("2026-08-01")?.map((n) => n.filename)).toEqual(["c.md"]);
   });
 });
 

--- a/tauri-app/src/lib/items.ts
+++ b/tauri-app/src/lib/items.ts
@@ -25,6 +25,8 @@ export interface NoteItem {
   title: string;
   tags: string[];
   preview: string;
+  /** 昇格元エントリの日時。タイムラインのチップ表示が日付部分を使う。 */
+  origin?: string;
 }
 
 export type Item = TimelineItem | NoteItem;
@@ -76,7 +78,29 @@ export function toNoteItems(notes: Note[]): NoteItem[] {
     title: firstLine(note.preview) || UNTITLED,
     tags: note.tags,
     preview: note.preview,
+    origin: note.origin,
   }));
+}
+
+/**
+ * 昇格ノートを origin の暦日で引けるようにする。タイムラインの日毎の
+ * チップはここから導出する — エントリ側のファイルには何も書いていない
+ * ので、並び替えや行の増減でズレる心配がない。
+ */
+export function notesByOriginDate(items: NoteItem[]): Map<string, NoteItem[]> {
+  const map = new Map<string, NoteItem[]>();
+  for (const item of items) {
+    const date = item.origin?.slice(0, 10);
+    if (date) {
+      const notes = map.get(date);
+      if (notes) {
+        notes.push(item);
+      } else {
+        map.set(date, [item]);
+      }
+    }
+  }
+  return map;
 }
 
 /** 連続する同じラベルだけをまとめる。日付順は呼び出し側の並びを尊重する。 */

--- a/tauri-app/src/lib/long-press.test.ts
+++ b/tauri-app/src/lib/long-press.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createLongPress } from "./long-press";
+
+const HOLD_MS = 500;
+
+function touchDown(): { pointerType: string } {
+  return { pointerType: "touch" };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createLongPress", () => {
+  it("fires after the hold duration on touch", () => {
+    const fired = vi.fn<() => void>();
+    const press = createLongPress(fired, HOLD_MS);
+
+    press.onPointerDown(touchDown());
+    vi.advanceTimersByTime(HOLD_MS);
+
+    expect(fired).toHaveBeenCalledTimes(1);
+  });
+
+  // PC の長押しに意味はない。マウスにはホバーのボタンがある
+  it("ignores mouse presses", () => {
+    const fired = vi.fn<() => void>();
+    const press = createLongPress(fired, HOLD_MS);
+
+    press.onPointerDown({ pointerType: "mouse" });
+    vi.advanceTimersByTime(HOLD_MS);
+
+    expect(fired).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when released early", () => {
+    const fired = vi.fn<() => void>();
+    const press = createLongPress(fired, HOLD_MS);
+
+    press.onPointerDown(touchDown());
+    vi.advanceTimersByTime(HOLD_MS - 1);
+    press.onPointerUp();
+    vi.advanceTimersByTime(HOLD_MS);
+
+    expect(fired).not.toHaveBeenCalled();
+  });
+
+  // 指が動いた=スクロール。押しっぱなしとは区別する
+  it("cancels when the pointer moves", () => {
+    const fired = vi.fn<() => void>();
+    const press = createLongPress(fired, HOLD_MS);
+
+    press.onPointerDown(touchDown());
+    press.onPointerMove();
+    vi.advanceTimersByTime(HOLD_MS);
+
+    expect(fired).not.toHaveBeenCalled();
+  });
+
+  // 長押し後に指を離すと click が飛ぶ。それを編集開始に流さない
+  it("swallows exactly the click that follows a long press", () => {
+    const press = createLongPress(vi.fn<() => void>(), HOLD_MS);
+
+    press.onPointerDown(touchDown());
+    vi.advanceTimersByTime(HOLD_MS);
+    press.onPointerUp();
+
+    expect(press.shouldClick()).toBe(false);
+    expect(press.shouldClick()).toBe(true);
+  });
+
+  it("lets an ordinary tap click through", () => {
+    const press = createLongPress(vi.fn<() => void>(), HOLD_MS);
+
+    press.onPointerDown(touchDown());
+    vi.advanceTimersByTime(100);
+    press.onPointerUp();
+
+    expect(press.shouldClick()).toBe(true);
+  });
+});

--- a/tauri-app/src/lib/long-press.ts
+++ b/tauri-app/src/lib/long-press.ts
@@ -1,0 +1,63 @@
+/**
+ * タッチ端末の長押し検出。ポインタイベントのハンドラ束として返し、
+ * 要素側にそのまま繋ぐ。
+ *
+ * マウスは対象にしない — PC にはホバーで出るボタンがあり、マウスの
+ * 長押しはドラッグやテキスト選択と衝突するだけで得るものがない。
+ */
+
+interface PointerLike {
+  pointerType: string;
+}
+
+export interface LongPress {
+  onPointerDown: (e: PointerLike) => void;
+  onPointerUp: () => void;
+  onPointerMove: () => void;
+  onPointerCancel: () => void;
+  /**
+   * 直後の click をそのまま処理してよいか。長押しが発火したあとに指を
+   * 離すとブラウザは click も飛ばすので、その 1 回だけを飲み込む。
+   */
+  shouldClick: () => boolean;
+}
+
+export function createLongPress(onLongPress: () => void, holdMs = 500): LongPress {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let fired = false;
+
+  const cancel = (): void => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  return {
+    onPointerDown: (e) => {
+      if (e.pointerType === "mouse") {
+        return;
+      }
+      cancel();
+      timer = setTimeout(() => {
+        timer = undefined;
+        fired = true;
+        onLongPress();
+      }, holdMs);
+    },
+    onPointerUp: cancel,
+    onPointerMove: cancel,
+    onPointerCancel: () => {
+      cancel();
+      // 押している間に OS がジェスチャを横取りした場合。click は来ない
+      fired = false;
+    },
+    shouldClick: () => {
+      if (fired) {
+        fired = false;
+        return false;
+      }
+      return true;
+    },
+  };
+}

--- a/tauri-app/src/styles/timeline.css
+++ b/tauri-app/src/styles/timeline.css
@@ -172,6 +172,64 @@
   gap: 4px;
 }
 
+/* エントリ単位の隠しアクション。ホバーでだけ現れる(タッチは長押し) */
+.entry-actions {
+  position: absolute;
+  top: -2px;
+  right: 0;
+  opacity: 0;
+  transition: opacity 0.12s;
+}
+
+.entry:hover .entry-actions,
+.entry-actions:focus-within {
+  opacity: 1;
+}
+
+.entry-action {
+  color: var(--app-text-faint);
+  padding: 5px;
+}
+
+.entry-action:hover {
+  background: var(--app-surface-2);
+  color: var(--app-text);
+}
+
+/* その日のエントリから育ったノートへの入り口 */
+.origin-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 2px 0 10px;
+}
+
+.origin-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  padding: 4px 10px;
+  border: 1px solid var(--app-border);
+  border-radius: 999px;
+  background: var(--app-surface);
+  color: var(--app-text-muted);
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.origin-chip:hover {
+  background: var(--app-accent-soft);
+  color: var(--app-text);
+}
+
+.origin-chip-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ---------------- selection mode ---------------- */
 
 /* 入口はリスト右上のテキストボタン 1 つだけ。普段は視界に入らない濃さに抑える */

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -14,14 +14,24 @@ import CaptureBar from "../components/CaptureBar";
 import CalendarPopover from "../components/CalendarPopover";
 import TagFilter from "../components/TagFilter";
 import TagText from "../components/TagText";
+import { useNavigate } from "@solidjs/router";
 import { typedInvoke } from "../lib/commands";
 import { getClientContext } from "../lib/client-context";
 import { useShell } from "../lib/shell";
 import { formatDayHeading, toIsoDate } from "../lib/day-labels";
-import { groupTimelineByDay, planBulkDelete, replaceDayItems, toTimelineItems } from "../lib/items";
-import type { TimelineItem } from "../lib/items";
+import {
+  groupTimelineByDay,
+  notesByOriginDate,
+  planBulkDelete,
+  replaceDayItems,
+  toNoteItems,
+  toTimelineItems,
+} from "../lib/items";
+import type { NoteItem, TimelineItem } from "../lib/items";
+import { createLongPress } from "../lib/long-press";
 import { entryMeta } from "../lib/timeline-meta";
 import { places } from "../lib/places";
+import { ROUTES } from "../lib/routes";
 import { countTags, parseTags } from "../lib/tags";
 import type { DeviceContext } from "../lib/parse-timeline";
 
@@ -52,10 +62,13 @@ interface EntryProps {
   onEdit: () => void;
   onCommit: () => void;
   onToggle: () => void;
+  onPromote: () => void;
 }
 
 function Entry(props: EntryProps): JSX.Element {
   const meta = createMemo(() => entryMeta(props.item.context, places.nameOf));
+  // モバイルの入り口は長押し。タップは今まで通りその場編集
+  const press = createLongPress(() => props.onPromote());
 
   return (
     <article
@@ -110,7 +123,19 @@ function Entry(props: EntryProps): JSX.Element {
 
         <Show when={!props.editing && !props.selecting}>
           {/* 本文そのものが編集の入口。button なのはキーボードから開けるようにするため */}
-          <button type="button" class="entry-text" onClick={() => props.onEdit()}>
+          <button
+            type="button"
+            class="entry-text"
+            onPointerDown={(e) => press.onPointerDown(e)}
+            onPointerUp={() => press.onPointerUp()}
+            onPointerMove={() => press.onPointerMove()}
+            onPointerCancel={() => press.onPointerCancel()}
+            onClick={() => {
+              if (press.shouldClick()) {
+                props.onEdit();
+              }
+            }}
+          >
             <TagText text={props.item.text} />
           </button>
           <Show when={meta().length}>
@@ -125,6 +150,18 @@ function Entry(props: EntryProps): JSX.Element {
               </For>
             </div>
           </Show>
+          {/* PC の入り口。隠しアクションの流儀どおり、ホバーでだけ現れる */}
+          <div class="entry-actions">
+            <button
+              type="button"
+              class="icon-button entry-action"
+              title="ノートにする"
+              aria-label="ノートにする"
+              onClick={() => props.onPromote()}
+            >
+              <Icon name="note-pencil" size={15} />
+            </button>
+          </div>
         </Show>
       </div>
     </article>
@@ -151,6 +188,7 @@ function EmptyTimeline(props: { filtered: boolean }): JSX.Element {
 
 export default function Timeline(): JSX.Element {
   const shell = useShell();
+  const navigate = useNavigate();
   const today = new Date();
 
   const [extraDates, setExtraDates] = createSignal<string[]>([]);
@@ -170,10 +208,24 @@ export default function Timeline(): JSX.Element {
   const [deleting, setDeleting] = createSignal(false);
 
   const [timeline, { refetch, mutate }] = createResource(extraDates, loadTimeline);
+  // 昇格ノートのチップに使う。タイムラインの描画は待たない — ノート一覧が
+  // 届いてからチップだけ後から現れる
+  const [notes, { refetch: refetchNotes }] = createResource(async () =>
+    toNoteItems(await typedInvoke("list_notes")),
+  );
 
   // 初回は createResource が読む。defer しないとマウント直後に同じ全読みを
   // もう一度走らせ、起動時の IPC がまるごと倍になる
-  createEffect(on(shell.dataVersion, () => void refetch(), { defer: true }));
+  createEffect(
+    on(
+      shell.dataVersion,
+      () => {
+        void refetch();
+        void refetchNotes();
+      },
+      { defer: true },
+    ),
+  );
 
   const entries = createMemo(() => timeline() ?? []);
   // 地名は記録の一部ではないので、これを待って一覧を出さない。座標のまま先に
@@ -190,6 +242,7 @@ export default function Timeline(): JSX.Element {
   });
 
   const days = createMemo(() => groupTimelineByDay(visible()));
+  const originNotes = createMemo(() => notesByOriginDate(notes() ?? []));
 
   /**
    * 日付を足すとデータを取り直すぶん行が作り直され、その場でスクロールしても
@@ -240,6 +293,30 @@ export default function Timeline(): JSX.Element {
 
   // タブを切り替えても書きかけを捨てない。blur はアンマウントでは飛ばない。
   onCleanup(() => void commitEdit());
+
+  /**
+   * エントリを昇格させてノートを作り、そのまま書き始められる状態で開く。
+   * エントリ側のファイルには何も書かない — ノートの frontmatter `origin`
+   * だけが両者を繋ぎ、チップは毎回そこから導出される。
+   */
+  const promote = async (item: TimelineItem): Promise<void> => {
+    const path = await typedInvoke("create_draft", {
+      body: item.text,
+      tags: parseTags(item.text),
+      origin: `${item.date}T${item.time}`,
+      client: await getClientContext(),
+    });
+    const filename = path.split("/").at(-1);
+    if (!filename) {
+      return;
+    }
+    shell.refreshData();
+    navigate(`${ROUTES.NOTES}?file=${encodeURIComponent(filename)}&edit=1`);
+  };
+
+  const openNote = (note: NoteItem): void => {
+    navigate(`${ROUTES.NOTES}?file=${encodeURIComponent(note.filename)}`);
+  };
 
   // ---- まとめて削除（選択 → 確認 → 実行）----
   const startSelecting = (): void => {
@@ -345,6 +422,25 @@ export default function Timeline(): JSX.Element {
                       <span class="day-heading-count">{day.items.length}件</span>
                     </header>
 
+                    {/* この日のエントリから育ったノートへの入り口 */}
+                    <Show when={originNotes().get(day.date)?.length}>
+                      <div class="origin-chips">
+                        <For each={originNotes().get(day.date)}>
+                          {(note) => (
+                            <button
+                              type="button"
+                              class="origin-chip"
+                              onClick={() => openNote(note)}
+                            >
+                              <Icon name="file-text" size={13} />
+                              <span class="origin-chip-title">{note.title}</span>
+                              <span aria-hidden="true">→</span>
+                            </button>
+                          )}
+                        </For>
+                      </div>
+                    </Show>
+
                     <For each={day.items}>
                       {(item) => (
                         <Entry
@@ -358,6 +454,7 @@ export default function Timeline(): JSX.Element {
                           onEdit={() => startEditing(item)}
                           onCommit={() => void commitEdit()}
                           onToggle={() => toggleSelected(item.id)}
+                          onPromote={() => void promote(item)}
                         />
                       )}
                     </For>

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -63,7 +63,7 @@ function EmptyNotes(): JSX.Element {
 
 export default function Workspace(): JSX.Element {
   const shell = useShell();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const today = new Date();
 
   const [selectedId, setSelectedId] = createSignal<string | null>(null);
@@ -74,6 +74,8 @@ export default function Workspace(): JSX.Element {
   const [hidden, setHidden] = createSignal<string[]>([]);
   const [noteBody, setNoteBody] = createSignal("");
   const [noteView, setNoteView] = createSignal<NoteView>("editor");
+  /** 本文の読み込みが済んでいるノートの id。`?edit=1` の自動編集開始が待つ。 */
+  const [loadedId, setLoadedId] = createSignal<string | null>(null);
   /** タッチ端末のツールバーが叩く先。編集をやめると undefined に戻る。 */
   const [markdownEditor, setMarkdownEditor] = createSignal<Editor | undefined>();
 
@@ -138,6 +140,7 @@ export default function Workspace(): JSX.Element {
         batch(() => {
           setNoteBody(content.body);
           setNoteView(content.view);
+          setLoadedId(item.id);
         });
       } catch {
         // 読めないノートを選んだまま、前のノートの本文を出し続けない
@@ -145,6 +148,7 @@ export default function Workspace(): JSX.Element {
           batch(() => {
             setNoteBody("");
             setNoteView("editor");
+            setLoadedId(item.id);
           });
         }
       }
@@ -277,6 +281,20 @@ export default function Workspace(): JSX.Element {
     await refetchNotes();
     shell.showToast("編集前の内容に戻しました");
   };
+
+  // タイムラインからの昇格 (?edit=1) は、本文が届き次第そのまま書き始める。
+  // パラメータは消費したら消す — 再読み込みのたびに編集へ放り込まない
+  createEffect(() => {
+    if (searchParams.edit !== "1") {
+      return;
+    }
+    const item = selected();
+    if (!item || item.filename !== searchParams.file || loadedId() !== item.id) {
+      return;
+    }
+    startEditing();
+    setSearchParams({ edit: undefined }, { replace: true });
+  });
 
   const revertable = createMemo<boolean>(() => {
     const item = selected();


### PR DESCRIPTION
## なぜやるか

capture-to-writing 計画の Phase 2 (2b)。タイムラインに書き捨てたメモが育ったとき、ノートに昇格させて続きを書ける経路がなかった。

## やったこと

- エントリの「ノートにする」: PC はホバーで出るボタン、タッチは長押し(タップは従来通りその場編集)。`create_draft` に origin を渡してノートを作り、`?file=&edit=1` で開いて本文が届き次第そのまま編集開始
- Rust core: `NoteFrontmatter` に typed な `origin` キー(エントリ日時)を追加。未設定なら書かないので、既存ノートの frontmatter は 1 バイトも変わらない(view キーと同じ約束)。`create_note_from_entry` を追加し既存 API は不変
- タイムライン側のチップ(📄 タイトル →)は一覧の origin から毎回導出。エントリ側のファイルには何も書かないため、行の増減や並び替えでリンクがズレない
- ipc-mock に origin / チップ検証用フィクスチャを追加

## やらなかったこと

- NoteMetaPopover からの手動リンク(計画の optional 項目、必要になったら)
