### PR TITLE
feat(palette): zero-query entry points and precise landing

### DIFF
--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -30,6 +30,11 @@ pub struct SearchHit {
     /// その日の何番目のエントリか。Note では `None`。
     pub index: Option<usize>,
     pub tags: Vec<String>,
+    /// `snippet` 内でクエリが一致し始める位置(文字数、省略記号込み)。
+    /// タグなど本文の外だけに一致したときは `None`。
+    pub match_start: Option<usize>,
+    /// 一致した長さ(文字数)。`match_start` と対で使う。
+    pub match_len: Option<usize>,
 }
 
 const SNIPPET_CONTEXT: usize = 40;
@@ -72,14 +77,17 @@ pub fn search_all(base_dir: &Path, query: &str) -> Result<Vec<SearchHit>, CoreEr
             if !lowered.contains(&needle) {
                 continue;
             }
+            let excerpt = snippet(text, &lowered, &needle);
             hits.push(SearchHit {
                 kind: HitKind::Timeline,
                 title: first_line(text).to_string(),
-                snippet: snippet(text, &lowered, &needle),
+                snippet: excerpt.text,
                 date: formatted.clone(),
                 filename: None,
                 index: Some(index),
                 tags: Vec::new(),
+                match_start: excerpt.match_start,
+                match_len: excerpt.match_start.map(|_| needle.chars().count()),
             });
         }
     }
@@ -97,10 +105,11 @@ pub fn search_all(base_dir: &Path, query: &str) -> Result<Vec<SearchHit>, CoreEr
             continue;
         }
         let lowered = note.preview.to_lowercase();
+        let excerpt = snippet(&note.preview, &lowered, &needle);
         hits.push(SearchHit {
             kind: HitKind::Note,
             title: first_line(&note.preview).to_string(),
-            snippet: snippet(&note.preview, &lowered, &needle),
+            snippet: excerpt.text,
             date: note
                 .time
                 .map(|t| t.format("%Y-%m-%d").to_string())
@@ -108,6 +117,8 @@ pub fn search_all(base_dir: &Path, query: &str) -> Result<Vec<SearchHit>, CoreEr
             filename: Some(note.filename),
             index: None,
             tags: note.tags,
+            match_start: excerpt.match_start,
+            match_len: excerpt.match_start.map(|_| needle.chars().count()),
         });
     }
 
@@ -120,14 +131,22 @@ fn first_line(text: &str) -> &str {
     text.lines().next().unwrap_or("").trim()
 }
 
+/// 切り出した抜粋と、その中でクエリが一致し始める位置(文字数)。
+struct Excerpt {
+    text: String,
+    /// 本文に一致がない(タグだけに当たった)ときは `None`。
+    match_start: Option<usize>,
+}
+
 /// ヒット位置の前後 `SNIPPET_CONTEXT` 文字を、文字境界を壊さずに切り出す。
 /// `lowered` は照合に使った `text` の小文字版。作り直さず受け取るのは、
 /// ここが 1 ヒットごとに走るため。
