### PR TITLE
feat(note): [[links]] between notes with derived backlinks

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -17,7 +17,7 @@ pub use note::{
     read_note_by_filename, read_note_meta, repair_notes, update_note, update_note_meta,
     update_note_view,
 };
-pub use search::{HitKind, SearchHit, search_all};
+pub use search::{HitKind, SearchHit, find_backlinks, search_all};
 pub use timeline::error::TimelineError;
 pub use timeline::{
     delete_timeline_entry, list_timeline_dates, read_timeline, save_timeline_entry,

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -40,14 +40,8 @@ pub struct SearchHit {
 const SNIPPET_CONTEXT: usize = 40;
 const MAX_HITS: usize = 100;
 
-/// Timeline と Notes を横断して大文字小文字を無視した部分一致で検索する。
-/// 新しいものから順に返す。
-pub fn search_all(base_dir: &Path, query: &str) -> Result<Vec<SearchHit>, CoreError> {
-    let needle = query.trim().to_lowercase();
-    if needle.is_empty() {
-        return Ok(Vec::new());
-    }
-
+/// タイムライン全日を走査して needle(小文字化済み)に一致するエントリを集める。
+fn timeline_hits(base_dir: &Path, needle: &str) -> Result<Vec<SearchHit>, CoreError> {
     let mut hits = Vec::new();
     let timeline = Timeline::new(base_dir.to_path_buf());
     // 改行をまたぐ needle だけは日単位の足切りが使えない。CRLF のファイルでは
@@ -60,7 +54,7 @@ pub fn search_all(base_dir: &Path, query: &str) -> Result<Vec<SearchHit>, CoreEr
         };
         // エントリ本文はその日のファイルの部分文字列なので、ファイル全体に無いなら
         // どのエントリにも無い。分割もコンテキスト JSON の判定も丸ごと省ける。
-        if day_filter_applies && !content.to_lowercase().contains(&needle) {
+        if day_filter_applies && !content.to_lowercase().contains(needle) {
             continue;
         }
 
@@ -74,10 +68,10 @@ pub fn search_all(base_dir: &Path, query: &str) -> Result<Vec<SearchHit>, CoreEr
         {
             let text = strip_timeline_prefix(&entry);
             let lowered = text.to_lowercase();
-            if !lowered.contains(&needle) {
+            if !lowered.contains(needle) {
                 continue;
             }
-            let excerpt = snippet(text, &lowered, &needle);
+            let excerpt = snippet(text, &lowered, needle);
             hits.push(SearchHit {
                 kind: HitKind::Timeline,
                 title: first_line(text).to_string(),
@@ -91,6 +85,18 @@ pub fn search_all(base_dir: &Path, query: &str) -> Result<Vec<SearchHit>, CoreEr
             });
         }
     }
+    Ok(hits)
+}
+
+/// Timeline と Notes を横断して大文字小文字を無視した部分一致で検索する。
+/// 新しいものから順に返す。
+pub fn search_all(base_dir: &Path, query: &str) -> Result<Vec<SearchHit>, CoreError> {
+    let needle = query.trim().to_lowercase();
+    if needle.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut hits = timeline_hits(base_dir, &needle)?;
 
     let mut haystack = String::new();
     for note in list_notes(base_dir)? {
@@ -106,6 +112,54 @@ pub fn search_all(base_dir: &Path, query: &str) -> Result<Vec<SearchHit>, CoreEr
         }
         let lowered = note.preview.to_lowercase();
         let excerpt = snippet(&note.preview, &lowered, &needle);
+        hits.push(SearchHit {
+            kind: HitKind::Note,
+            title: first_line(&note.preview).to_string(),
+            snippet: excerpt.text,
+            date: note
+                .time
+                .map(|t| t.format("%Y-%m-%d").to_string())
+                .unwrap_or_default(),
+            filename: Some(note.filename),
+            index: None,
+            tags: note.tags,
+            match_start: excerpt.match_start,
+            match_len: excerpt.match_start.map(|_| needle.chars().count()),
+        });
+    }
+
+    hits.sort_by(|a, b| b.date.cmp(&a.date));
+    hits.truncate(MAX_HITS);
+    Ok(hits)
+}
+
+/// `target` へ `[[ID]]` で言及している記録(ノート・タイムライン)を集める。
+///
+/// インデックスは持たず、開かれるたびに走査で導出する。ノートは一覧の
+/// preview(先頭 100 文字)ではなく全文を読む — リンクは本文のどこにでも
+/// 書かれるため。
+pub fn find_backlinks(
+    base_dir: &Path,
+    target: &crate::utils::validated::NoteFilename,
+) -> Result<Vec<SearchHit>, CoreError> {
+    let stem = target.as_str().trim_end_matches(".md");
+    let needle = format!("[[{stem}]]");
+
+    let mut hits = timeline_hits(base_dir, &needle)?;
+
+    for note in list_notes(base_dir)? {
+        if note.filename == target.as_str() {
+            continue;
+        }
+        // 読めないノートはバックリンク欄から消えるだけ。開けない一覧を出すより良い
+        let Ok(body) = crate::read_note(&note.path) else {
+            continue;
+        };
+        if !body.contains(&needle) {
+            continue;
+        }
+        let lowered = body.to_lowercase();
+        let excerpt = snippet(&body, &lowered, &needle);
         hits.push(SearchHit {
             kind: HitKind::Note,
             title: first_line(&note.preview).to_string(),
@@ -400,5 +454,93 @@ mod tests {
 
         assert_eq!(hits[0].match_start, None);
         assert_eq!(hits[0].match_len, None);
+    }
+
+    fn filename_of(path: &Path) -> crate::utils::validated::NoteFilename {
+        crate::utils::validated::NoteFilename::parse(path.file_name().unwrap().to_str().unwrap())
+            .unwrap()
+    }
+
+    fn stem_of(path: &Path) -> String {
+        path.file_stem().unwrap().to_str().unwrap().to_string()
+    }
+
+    /// 2 件目のノートを固定名で直接書く。`create_draft_note` を同じ秒に
+    /// 2 回呼ぶとファイル名が衝突し、1 件目を上書きしてしまう。
+    fn write_second_note(base: &Path, filename: &str, body: &str) {
+        use crate::utils::frontmatter::{self, NoteFrontmatter};
+        use chrono::TimeZone;
+        let fm = NoteFrontmatter {
+            time: chrono::FixedOffset::east_opt(9 * 3600)
+                .unwrap()
+                .with_ymd_and_hms(2020, 1, 1, 0, 0, 0)
+                .unwrap(),
+            tags: vec![],
+            context: None,
+            view: None,
+            origin: None,
+        };
+        let path = crate::utils::paths::notes_dir(base).join(filename);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, frontmatter::render(&fm, body).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn a_timeline_entry_that_links_a_note_is_a_backlink() {
+        let tmp = TempDir::new().unwrap();
+        let target = create_draft_note(tmp.path(), "指される側", &[], &context()).unwrap();
+        let link = format!("これ参照 [[{}]]", stem_of(&target));
+        save_timeline_entry(tmp.path(), &link, &context()).unwrap();
+
+        let hits = find_backlinks(tmp.path(), &filename_of(&target)).unwrap();
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].kind, HitKind::Timeline);
+        assert!(hits[0].snippet.contains("これ参照"));
+    }
+
+    /// 一覧の preview は先頭 100 文字しかない。リンクは本文のどこにでも
+    /// 書かれるので、全文を読まないと深い位置のリンクを見落とす。
+    #[test]
+    fn a_link_deep_in_a_long_note_is_still_found() {
+        let tmp = TempDir::new().unwrap();
+        let target = create_draft_note(tmp.path(), "指される側", &[], &context()).unwrap();
+        let body = format!("{}\n[[{}]]", "あ".repeat(300), stem_of(&target));
+        write_second_note(tmp.path(), "20200101_000000.md", &body);
+
+        let hits = find_backlinks(tmp.path(), &filename_of(&target)).unwrap();
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].kind, HitKind::Note);
+    }
+
+    /// 自分の中に自分へのリンクを書いても「リンクされている記録」ではない。
+    #[test]
+    fn a_note_is_not_its_own_backlink() {
+        let tmp = TempDir::new().unwrap();
+        let target =
+            create_draft_note(tmp.path(), "後で本文に自分を書く", &[], &context()).unwrap();
+        let stem = stem_of(&target);
+        crate::update_note(&target, &format!("自分 [[{stem}]]"), &context()).unwrap();
+
+        assert!(
+            find_backlinks(tmp.path(), &filename_of(&target))
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn no_links_means_no_backlinks() {
+        let tmp = TempDir::new().unwrap();
+        let target = create_draft_note(tmp.path(), "誰も指していない", &[], &context()).unwrap();
+        write_second_note(tmp.path(), "20200101_000000.md", "無関係なノート");
+        save_timeline_entry(tmp.path(), "無関係なエントリ", &context()).unwrap();
+
+        assert!(
+            find_backlinks(tmp.path(), &filename_of(&target))
+                .unwrap()
+                .is_empty()
+        );
     }
 }

--- a/tauri-app/dev/ipc-mock.js
+++ b/tauri-app/dev/ipc-mock.js
@@ -131,6 +131,16 @@
       },
     ],
     [
+      "20260811_100000.md",
+      {
+        time: "2026-08-11T10:00:00+09:00",
+        tags: [],
+        view: null,
+        // [[リンク]] の解決とバックリンクの検証用
+        body: "# リンク集\n\nまず [[20260813_083000]] を読む。次に [[20260810_090000]]。",
+      },
+    ],
+    [
       "20260813_083000.md",
       {
         time: "2026-08-13T08:30:00+09:00",
@@ -142,6 +152,9 @@
       },
     ],
   ]);