-fn snippet(text: &str, lowered: &str, needle: &str) -> String {
+fn snippet(text: &str, lowered: &str, needle: &str) -> Excerpt {
     // ヒットしたのが本文以外（ノートのタグなど）なら先頭から切り出す。
-    let at = lowered
+    let found = lowered
         .find(needle)
-        .map_or(0, |byte| lowered[..byte].chars().count());
+        .map(|byte| lowered[..byte].chars().count());
+    let at = found.unwrap_or(0);
     let end = at + needle.chars().count() + SNIPPET_CONTEXT;
     let start = at.saturating_sub(SNIPPET_CONTEXT);
 
@@ -135,19 +154,29 @@ fn snippet(text: &str, lowered: &str, needle: &str) -> String {
     if start > 0 {
         out.push('…');
     }
+    // 先頭の「…」も 1 文字。位置に入れないとハイライトが 1 文字ずれる
+    let match_start = found.map(|at| at - start + usize::from(start > 0));
     // Vec<char> を 3 本作らずに 1 度だけ走査する。
     let mut chars = text.chars().skip(start);
     for _ in start..end {
         match chars.next() {
             Some('\n') => out.push(' '),
             Some(c) => out.push(c),
-            None => return out,
+            None => {
+                return Excerpt {
+                    text: out,
+                    match_start,
+                };
+            }
         }
     }
     if chars.next().is_some() {
         out.push('…');
     }
-    out
+    Excerpt {
+        text: out,
+        match_start,
+    }
 }
 
 #[cfg(test)]
@@ -317,5 +346,59 @@ mod tests {
         let hits = search_all(tmp.path(), "needle").unwrap();
 
         assert_eq!(hits[0].snippet, "short needle here");
+    }
+
+    /// 抜粋のどこが一致したか。UI はこの位置でハイライトを塗るので、
+    /// ずれると無関係な文字が光る。
+    #[test]
+    fn a_hit_reports_where_the_match_sits_in_the_snippet() {
+        let tmp = TempDir::new().unwrap();
+        save_timeline_entry(tmp.path(), "short needle here", &context()).unwrap();
+
+        let hits = search_all(tmp.path(), "needle").unwrap();
+
+        assert_eq!(hits[0].match_start, Some(6));
+        assert_eq!(hits[0].match_len, Some(6));
+    }
+
+    /// 前が省略された抜粋では先頭に「…」が 1 文字入る。位置はそれ込みで
+    /// 返さないと、ハイライトが 1 文字ずれる。
+    #[test]
+    fn an_elided_snippet_counts_the_leading_ellipsis() {
+        let tmp = TempDir::new().unwrap();
+        let long = format!("{}NEEDLE{}", "a".repeat(80), "b".repeat(80));
+        save_timeline_entry(tmp.path(), &long, &context()).unwrap();
+
+        let hits = search_all(tmp.path(), "needle").unwrap();
+
+        let start = hits[0].match_start.unwrap();
+        let len = hits[0].match_len.unwrap();
+        let matched: String = hits[0].snippet.chars().skip(start).take(len).collect();
+        assert_eq!(matched, "NEEDLE");
+    }
+
+    /// マルチバイト文字圏でも位置は文字数で数える。バイト数で返すと
+    /// 日本語の本文で必ずずれる。
+    #[test]
+    fn a_match_position_counts_chars_not_bytes() {
+        let tmp = TempDir::new().unwrap();
+        save_timeline_entry(tmp.path(), "日本語の本文にリトライ", &context()).unwrap();
+
+        let hits = search_all(tmp.path(), "リトライ").unwrap();
+
+        assert_eq!(hits[0].match_start, Some(7));
+        assert_eq!(hits[0].match_len, Some(4));
+    }
+
+    /// タグだけに一致したときは本文に光らせる場所がない。
+    #[test]
+    fn a_tag_only_hit_has_no_match_position() {
+        let tmp = TempDir::new().unwrap();
+        create_draft_note(tmp.path(), "本文", &["sync".to_string()], &context()).unwrap();
+
+        let hits = search_all(tmp.path(), "sync").unwrap();
+
+        assert_eq!(hits[0].match_start, None);
+        assert_eq!(hits[0].match_len, None);
     }
 }

--- a/tauri-app/dev/ipc-mock.js
+++ b/tauri-app/dev/ipc-mock.js
@@ -193,7 +193,61 @@
       }
       return answers;
     },