+
+  // バックリンク検証用: 昨日のエントリからも 短いメモ を指しておく
+  timeline.get(isoDaysAgo(1))?.push(`- [21:00:00] 昨日の続きは [[20260813_083000]] にまとめた`);
 
   const noteList = () =>
     [...notes.entries()]
@@ -249,6 +262,45 @@
       return hits.toSorted((a, b) => b.date.localeCompare(a.date)).slice(0, 100);
     },
     list_notes: () => noteList(),
+    find_backlinks: ({ filename }) => {
+      const needle = `[[${filename.replace(/\.md$/, "")}]]`;
+      const hits = [];
+      for (const [iso, lines] of timeline) {
+        lines.forEach((raw, index) => {
+          const text = raw.replace(/^- \[\d\d:\d\d:\d\d\] /, "").replace(/ \{.*\}$/, "");
+          if (text.includes(needle)) {
+            hits.push({
+              kind: "timeline",
+              title: text.split("\n")[0],
+              snippet: text.slice(0, 90),
+              date: iso,
+              filename: null,
+              index,
+              tags: [],
+              match_start: null,
+              match_len: null,
+            });
+          }
+        });
+      }
+      for (const [name, note] of notes) {
+        if (name === filename || !note.body.includes(needle)) {
+          continue;
+        }
+        hits.push({
+          kind: "note",
+          title: note.body.split("\n")[0].replace(/^#+\s*/, ""),
+          snippet: note.body.slice(0, 90),
+          date: note.time.slice(0, 10),
+          filename: name,
+          index: null,
+          tags: note.tags,
+          match_start: null,
+          match_len: null,
+        });
+      }
+      return hits.toSorted((a, b) => b.date.localeCompare(a.date));
+    },
     read_note: async ({ filename }) => {
       // ディスク読みの往復ぶん。ノート切替の描画順の検証に効く
       await delay(30);

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -109,6 +109,13 @@ fn read_note(handle: AppHandle, filename: String) -> Result<String, String> {
 }
 
 #[tauri::command]
+fn find_backlinks(handle: AppHandle, filename: String) -> Result<Vec<SearchHit>, String> {
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    let filename = NoteFilename::parse(&filename).map_err(|e| e.to_string())?;
+    magical_merchant_core::find_backlinks(&base_dir, &filename).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 fn read_note_meta(handle: AppHandle, filename: String) -> Result<NoteMeta, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
     let filename = NoteFilename::parse(&filename).map_err(|e| e.to_string())?;
@@ -296,6 +303,7 @@ pub fn run() {
             list_notes,
             read_note,
             read_note_meta,
+            find_backlinks,
             update_note_meta,
             set_note_view,
             read_timeline,

--- a/tauri-app/src/components/MarkdownPreview.tsx
+++ b/tauri-app/src/components/MarkdownPreview.tsx
@@ -6,6 +6,8 @@ import type { JSX } from "solid-js";
 
 interface MarkdownPreviewProps {
   source: string;
+  /** `[[ID]]` をタイトルで描くための解決表。無ければ保存形のまま出る。 */
+  noteTitles?: ReadonlyMap<string, string>;
 }
 
 interface ZoomedDiagram {
@@ -61,14 +63,14 @@ export default function MarkdownPreview(props: MarkdownPreviewProps): JSX.Elemen
   createEffect(
     on(
       // mermaid はテーマの色を SVG に焼き込むので、切り替えたら描き直すしかない
-      () => [props.source, resolvedTheme()] as const,
-      async ([source]) => {
+      () => [props.source, resolvedTheme(), props.noteTitles] as const,
+      async ([source, , noteTitles]) => {
         const currentVersion = ++renderVersion;
         if (!source) {
           setHtml("");
           return;
         }
-        const rendered = await renderMarkdown(source);
+        const rendered = await renderMarkdown(source, noteTitles);
         if (currentVersion === renderVersion) {
           setHtml(rendered);
         }

--- a/tauri-app/src/components/MilkdownEditor.tsx
+++ b/tauri-app/src/components/MilkdownEditor.tsx
@@ -17,6 +17,8 @@ import { exitCodeBlockPlugin } from "../lib/exit-code-block-plugin";
 import { codeBlockViewPlugin } from "../lib/code-block-view-plugin";
 import { codeBlockActivePlugin } from "../lib/code-block-active-plugin";
 import { createPlaceholderPlugin } from "../lib/placeholder-plugin";
+import { createNoteLinkPlugin } from "../lib/note-link-plugin";
+import type { NoteLinkTarget } from "../lib/note-link-plugin";
 import { getShikiTheme } from "../lib/theme";
 import type { JSX } from "solid-js";
 
@@ -34,6 +36,8 @@ interface MilkdownEditorProps {
   placeholder?: string;
   onEditorReady?: (editor?: Editor) => void;
   caret?: CaretPoint;
+  /** `[[` の補完候補とチップ表示に使うリンク先。渡したときだけ有効。 */
+  noteLinks?: () => NoteLinkTarget[];
 }
 
 export default function MilkdownEditor(props: MilkdownEditorProps): JSX.Element {
@@ -147,6 +151,7 @@ export default function MilkdownEditor(props: MilkdownEditorProps): JSX.Element 
       .use(codeBlockViewPlugin)
       .use(codeBlockActivePlugin)
       .use(props.placeholder ? createPlaceholderPlugin(props.placeholder) : [])
+      .use(props.noteLinks ? createNoteLinkPlugin(props.noteLinks) : [])
       .create();
 
     placeCaret(editor);

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -70,6 +70,8 @@ interface CommandMap {
   update_timeline_entry: { args: { date: string; index: number; text: string }; result: void };
   delete_timeline_entry: { args: { date: string; index: number }; result: void };
   search_all: { args: { query: string }; result: SearchHit[] };
+  /** このノートを `[[ID]]` で指している記録。開くたびに走査で導出される。 */
+  find_backlinks: { args: { filename: string }; result: SearchHit[] };
   /** 座標 → 地名。引けたものだけが `["緯度,経度", 地名]` で返る。 */
   resolve_places: { args: { coordinates: [number, number][] }; result: [string, string][] };
   create_draft: {

--- a/tauri-app/src/lib/markdown.ts
+++ b/tauri-app/src/lib/markdown.ts
@@ -1,6 +1,7 @@
 import MarkdownIt from "markdown-it";
 import { getHighlighter } from "./highlighter";
 import { renderDiagrams } from "./mermaid";
+import { noteLinkPlugin } from "./note-link-markdown";
 import { isPreservedEmptyLine } from "./preserved-empty-line";
 import { tagPlugin } from "./tag-markdown";
 
@@ -30,9 +31,13 @@ const md = new MarkdownIt({
 
 md.use(tagPlugin);
 md.use(preservedEmptyLinePlugin);
+md.use(noteLinkPlugin);
 
-export function renderMarkdownSync(source: string): string {
-  return md.render(source);
+export function renderMarkdownSync(
+  source: string,
+  noteTitles?: ReadonlyMap<string, string>,
+): string {
+  return md.render(source, { noteTitles });
 }
 
 interface FenceBlock {
@@ -42,6 +47,7 @@ interface FenceBlock {
 
 interface RenderEnv {
   __fenceBlocks?: FenceBlock[];
+  noteTitles?: ReadonlyMap<string, string>;
 }
 
 const fenceMd = new MarkdownIt({
@@ -52,6 +58,7 @@ const fenceMd = new MarkdownIt({
 
 fenceMd.use(tagPlugin);
 fenceMd.use(preservedEmptyLinePlugin);
+fenceMd.use(noteLinkPlugin);
 
 /**
  * フェンスの描画結果を差し込む目印。markdown-it は CommonMark どおり入力中の U+0000 を
@@ -137,8 +144,11 @@ function fillSlots(html: string, rendered: string[]): string {
   return parts.map((part, index) => (index === 0 ? part : rendered[index - 1] + part)).join("");
 }
 
-export async function renderMarkdown(source: string): Promise<string> {
-  const env: RenderEnv = {};
+export async function renderMarkdown(
+  source: string,
+  noteTitles?: ReadonlyMap<string, string>,
+): Promise<string> {
+  const env: RenderEnv = { noteTitles };
   const html = fenceMd.render(source, env);
 
   const blocks = env.__fenceBlocks;

--- a/tauri-app/src/lib/note-link-markdown.test.ts
+++ b/tauri-app/src/lib/note-link-markdown.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { renderMarkdownSync } from "./markdown";
+
+const TITLES = new Map([["20260813_083000", "短いメモ"]]);
+
+describe("note links in the preview", () => {
+  it("renders a known link as its resolved title", () => {
+    const html = renderMarkdownSync("見よ [[20260813_083000]] を", TITLES);
+
+    expect(html).toContain('data-file="20260813_083000.md"');
+    expect(html).toContain("短いメモ");
+    expect(html).not.toContain("[[20260813_083000]]");
+  });
+
+  // 指し先が消えたリンク。タイトルに化けさせると「あるはずのノート」に
+  // 見えてしまうので、保存形のまま出す
+  it("leaves an unresolvable link as raw text", () => {
+    const html = renderMarkdownSync("[[20990101_000000]]", TITLES);
+
+    expect(html).toContain("[[20990101_000000]]");
+    expect(html).not.toContain("data-file");
+  });
+
+  it("does not touch links inside code spans", () => {
+    const html = renderMarkdownSync("`[[20260813_083000]]`", TITLES);
+
+    expect(html).toContain("[[20260813_083000]]");
+    expect(html).not.toContain("data-file");
+  });
+
+  it("escapes a hostile title", () => {
+    const titles = new Map([["20260813_083000", '<img src="x">']]);
+    const html = renderMarkdownSync("[[20260813_083000]]", titles);
+
+    expect(html).not.toContain("<img");
+  });
+
+  it("renders without a title map as before", () => {
+    expect(renderMarkdownSync("[[20260813_083000]]")).toContain("[[20260813_083000]]");
+  });
+});

--- a/tauri-app/src/lib/note-link-markdown.ts
+++ b/tauri-app/src/lib/note-link-markdown.ts
@@ -1,0 +1,56 @@
+import type MarkdownIt from "markdown-it";
+import type Token from "markdown-it/lib/token.mjs";
+import type StateCore from "markdown-it/lib/rules_core/state_core.mjs";
+import { noteLinkFile, splitNoteLinks } from "./note-link";
+
+/** 描画時に渡す、ID → タイトルの解決表。 */
+interface NoteLinkEnv {
+  noteTitles?: ReadonlyMap<string, string>;
+}
+
+function split(
+  md: MarkdownIt,
+  state: StateCore,
+  token: Token,
+  titles: ReadonlyMap<string, string>,
+): Token[] {
+  const segments = splitNoteLinks(token.content);
+  if (!segments.some((segment) => segment.id !== null && titles.has(segment.id))) {
+    return [token];
+  }
+
+  return segments.map((segment) => {
+    const title = segment.id === null ? undefined : titles.get(segment.id);
+    // 指し先の消えたリンクはタイトルに化けさせず、保存形のまま見せる
+    if (segment.id === null || title === undefined) {
+      const text = new state.Token("text", "", 0);
+      text.content = segment.text;
+      return text;
+    }
+    const html = new state.Token("html_inline", "", 0);
+    html.content = `<a class="note-link" data-file="${noteLinkFile(segment.id)}">${md.utils.escapeHtml(title)}</a>`;
+    return html;
+  });
+}
+
+/**
+ * 本文の `[[ID]]` をタイトル表示のリンクにする markdown-it プラグイン。
+ *
+ * tagPlugin と同じく `text` トークンだけを割るので、コードスパンや
+ * フェンスの中身には手が入らない。
+ */
+export function noteLinkPlugin(md: MarkdownIt): void {
+  md.core.ruler.push("note_link", (state) => {
+    const titles = (state.env as NoteLinkEnv).noteTitles;
+    if (!titles || titles.size === 0) {
+      return;
+    }
+    const inline = state.tokens.filter((block) => block.type === "inline" && block.children);
+    for (const block of inline) {
+      block.children =
+        block.children?.flatMap((token) =>
+          token.type === "text" ? split(md, state, token, titles) : [token],
+        ) ?? null;
+    }
+  });
+}

--- a/tauri-app/src/lib/note-link-plugin.ts
+++ b/tauri-app/src/lib/note-link-plugin.ts
@@ -1,0 +1,234 @@
+import { $prose } from "@milkdown/kit/utils";
+import { Plugin, TextSelection } from "@milkdown/kit/prose/state";
+import { Decoration, DecorationSet } from "@milkdown/kit/prose/view";
+import type { EditorView } from "@milkdown/kit/prose/view";
+import type { Node as ProseNode } from "@milkdown/kit/prose/model";
+import type { MilkdownPlugin } from "@milkdown/kit/ctx";
+import { isImeComposing } from "./ime";
+import { splitNoteLinks } from "./note-link";
+
+/** リンク先の候補。Workspace が今の一覧から作って渡す。 */
+export interface NoteLinkTarget {
+  id: string;
+  title: string;
+}
+
+interface LinkRange {
+  from: number;
+  to: number;
+  id: string;
+}
+
+/** 文書中の `[[ID]]` の位置を集める。 */
+function linkRanges(doc: ProseNode): LinkRange[] {
+  const ranges: LinkRange[] = [];
+  doc.descendants((node, pos) => {
+    if (!node.isText || !node.text?.includes("[[")) {
+      return;
+    }
+    let offset = 0;
+    for (const segment of splitNoteLinks(node.text)) {
+      if (segment.id !== null) {
+        ranges.push({ from: pos + offset, to: pos + offset + segment.text.length, id: segment.id });
+      }
+      offset += segment.text.length;
+    }
+  });
+  return ranges;
+}
+
+function titleOf(targets: NoteLinkTarget[], id: string): string | undefined {
+  return targets.find((target) => target.id === id)?.title;
+}
+
+/** `[[` を打っている途中の補完候補ポップアップ。それ以外のときは何も出さない。 */
+class NoteLinkSuggest {
+  private readonly root: HTMLDivElement;
+  private readonly view: EditorView;
+  private readonly targets: () => NoteLinkTarget[];
+  private items: NoteLinkTarget[] = [];
+  private cursor = 0;
+  private matchFrom = -1;
+
+  constructor(view: EditorView, targets: () => NoteLinkTarget[]) {
+    this.view = view;
+    this.targets = targets;
+    this.root = document.createElement("div");
+    this.root.className = "note-link-suggest";
+    this.root.style.display = "none";
+    document.body.append(this.root);
+  }
+
+  update(view: EditorView): void {
+    const { state } = view;
+    const { $from, empty } = state.selection;
+    if (!empty || !$from.parent.isTextblock) {
+      this.hide();
+      return;
+    }
+    const before = $from.parent.textBetween(0, $from.parentOffset, "\n", "\n");
+    const match = /\[\[([^\n[\]]*)$/.exec(before);
+    if (!match) {
+      this.hide();
+      return;
+    }
+    const [, query] = match;
+    this.matchFrom = $from.pos - query.length;
+    this.items = this.targets()
+      .filter((t) => t.title.includes(query) || t.id.startsWith(query))
+      .slice(0, 6);
+    if (this.items.length === 0) {
+      this.hide();
+      return;
+    }
+    this.cursor = Math.min(this.cursor, this.items.length - 1);
+    this.render(view);
+  }
+
+  /** ポップアップが出ている間だけ矢印と Enter を横取りする。 */
+  handleKey(event: KeyboardEvent): boolean {
+    if (this.root.style.display === "none") {
+      return false;
+    }
+    if (event.key === "ArrowDown") {
+      this.cursor = (this.cursor + 1) % this.items.length;
+      this.render(this.view);
+      return true;
+    }
+    if (event.key === "ArrowUp") {
+      this.cursor = (this.cursor - 1 + this.items.length) % this.items.length;
+      this.render(this.view);
+      return true;
+    }
+    // 変換確定の Enter は IME のもの。候補の確定には使わない (#102)
+    if (event.key === "Enter" && !isImeComposing(event)) {
+      this.pick(this.items[this.cursor]);
+      return true;
+    }
+    if (event.key === "Escape") {
+      this.hide();
+      return true;
+    }
+    return false;
+  }
+
+  private pick(target: NoteLinkTarget | undefined): void {
+    if (!target) {
+      return;
+    }
+    const { state } = this.view;
+    // 打ちかけの `[[query` を `[[ID]]` に完成させる
+    this.view.dispatch(state.tr.insertText(`${target.id}]]`, this.matchFrom, state.selection.from));
+    this.view.focus();
+    this.hide();
+  }
+
+  private render(view: EditorView): void {
+    this.root.replaceChildren(
+      ...this.items.map((target, index) => {
+        const row = document.createElement("button");
+        row.type = "button";
+        row.className = "note-link-suggest-item";
+        row.classList.toggle("note-link-suggest-item--active", index === this.cursor);
+        row.textContent = target.title;
+        // click より前の mousedown でエディタがフォーカスを失うのを防ぐ
+        row.addEventListener("mousedown", (e) => {
+          e.preventDefault();
+          this.pick(target);
+        });
+        return row;
+      }),
+    );
+    const coords = view.coordsAtPos(view.state.selection.from);
+    this.root.style.display = "block";
+    this.root.style.top = `${coords.bottom + 4}px`;
+    this.root.style.left = `${coords.left}px`;
+  }
+
+  private hide(): void {
+    this.root.style.display = "none";
+  }
+
+  destroy(): void {
+    this.root.remove();
+  }
+}
+
+/**
+ * `[[ID]]` のリンクをタイトルのチップとして見せる Milkdown プラグイン束。
+ *
+ * スキーマにノードは足さない — 保存形はあくまで本文中のプレーンテキストで、
+ * 装飾(decoration)が表示だけをタイトルに差し替える。カーソルが範囲に
+ * 触れている間は保存形をそのまま見せる(コードブロックの is-active と
+ * 同じ流儀)。
+ */
+export function createNoteLinkPlugin(targets: () => NoteLinkTarget[]): MilkdownPlugin[] {
+  const decorations = $prose(
+    () =>
+      new Plugin({
+        props: {
+          decorations(state) {
+            // 速い経路: リンクの無い文書を毎打鍵ごとに走査しない
+            if (!state.doc.textContent.includes("[[")) {
+              return DecorationSet.empty;
+            }
+            const { from, to } = state.selection;
+            const decos: Decoration[] = [];
+            for (const range of linkRanges(state.doc)) {
+              // 端に触れただけでも保存形に戻す。隣で打っていて急に化けない
+              if (from <= range.to && to >= range.from) {
+                decos.push(Decoration.inline(range.from, range.to, { class: "note-link-source" }));
+              } else {
+                decos.push(
+                  Decoration.inline(range.from, range.to, { class: "note-link-hidden" }),
+                  Decoration.widget(
+                    range.from,
+                    (view) => {
+                      const chip = document.createElement("span");
+                      chip.className = "note-link-chip";
+                      chip.textContent = titleOf(targets(), range.id) ?? `[[${range.id}]]`;
+                      // 押すとカーソルが中に入り、保存形が現れて編集できる
+                      chip.addEventListener("mousedown", (e) => {
+                        e.preventDefault();
+                        view.dispatch(
+                          view.state.tr.setSelection(
+                            TextSelection.create(view.state.doc, range.from + 2),
+                          ),
+                        );
+                        view.focus();
+                      });
+                      return chip;
+                    },
+                    { side: 1 },
+                  ),
+                );
+              }
+            }
+            return DecorationSet.create(state.doc, decos);
+          },
+        },
+      }),
+  );
+
+  let suggest: NoteLinkSuggest | undefined;
+  const autocomplete = $prose(
+    () =>
+      new Plugin({
+        view(editorView) {
+          suggest = new NoteLinkSuggest(editorView, targets);
+          return {
+            update: (view) => suggest?.update(view),
+            destroy: () => {
+              suggest?.destroy();
+              suggest = undefined;
+            },
+          };
+        },
+        props: {
+          handleKeyDown: (_view, event) => suggest?.handleKey(event) ?? false,
+        },
+      }),
+  );
+
+  return [decorations, autocomplete];
+}

--- a/tauri-app/src/lib/note-link.test.ts
+++ b/tauri-app/src/lib/note-link.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { noteLinkFile, splitNoteLinks } from "./note-link";
+
+describe("splitNoteLinks", () => {
+  it("returns the whole text when there is no link", () => {
+    expect(splitNoteLinks("ただの本文")).toEqual([{ text: "ただの本文", id: null }]);
+  });
+
+  it("splits text around a link", () => {
+    expect(splitNoteLinks("前 [[20260813_083000]] 後")).toEqual([
+      { text: "前 ", id: null },
+      { text: "[[20260813_083000]]", id: "20260813_083000" },
+      { text: " 後", id: null },
+    ]);
+  });
+
+  it("finds every link in the text", () => {
+    const segments = splitNoteLinks("[[20260813_083000]][[20260810_090000]]");
+    expect(segments.map((s) => s.id)).toEqual(["20260813_083000", "20260810_090000"]);
+  });
+
+  // ファイル名はゼロ埋めの日時と決まっている。それ以外の [[...]] は
+  // ユーザーの本文であって、リンクに化けてはいけない
+  it("leaves non-filename brackets alone", () => {
+    expect(splitNoteLinks("[[wiki 風のメモ]]")).toEqual([{ text: "[[wiki 風のメモ]]", id: null }]);
+  });
+});
+
+describe("noteLinkFile", () => {
+  it("turns a link id into the note filename", () => {
+    expect(noteLinkFile("20260813_083000")).toBe("20260813_083000.md");
+  });
+});

--- a/tauri-app/src/lib/note-link.ts
+++ b/tauri-app/src/lib/note-link.ts
@@ -1,0 +1,33 @@
+/**
+ * ノート間リンクの保存形は `[[YYYYMMDD_HHMMSS]]`。ファイル名(不変の ID)を
+ * 指すのでタイトルを変えてもリンクは切れない。表示側が毎回タイトルに
+ * 解決する — 解決結果はどこにも書かない。
+ */
+
+const LINK = /\[\[(\d{8}_\d{6})\]\]/g;
+
+export interface NoteLinkSegment {
+  text: string;
+  /** リンクなら指し先の ID(拡張子なしのファイル名)。地の文なら null。 */
+  id: string | null;
+}
+
+export function splitNoteLinks(text: string): NoteLinkSegment[] {
+  const segments: NoteLinkSegment[] = [];
+  let last = 0;
+  for (const match of text.matchAll(LINK)) {
+    if (match.index > last) {
+      segments.push({ text: text.slice(last, match.index), id: null });
+    }
+    segments.push({ text: match[0], id: match[1] });
+    last = match.index + match[0].length;
+  }
+  if (last < text.length || segments.length === 0) {
+    segments.push({ text: text.slice(last), id: null });
+  }
+  return segments;
+}
+
+export function noteLinkFile(id: string): string {
+  return `${id}.md`;
+}

--- a/tauri-app/src/styles/editor.css
+++ b/tauri-app/src/styles/editor.css
@@ -343,3 +343,61 @@
 .milkdown-link-edit .button.confirm:hover {
   opacity: 0.9;
 }
+
+/* ---- ノート間リンク [[ID]] ---- */
+
+/* カーソルが離れている間、保存形のテキストはチップの裏に隠れる。
+   display: none にしないのはカーソル移動の位置を壊さないため */
+.note-link-hidden {
+  font-size: 0;
+}
+
+/* カーソルが触れている間は保存形をそのまま見せる */
+.note-link-source {
+  background: var(--app-accent-soft);
+  border-radius: 3px;
+}
+
+.note-link-chip {
+  display: inline;
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: var(--app-accent-soft);
+  color: var(--app-accent);
+  cursor: pointer;
+}
+
+/* [[ を打っている間だけ出る補完候補 */
+.note-link-suggest {
+  position: fixed;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  min-width: 180px;
+  max-width: 320px;
+  padding: 4px;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-2);
+  background: var(--app-surface);
+  box-shadow: var(--shadow-3);
+}
+
+.note-link-suggest-item {
+  padding: 6px 10px;
+  border: none;
+  border-radius: var(--radius-1);
+  background: none;
+  color: var(--app-text);
+  font-family: inherit;
+  font-size: 13px;
+  text-align: start;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.note-link-suggest-item:hover,
+.note-link-suggest-item--active {
+  background: var(--app-accent-soft);
+}

--- a/tauri-app/src/styles/markdown-preview.css
+++ b/tauri-app/src/styles/markdown-preview.css
@@ -133,3 +133,14 @@
   color: var(--shiki-dark);
   background-color: transparent;
 }
+
+/* ---- ノート間リンク。タイトルで描かれ、押すとそのノートが開く ---- */
+
+.markdown-preview .note-link {
+  color: var(--app-accent);
+  background: var(--app-accent-soft);
+  border-radius: 4px;
+  padding: 1px 4px;
+  cursor: pointer;
+  text-decoration: none;
+}

--- a/tauri-app/src/styles/workspace.css
+++ b/tauri-app/src/styles/workspace.css
@@ -427,3 +427,65 @@
   --markmap-code-bg: var(--app-surface-2);
   --markmap-code-color: var(--app-text);
 }
+
+/* ---- バックリンク(このノートを指している記録) ---- */
+
+.backlinks {
+  margin-top: 40px;
+  border-top: 1px solid var(--app-hairline);
+  padding-top: 10px;
+}
+
+.backlinks-summary {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--app-text-faint);
+  cursor: pointer;
+  user-select: none;
+}
+
+.backlinks-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 6px;
+}
+
+.backlink-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border: none;
+  border-radius: var(--radius-2);
+  background: none;
+  color: var(--app-text-muted);
+  font-family: inherit;
+  font-size: 13px;
+  text-align: start;
+  cursor: pointer;
+}
+
+.backlink-row:hover {
+  background: var(--app-surface-2);
+  color: var(--app-text);
+}
+
+.backlink-row .icon {
+  flex-shrink: 0;
+  color: var(--app-text-faint);
+}
+
+.backlink-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.backlink-date {
+  margin-left: auto;
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--app-text-hint);
+  font-variant-numeric: tabular-nums;
+}

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -11,7 +11,7 @@ import {
   onCleanup,
 } from "solid-js";
 import type { JSX } from "solid-js";
-import { useSearchParams } from "@solidjs/router";
+import { useNavigate, useSearchParams } from "@solidjs/router";
 import type { Editor } from "@milkdown/kit/core";
 import Icon from "../components/Icon";
 import MarkdownPreview from "../components/MarkdownPreview";
@@ -31,6 +31,9 @@ import {
   writeBackup,
 } from "../lib/edit-backup";
 import type { CaretPoint } from "../components/MilkdownEditor";
+import type { NoteLinkTarget } from "../lib/note-link-plugin";
+import type { SearchHit } from "../lib/commands";
+import { ROUTES } from "../lib/routes";
 
 // Milkdown + ProseMirror は編集を始めるまで要らない。一覧とプレビューだけの
 // 表示をこの重さから切り離す
@@ -63,6 +66,7 @@ function EmptyNotes(): JSX.Element {
 
 export default function Workspace(): JSX.Element {
   const shell = useShell();
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const today = new Date();
 
@@ -102,6 +106,32 @@ export default function Workspace(): JSX.Element {
     const items = visibleItems();
     return items.find((item) => item.id === selectedId()) ?? items[0];
   });
+
+  /** `[[ID]]` → タイトルの解決表。プレビューが毎回これを引いて描く。 */
+  const noteTitles = createMemo<ReadonlyMap<string, string>>(
+    () => new Map(visibleItems().map((item) => [item.filename.replace(/\.md$/, ""), item.title])),
+  );
+
+  /** `[[` 補完の候補。自分自身へのリンクは出さない。 */
+  const linkTargets = (): NoteLinkTarget[] =>
+    visibleItems()
+      .filter((item) => item.id !== selected()?.id)
+      .map((item) => ({ id: item.filename.replace(/\.md$/, ""), title: item.title }));
+
+  // このノートを [[ID]] で指している記録。開くたびに走査で導出される
+  const [backlinks] = createResource(
+    () => selected()?.filename,
+    (filename) => typedInvoke("find_backlinks", { filename }),
+  );
+
+  const openBacklink = (hit: SearchHit): void => {
+    if (hit.kind === "note" && hit.filename) {
+      setSelectedId(hit.filename);
+      setDetailOpen(true);
+    } else {
+      navigate(`${ROUTES.TIMELINE}?day=${hit.date}`);
+    }
+  };
 
   // ウィジェットの行から `?file=` 付きで来たときだけ、その 1 件を開く。
   // 一覧が届く前に来ることがあるが、id はファイル名そのものなので先に置ける
@@ -243,8 +273,16 @@ export default function Workspace(): JSX.Element {
       return;
     }
     const target = e.target instanceof Element ? e.target : null;
-    // リンクは踏める・図はズームのまま。編集に化けさせない
-    if (target?.closest("a, button, .mermaid-block, .mermaid-zoom")) {
+    // ノートリンクはこのアプリの中で解決する。href の無い a なので自前で開く
+    const noteLink = target?.closest("a.note-link");
+    if (noteLink instanceof HTMLElement && noteLink.dataset.file) {
+      setSelectedId(noteLink.dataset.file);
+      setDetailOpen(true);
+      return;
+    }
+    // リンクは踏める・図はズームのまま・バックリンク欄は一覧のまま。
+    // 編集に化けさせない
+    if (target?.closest("a, button, .mermaid-block, .mermaid-zoom, .backlinks")) {
       return;
     }
     // 本文をなぞってコピーしたいだけのときも編集へ切り替えない
@@ -492,7 +530,39 @@ export default function Workspace(): JSX.Element {
                   fallback={
                     <Show
                       when={noteView() === "mindmap"}
-                      fallback={<MarkdownPreview source={noteBody()} />}
+                      fallback={
+                        <>
+                          <MarkdownPreview source={noteBody()} noteTitles={noteTitles()} />
+                          {/* このノートを指している記録。畳んだ 1 行以上の場所は取らない */}
+                          <Show when={(backlinks() ?? []).length > 0}>
+                            <details class="backlinks">
+                              <summary class="backlinks-summary">
+                                リンクされている記録 ({(backlinks() ?? []).length})
+                              </summary>
+                              <div class="backlinks-list">
+                                <For each={backlinks()}>
+                                  {(hit) => (
+                                    <button
+                                      type="button"
+                                      class="backlink-row"
+                                      onClick={() => openBacklink(hit)}
+                                    >
+                                      <Icon
+                                        name={hit.kind === "note" ? "file-text" : "lightning"}
+                                        size={14}
+                                      />
+                                      <span class="backlink-title">{hit.title || hit.snippet}</span>
+                                      <span class="backlink-date">
+                                        {hit.date.slice(5).replace("-", "/")}
+                                      </span>
+                                    </button>
+                                  )}
+                                </For>
+                              </div>
+                            </details>
+                          </Show>
+                        </>
+                      }
                     >
                       <MindmapView source={noteBody()} />
                     </Show>
@@ -501,6 +571,7 @@ export default function Workspace(): JSX.Element {
                   <MilkdownEditor
                     placeholder="ノートを書く…"
                     caret={tapCaret()}
+                    noteLinks={linkTargets}
                     defaultValue={draft()}
                     onChange={(markdown) => {
                       setDraft(markdown);


### PR DESCRIPTION
## なぜやるか

capture-to-writing 計画の Phase 4 (1d)。ノート同士を繋ぐ手段がなく、関連する記録は検索で探し直すしかなかった。

## やったこと

- 保存形 `[[YYYYMMDD_HHMMSS]]`(ファイル名 = 不変 ID)のノート間リンク。タイトルを変えてもリンクは切れず、表示側が毎回タイトルに解決する
- エディタ: スキーマにノードを足さず decoration で表示だけタイトルのチップに差し替え(カーソルが触れている間は保存形を見せる、コードブロック is-active と同じ流儀)。補完は `[[` 入力中だけ出るポップアップで常設クロームなし
- プレビュー: markdown-it プラグインでタイトル表示のリンクに変換。クリックでそのノートへ(コードスパン内は対象外)
- バックリンク: core の `find_backlinks` が開くたびに走査で導出(インデックスなし)。preview は先頭 100 文字しかないため全文を読む。ノート詳細の畳めるフッター「リンクされている記録」から各記録へ着地

## やらなかったこと

- remark のインライン拡張(保存形がプレーンテキストである以上パーサに教えることがない)
- MCP へのバックリンク公開(計画でも later 扱い)