-    search_all: () => [],
+    search_all: ({ query }) => {
+      const needle = query.trim().toLowerCase();
+      if (!needle) {
+        return [];
+      }
+      /** 本流(core)と同じ形: 一致の前後を含む抜粋と、文字数の一致位置。 */
+      const excerpt = (text) => {
+        const flat = text.replaceAll("\n", " ");
+        const at = flat.toLowerCase().indexOf(needle);
+        if (at === -1) {
+          return { snippet: flat.slice(0, 90), match_start: null, match_len: null };
+        }
+        const start = Math.max(0, at - 40);
+        const lead = start > 0 ? "…" : "";
+        const snippet = lead + flat.slice(start, at + needle.length + 40);
+        return {
+          snippet,
+          match_start: [...(lead + flat.slice(start, at))].length,
+          match_len: [...flat.slice(at, at + needle.length)].length,
+        };
+      };
+      const hits = [];
+      for (const [iso, lines] of timeline) {
+        lines.forEach((raw, index) => {
+          const text = raw.replace(/^- \[\d\d:\d\d:\d\d\] /, "").replace(/ \{.*\}$/, "");
+          if (!text.toLowerCase().includes(needle)) {
+            return;
+          }
+          hits.push({
+            kind: "timeline",
+            title: text.split("\n")[0],
+            date: iso,
+            filename: null,
+            index,
+            tags: [],
+            ...excerpt(text),
+          });
+        });
+      }
+      for (const [filename, note] of notes) {
+        if (!note.body.toLowerCase().includes(needle)) {
+          continue;
+        }
+        hits.push({
+          kind: "note",
+          title: note.body.split("\n")[0].replace(/^#+\s*/, ""),
+          date: note.time.slice(0, 10),
+          filename,
+          index: null,
+          tags: note.tags,
+          ...excerpt(note.body),
+        });
+      }
+      return hits.toSorted((a, b) => b.date.localeCompare(a.date)).slice(0, 100);
+    },
     list_notes: () => noteList(),
     read_note: async ({ filename }) => {
       // ディスク読みの往復ぶん。ノート切替の描画順の検証に効く

--- a/tauri-app/src/components/CommandPalette.tsx
+++ b/tauri-app/src/components/CommandPalette.tsx
@@ -6,6 +6,10 @@ import { typedInvoke } from "../lib/commands";
 import type { SearchHit } from "../lib/commands";
 import { createDebouncedAccessor } from "../lib/debounce";
 import { isImeComposing } from "../lib/ime";
+import { toNoteItems } from "../lib/items";
+import { countNoteTags, dayJumpHits, recentNoteHits } from "../lib/palette-home";
+import { splitSnippet } from "../lib/snippet-highlight";
+import type { SnippetParts } from "../lib/snippet-highlight";
 
 interface PaletteCommand {
   id: string;
@@ -21,9 +25,19 @@ interface CommandPaletteProps {
   onClose: () => void;
 }
 
-interface Row {
+interface PaletteRow {
   key: string;
+  icon: IconName;
+  label: string;
+  meta?: string;
+  /** 一致箇所つきの抜粋。タイトルと同文のときは出さない。 */
+  highlight?: SnippetParts | null;
   run: () => void;
+}
+
+interface PaletteSection {
+  title: string;
+  rows: PaletteRow[];
 }
 
 function searchHits(query: string): Promise<SearchHit[]> {
@@ -40,10 +54,32 @@ function searchHits(query: string): Promise<SearchHit[]> {
  */
 const SEARCH_DEBOUNCE_MS = 200;
 
+/** zero-query に出すタグの数。全部出すと入り口ではなく一覧になってしまう。 */
+const HOME_TAG_LIMIT = 6;
+
+function monthDay(iso: string): string {
+  return iso.slice(5).replace("-", "/");
+}
+
 export default function CommandPalette(props: CommandPaletteProps): JSX.Element {
   const [query, setQuery] = createSignal("");
   const [cursor, setCursor] = createSignal(0);
   const [hits] = createResource(createDebouncedAccessor(query, SEARCH_DEBOUNCE_MS), searchHits);
+
+  // zero-query の入り口。どれも既存の IPC から導出するだけで、開いた瞬間に
+  // 1 回読めば足りる
+  const [home] = createResource(async () => {
+    const [notes, dates] = await Promise.all([
+      typedInvoke("list_notes"),
+      typedInvoke("list_timeline_dates"),
+    ]);
+    const items = toNoteItems(notes);
+    return {
+      recent: recentNoteHits(items),
+      tags: countNoteTags(items).slice(0, HOME_TAG_LIMIT),
+      days: dayJumpHits(dates, new Date()),
+    };
+  });
 
   let inputRef: HTMLInputElement | undefined;
   onMount(() => inputRef?.focus());
@@ -56,15 +92,67 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
     return props.commands.filter((c) => c.label.toLowerCase().includes(needle));
   });
 
-  const rows = createMemo<Row[]>(() => [
-    ...matchingCommands().map((command) => ({ key: `cmd:${command.id}`, run: command.run })),
-    ...(hits() ?? []).map((hit, i) => ({
-      key: `hit:${i}`,
-      run: () => props.onSelectHit(hit),
-    })),
-  ]);
+  const sections = createMemo<PaletteSection[]>(() => {
+    const commands: PaletteRow[] = matchingCommands().map((command) => ({
+      key: `cmd:${command.id}`,
+      icon: command.icon,
+      label: command.label,
+      meta: command.shortcut,
+      run: command.run,
+    }));
 
-  const clampedCursor = createMemo(() => Math.min(cursor(), Math.max(rows().length - 1, 0)));
+    if (!query().trim()) {
+      const entry = home();
+      const days: PaletteRow[] = (entry?.days ?? []).map((day) => ({
+        key: `day:${day.hit.date}`,
+        icon: "calendar-blank",
+        label: day.label,
+        meta: monthDay(day.hit.date),
+        run: () => props.onSelectHit(day.hit),
+      }));
+      const recent: PaletteRow[] = (entry?.recent ?? []).map((hit) => ({
+        key: `recent:${hit.filename}`,
+        icon: "file-text",
+        label: hit.title,
+        meta: monthDay(hit.date),
+        run: () => props.onSelectHit(hit),
+      }));
+      const tags: PaletteRow[] = (entry?.tags ?? []).map((tag) => ({
+        key: `tag:${tag.tag}`,
+        icon: "magnifying-glass",
+        label: `#${tag.tag}`,
+        meta: `${tag.count}件`,
+        run: () => {
+          // タグは着地先が一つに決まらないので、検索として引き継ぐ
+          setQuery(tag.tag);
+          setCursor(0);
+        },
+      }));
+      return [
+        { title: "コマンド", rows: commands },
+        { title: "日付", rows: days },
+        { title: "最近のノート", rows: recent },
+        { title: "タグ", rows: tags },
+      ].filter((section) => section.rows.length > 0);
+    }
+
+    const hitRows: PaletteRow[] = (hits() ?? []).map((hit, i) => ({
+      key: `hit:${i}`,
+      icon: hit.kind === "note" ? "file-text" : "lightning",
+      label: hit.title || hit.snippet,
+      meta: monthDay(hit.date),
+      highlight: splitSnippet(hit.snippet, hit.match_start, hit.match_len),
+      run: () => props.onSelectHit(hit),
+    }));
+    return [
+      { title: "コマンド", rows: commands },
+      { title: "ノート・エントリ", rows: hitRows },
+    ].filter((section) => section.rows.length > 0);
+  });
+
+  const flatRows = createMemo<PaletteRow[]>(() => sections().flatMap((section) => section.rows));
+
+  const clampedCursor = createMemo(() => Math.min(cursor(), Math.max(flatRows().length - 1, 0)));
 
   const handleKeyDown = (e: KeyboardEvent): void => {
     if (e.key === "Escape") {
@@ -74,7 +162,7 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
     }
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setCursor(Math.min(clampedCursor() + 1, rows().length - 1));
+      setCursor(Math.min(clampedCursor() + 1, flatRows().length - 1));
       return;
     }
     if (e.key === "ArrowUp") {
@@ -85,11 +173,13 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
     // 変換確定の Enter は IME のもの。行の実行には使わない (#102)
     if (e.key === "Enter" && !isImeComposing(e)) {
       e.preventDefault();
-      rows()[clampedCursor()]?.run();
+      flatRows()[clampedCursor()]?.run();
     }
   };
 
-  const commandOffset = (): number => matchingCommands().length;
+  /** セクションをまたいだ通し番号。↑↓ のカーソルはこの並びで動く。 */
+  const globalIndex = (row: PaletteRow): number =>
+    flatRows().findIndex((candidate) => candidate.key === row.key);
 
   return (
     <div
@@ -120,43 +210,48 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
         </div>
 
         <div class="palette-results">
-          <Show when={matchingCommands().length}>
-            <div class="palette-section">コマンド</div>
-            <For each={matchingCommands()}>
-              {(command, i) => (
-                <button
-                  type="button"
-                  class="palette-row"
-                  classList={{ "palette-row--active": clampedCursor() === i() }}
-                  onClick={command.run}
-                >
-                  <Icon name={command.icon} size={16} />
-                  <span class="palette-row-label">{command.label}</span>
-                  <Show when={command.shortcut}>
-                    {(shortcut) => <span class="palette-row-meta">{shortcut()}</span>}
-                  </Show>
-                </button>
-              )}
-            </For>
-          </Show>
-
-          <Show when={hits()?.length}>
-            <div class="palette-section">ノート・エントリ</div>
-            <For each={hits()}>
-              {(hit, i) => (
-                <button
-                  type="button"
-                  class="palette-row"
-                  classList={{ "palette-row--active": clampedCursor() === commandOffset() + i() }}
-                  onClick={() => props.onSelectHit(hit)}
-                >
-                  <Icon name={hit.kind === "note" ? "file-text" : "lightning"} size={16} />
-                  <span class="palette-row-label">{hit.title || hit.snippet}</span>
-                  <span class="palette-row-meta">{hit.date.slice(5).replace("-", "/")}</span>
-                </button>
-              )}
-            </For>
-          </Show>
+          <For each={sections()}>
+            {(section) => (
+              <>
+                <div class="palette-section">{section.title}</div>
+                <For each={section.rows}>
+                  {(row) => (
+                    <button
+                      type="button"
+                      class="palette-row"
+                      classList={{ "palette-row--active": clampedCursor() === globalIndex(row) }}
+                      onClick={() => row.run()}
+                    >
+                      <Icon name={row.icon} size={16} />
+                      <span class="palette-row-text">
+                        <span class="palette-row-label">{row.label}</span>
+                        <Show
+                          when={
+                            row.highlight &&
+                            row.highlight.before + row.highlight.match + row.highlight.after !==
+                              row.label
+                              ? row.highlight
+                              : undefined
+                          }
+                        >
+                          {(parts) => (
+                            <span class="palette-row-snippet">
+                              {parts().before}
+                              <mark>{parts().match}</mark>
+                              {parts().after}
+                            </span>
+                          )}
+                        </Show>
+                      </span>
+                      <Show when={row.meta}>
+                        {(meta) => <span class="palette-row-meta">{meta()}</span>}
+                      </Show>
+                    </button>
+                  )}
+                </For>
+              </>
+            )}
+          </For>
 
           <Show when={query().trim() && !hits.loading && !hits()?.length}>
             <p class="palette-empty">一致するものがありません</p>

--- a/tauri-app/src/layouts/AppLayout.tsx
+++ b/tauri-app/src/layouts/AppLayout.tsx
@@ -268,7 +268,13 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
           ]}
           onSelectHit={(hit) => {
             shell.closePalette();
-            navigate(hit.kind === "note" ? ROUTES.NOTES : ROUTES.TIMELINE);
+            // モードの切り替えだけでは「見つけたのに探し直す」ことになる。
+            // ノートはその 1 件を、タイムラインはその日を URL で指す
+            if (hit.kind === "note" && hit.filename) {
+              navigate(`${ROUTES.NOTES}?file=${encodeURIComponent(hit.filename)}`);
+            } else {
+              navigate(`${ROUTES.TIMELINE}?day=${hit.date}`);
+            }
           }}
           onClose={() => shell.closePalette()}
         />

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -46,6 +46,10 @@ export interface SearchHit {
   filename: string | null;
   index: number | null;
   tags: string[];
+  /** `snippet` 内の一致開始位置(文字数)。タグだけに当たったときは無い。 */
+  match_start?: number | null;
+  /** 一致の長さ(文字数)。`match_start` と対。 */
+  match_len?: number | null;
 }
 
 interface SyncConfig {

--- a/tauri-app/src/lib/palette-home.test.ts
+++ b/tauri-app/src/lib/palette-home.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { countNoteTags, dayJumpHits, recentNoteHits } from "./palette-home";
+import type { NoteItem } from "./items";
+
+const TODAY = new Date(2026, 7, 16);
+
+function item(overrides: Partial<NoteItem> = {}): NoteItem {
+  return {
+    kind: "note",
+    id: "a.md",
+    filename: "a.md",
+    path: "/data/notes/a.md",
+    date: "2026-08-14",
+    time: "09:00",
+    title: "タイトル",
+    tags: [],
+    preview: "タイトル\n本文",
+    ...overrides,
+  };
+}
+
+describe("recentNoteHits", () => {
+  it("turns the head of the list into openable note hits", () => {
+    const hits = recentNoteHits([
+      item({ filename: "b.md", title: "二番目" }),
+      item({ filename: "a.md", title: "一番目" }),
+    ]);
+
+    expect(hits[0]).toMatchObject({ kind: "note", filename: "b.md", title: "二番目" });
+  });
+
+  it("caps the list at five", () => {
+    const items = Array.from({ length: 8 }, (_, i) => item({ filename: `${i}.md` }));
+    expect(recentNoteHits(items)).toHaveLength(5);
+  });
+
+  it("is empty when there are no notes", () => {
+    expect(recentNoteHits([])).toEqual([]);
+  });
+});
+
+describe("countNoteTags", () => {
+  it("counts tags across notes, most used first", () => {
+    const tags = countNoteTags([
+      item({ tags: ["sync", "design"] }),
+      item({ tags: ["sync"] }),
+      item({ tags: [] }),
+    ]);
+
+    expect(tags).toEqual([
+      { tag: "sync", count: 2 },
+      { tag: "design", count: 1 },
+    ]);
+  });
+
+  it("is empty when no note has tags", () => {
+    expect(countNoteTags([item()])).toEqual([]);
+  });
+});
+
+describe("dayJumpHits", () => {
+  it("offers 今日 and 昨日 when both days have entries", () => {
+    const hits = dayJumpHits(["2026-08-16", "2026-08-15", "2026-08-10"], TODAY);
+
+    expect(hits.map((h) => h.label)).toEqual(["今日", "昨日"]);
+    expect(hits[0]?.hit).toMatchObject({ kind: "timeline", date: "2026-08-16" });
+  });
+
+  // 記録のない日をパレットに出すと、選んでも何も表示されない着地になる
+  it("omits a day that has no entries", () => {
+    const hits = dayJumpHits(["2026-08-15"], TODAY);
+
+    expect(hits.map((h) => h.label)).toEqual(["昨日"]);
+  });
+
+  it("is empty when neither day has entries", () => {
+    expect(dayJumpHits(["2026-08-01"], TODAY)).toEqual([]);
+  });
+});

--- a/tauri-app/src/lib/palette-home.ts
+++ b/tauri-app/src/lib/palette-home.ts
@@ -1,0 +1,73 @@
+/**
+ * パレットの zero-query 状態(何も打っていないとき)に出す入り口。
+ *
+ * どれも既にある IPC(list_notes / list_timeline_dates)から導出するだけで、
+ * 新しいコマンドは増やさない。行は既存の SearchHit の形に寄せて、選んだ
+ * ときの着地を検索ヒットと同じ経路に流す。
+ */
+
+import type { SearchHit } from "./commands";
+import { toIsoDate } from "./day-labels";
+import type { NoteItem } from "./items";
+import type { TagCount } from "./tags";
+
+const RECENT_LIMIT = 5;
+
+function noteHit(item: NoteItem): SearchHit {
+  return {
+    kind: "note",
+    title: item.title,
+    snippet: "",
+    date: item.date,
+    filename: item.filename,
+    index: null,
+    tags: item.tags,
+  };
+}
+
+/** 一覧の先頭 = 最近のノート。開く行にして返す。 */
+export function recentNoteHits(items: NoteItem[]): SearchHit[] {
+  return items.slice(0, RECENT_LIMIT).map((item) => noteHit(item));
+}
+
+/** ノートに付いたタグを数える。多い順。 */
+export function countNoteTags(items: NoteItem[]): TagCount[] {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    for (const tag of item.tags) {
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+  return [...counts]
+    .map(([tag, count]) => ({ tag, count }))
+    .toSorted((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+}
+
+export interface DayJump {
+  label: string;
+  hit: SearchHit;
+}
+
+/** 今日・昨日への入り口。記録のある日だけ出す — 空の日に着地させない。 */
+export function dayJumpHits(recordedDates: string[], today: Date): DayJump[] {
+  const dates = new Set(recordedDates);
+  const yesterday = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 1);
+  const candidates: [string, string][] = [
+    ["今日", toIsoDate(today)],
+    ["昨日", toIsoDate(yesterday)],
+  ];
+  return candidates
+    .filter(([, iso]) => dates.has(iso))
+    .map(([label, iso]) => ({
+      label,
+      hit: {
+        kind: "timeline",
+        title: label,
+        snippet: "",
+        date: iso,
+        filename: null,
+        index: null,
+        tags: [],
+      },
+    }));
+}

--- a/tauri-app/src/lib/snippet-highlight.test.ts
+++ b/tauri-app/src/lib/snippet-highlight.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { splitSnippet } from "./snippet-highlight";
+
+describe("splitSnippet", () => {
+  it("splits the snippet around the match", () => {
+    expect(splitSnippet("short needle here", 6, 6)).toEqual({
+      before: "short ",
+      match: "needle",
+      after: " here",
+    });
+  });
+
+  // core の位置は文字数で来る。バイトや UTF-16 コード単位で切ると
+  // 絵文字やサロゲートペアでずれる
+  it("counts characters, not UTF-16 code units", () => {
+    expect(splitSnippet("😀😀リトライ後", 2, 4)).toEqual({
+      before: "😀😀",
+      match: "リトライ",
+      after: "後",
+    });
+  });
+
+  it("returns null when there is no match position", () => {
+    expect(splitSnippet("本文だけ", null, null)).toBeNull();
+    expect(splitSnippet("本文だけ")).toBeNull();
+  });
+
+  // 古い core と新しい UI が混ざっても落ちない。範囲外は塗らないだけ
+  it("returns null when the position runs past the snippet", () => {
+    expect(splitSnippet("短い", 10, 4)).toBeNull();
+  });
+});

--- a/tauri-app/src/lib/snippet-highlight.ts
+++ b/tauri-app/src/lib/snippet-highlight.ts
@@ -1,0 +1,29 @@
+/**
+ * 検索ヒットの抜粋を「前・一致・後」に分ける。core が返す位置は文字数
+ * なので、UTF-16 の添字ではなくコードポイントで数える。
+ */
+
+export interface SnippetParts {
+  before: string;
+  match: string;
+  after: string;
+}
+
+export function splitSnippet(
+  snippet: string,
+  start?: number | null,
+  len?: number | null,
+): SnippetParts | null {
+  if (start === null || start === undefined || len === null || len === undefined) {
+    return null;
+  }
+  const chars = [...snippet];
+  if (start + len > chars.length) {
+    return null;
+  }
+  return {
+    before: chars.slice(0, start).join(""),
+    match: chars.slice(start, start + len).join(""),
+    after: chars.slice(start + len).join(""),
+  };
+}

--- a/tauri-app/src/styles/palette.css
+++ b/tauri-app/src/styles/palette.css
@@ -85,10 +85,33 @@
   flex-shrink: 0;
 }
 
+.palette-row-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
 .palette-row-label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* ヒット箇所の前後を含む抜粋。どこに当たったかは <mark> が塗る */
+.palette-row-snippet {
+  font-size: 11.5px;
+  color: var(--app-text-faint);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.palette-row-snippet mark {
+  background: var(--app-accent-soft);
+  color: var(--app-text);
+  border-radius: 2px;
+  padding: 0 1px;
 }
 
 .palette-row-meta {

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -14,7 +14,7 @@ import CaptureBar from "../components/CaptureBar";
 import CalendarPopover from "../components/CalendarPopover";
 import TagFilter from "../components/TagFilter";
 import TagText from "../components/TagText";
-import { useNavigate } from "@solidjs/router";
+import { useNavigate, useSearchParams } from "@solidjs/router";
 import { typedInvoke } from "../lib/commands";
 import { getClientContext } from "../lib/client-context";
 import { useShell } from "../lib/shell";
@@ -189,6 +189,7 @@ function EmptyTimeline(props: { filtered: boolean }): JSX.Element {
 export default function Timeline(): JSX.Element {
   const shell = useShell();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const today = new Date();
 
   const [extraDates, setExtraDates] = createSignal<string[]>([]);
@@ -243,6 +244,18 @@ export default function Timeline(): JSX.Element {
 
   const days = createMemo(() => groupTimelineByDay(visible()));
   const originNotes = createMemo(() => notesByOriginDate(notes() ?? []));
+
+  // 検索やパレットからの着地 (?day=)。カレンダーで選んだときと同じ経路に
+  // 流す — 直近 14 日より前ならデータを足し、その日の見出しまでスクロール
+  createEffect(() => {
+    const { day } = searchParams;
+    if (typeof day !== "string" || !day) {
+      return;
+    }
+    setExtraDates((dates) => (dates.includes(day) ? dates : [...dates, day]));
+    setJumpTo(day);
+    setSearchParams({ day: undefined }, { replace: true });
+  });
 
   /**
    * 日付を足すとデータを取り直すぶん行が作り直され、その場でスクロールしても


### PR DESCRIPTION
## なぜやるか

capture-to-writing 計画の Phase 3 (1c)。⌘K パレットは開いた直後が空で入り口にならず、検索結果を選んでもモードが切り替わるだけで「見つけたのに探し直す」着地だった。

## やったこと

- zero-query 状態: 最近のノート 5 件・記録のある今日/昨日・よく使うタグ(押すと検索クエリに引き継ぐ)。すべて既存 IPC(list_notes / list_timeline_dates)からの導出で新コマンドなし
- 着地の正確化: ノートは `?file=` でその 1 件、タイムラインは `?day=` でその日(カレンダージャンプと同じ extraDates + data-day スクロール経路)
- core の search_all が抜粋内の一致位置(文字数、省略記号込み)を返すようになり、パレットが該当箇所を `<mark>` でハイライト。バイトでなく文字数なのは日本語でずれないため
- 200ms debounce と IME Enter ガードは据え置き

## やらなかったこと

- タイムラインヒットのエントリ単位への着地(日単位まで。index は返しているので必要なら次で)
