### PR TITLE
feat(timeline): weekly digest card at the top of the journal

### DIFF
--- a/tauri-app/dev/ipc-mock.js
+++ b/tauri-app/dev/ipc-mock.js
@@ -156,6 +156,13 @@
   // バックリンク検証用: 昨日のエントリからも 短いメモ を指しておく
   timeline.get(isoDaysAgo(1))?.push(`- [21:00:00] 昨日の続きは [[20260813_083000]] にまとめた`);
 
+  // 週次ダイジェストの「1年前の今日」検証用
+  {
+    const yearAgo = new Date(today.getFullYear() - 1, today.getMonth(), today.getDate());
+    const iso = `${yearAgo.getFullYear()}-${pad(yearAgo.getMonth() + 1)}-${pad(yearAgo.getDate())}`;
+    timeline.set(iso, [`- [12:00:00] 一年前のきょうの記録`]);
+  }
+
   const noteList = () =>
     [...notes.entries()]
       .toSorted(([a], [b]) => b.localeCompare(a))

--- a/tauri-app/src/lib/weekly-digest.test.ts
+++ b/tauri-app/src/lib/weekly-digest.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { digestWeekKey, isDigestDismissed, summarizeWeek, yearAgoToday } from "./weekly-digest";
+import type { TimelineItem } from "./items";
+
+/** 2026-08-16 は日曜。その週の月曜は 08-10。 */
+const SUNDAY = new Date(2026, 7, 16);
+const MONDAY = new Date(2026, 7, 10);
+
+function entry(date: string, text: string): TimelineItem {
+  return {
+    kind: "timeline",
+    id: `${date}#0`,
+    date,
+    index: 0,
+    raw: text,
+    text,
+    time: "09:00:00",
+    context: null,
+  };
+}
+
+describe("digestWeekKey", () => {
+  it("keys a week by its monday", () => {
+    expect(digestWeekKey(SUNDAY)).toBe("2026-08-10");
+  });
+
+  it("a monday keys itself", () => {
+    expect(digestWeekKey(MONDAY)).toBe("2026-08-10");
+  });
+});
+
+describe("isDigestDismissed", () => {
+  it("is not dismissed when nothing was stored", () => {
+    expect(isDigestDismissed(null, SUNDAY)).toBe(false);
+  });
+
+  it("is dismissed for the rest of the same week", () => {
+    expect(isDigestDismissed("2026-08-10", SUNDAY)).toBe(true);
+  });
+
+  // 先週閉じたカードが今週も出ないなら「週に一度」ではない
+  it("reappears the next week", () => {
+    expect(isDigestDismissed("2026-08-03", SUNDAY)).toBe(false);
+  });
+});
+
+describe("summarizeWeek", () => {
+  it("is empty with no entries", () => {
+    expect(summarizeWeek([], SUNDAY)).toEqual({ count: 0, days: 0, topTags: [] });
+  });
+
+  it("counts entries and distinct days within the week", () => {
+    const summary = summarizeWeek(
+      [
+        entry("2026-08-15", "a #sync"),
+        entry("2026-08-15", "b #sync"),
+        entry("2026-08-11", "c #perf"),
+      ],
+      SUNDAY,
+    );
+
+    expect(summary.count).toBe(3);
+    expect(summary.days).toBe(2);
+    expect(summary.topTags.map((t) => t.tag)).toEqual(["sync", "perf"]);
+  });
+
+  // 先週のエントリを混ぜると「今週のふりかえり」ではなくなる
+  it("ignores entries before the week started", () => {
+    const summary = summarizeWeek([entry("2026-08-09", "old")], SUNDAY);
+
+    expect(summary.count).toBe(0);
+  });
+
+  it("caps the tags at three", () => {
+    const summary = summarizeWeek([entry("2026-08-15", "#a #a #b #b #c #d")], SUNDAY);
+
+    expect(summary.topTags).toHaveLength(3);
+  });
+});
+
+describe("yearAgoToday", () => {
+  it("returns the date when it has entries", () => {
+    expect(yearAgoToday(SUNDAY, ["2025-08-16", "2025-08-15"])).toBe("2025-08-16");
+  });
+
+  it("returns null when that day has no entries", () => {
+    expect(yearAgoToday(SUNDAY, ["2025-08-15"])).toBeNull();
+  });
+});

--- a/tauri-app/src/lib/weekly-digest.ts
+++ b/tauri-app/src/lib/weekly-digest.ts
@@ -1,0 +1,52 @@
+/**
+ * タイムライン先頭に週 1 回だけ出すふりかえりカードの材料。
+ *
+ * すべて読み込み済みのタイムラインと日付一覧からの集計で、core にも
+ * データファイルにも何も書かない。閉じた記録だけを端末ローカル
+ * (localStorage)に持つ — どの端末で閉じたかは他の端末に関係ない。
+ */
+
+import { toIsoDate } from "./day-labels";
+import type { TimelineItem } from "./items";
+import { countTags } from "./tags";
+import type { TagCount } from "./tags";
+
+const TOP_TAGS = 3;
+
+/** 週の身元は月曜の日付。閉じた週と今の週の比較に使う。 */
+export function digestWeekKey(today: Date): string {
+  // getDay(): 日曜 0。月曜起点に写像する
+  const sinceMonday = (today.getDay() + 6) % 7;
+  const monday = new Date(today.getFullYear(), today.getMonth(), today.getDate() - sinceMonday);
+  return toIsoDate(monday);
+}
+
+/** 閉じたのが今週なら出さない。週が変われば出し直す。 */
+export function isDigestDismissed(stored: string | null, today: Date): boolean {
+  return stored === digestWeekKey(today);
+}
+
+export interface WeekSummary {
+  /** 今週のエントリ数。 */
+  count: number;
+  /** 記録のあった日数。 */
+  days: number;
+  topTags: TagCount[];
+}
+
+/** 今週(月曜起点)のエントリだけを数える。 */
+export function summarizeWeek(items: TimelineItem[], today: Date): WeekSummary {
+  const start = digestWeekKey(today);
+  const week = items.filter((item) => item.date >= start && item.date <= toIsoDate(today));
+  return {
+    count: week.length,
+    days: new Set(week.map((item) => item.date)).size,
+    topTags: countTags(week.map((item) => item.text)).slice(0, TOP_TAGS),
+  };
+}
+
+/** 1 年前の今日。記録が無い日は出しても着地する先がないので null。 */
+export function yearAgoToday(today: Date, recordedDates: string[]): string | null {
+  const target = toIsoDate(new Date(today.getFullYear() - 1, today.getMonth(), today.getDate()));
+  return recordedDates.includes(target) ? target : null;
+}

--- a/tauri-app/src/styles/timeline.css
+++ b/tauri-app/src/styles/timeline.css
@@ -550,3 +550,89 @@
     border-radius: 12px;
   }
 }
+
+/* ---------------- 週次ダイジェスト ---------------- */
+
+.digest-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 14px 0 4px;
+  padding: 14px 16px;
+  border: 1px solid var(--app-hairline);
+  border-radius: var(--radius-3);
+  background: var(--app-surface-2);
+}
+
+.digest-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.digest-title {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--app-text-faint);
+}
+
+.digest-close {
+  color: var(--app-text-hint);
+  padding: 4px;
+}
+
+.digest-line {
+  margin: 0;
+  font-size: 14px;
+  color: var(--app-text);
+}
+
+.digest-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.digest-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 10px;
+  border: 1px solid var(--app-border);
+  border-radius: 999px;
+  background: var(--app-surface);
+  color: var(--app-text-muted);
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.digest-tag:hover {
+  background: var(--app-accent-soft);
+  color: var(--app-text);
+}
+
+.digest-tag-count {
+  font-size: 11px;
+  color: var(--app-text-hint);
+  font-variant-numeric: tabular-nums;
+}
+
+.digest-year-ago {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  padding: 2px 0;
+  border: none;
+  background: none;
+  color: var(--app-accent);
+  font-family: inherit;
+  font-size: 12.5px;
+  cursor: pointer;
+}
+
+.digest-year-ago:hover {
+  text-decoration: underline;
+}

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -33,10 +33,19 @@ import { entryMeta } from "../lib/timeline-meta";
 import { places } from "../lib/places";
 import { ROUTES } from "../lib/routes";
 import { countTags, parseTags } from "../lib/tags";
+import {
+  digestWeekKey,
+  isDigestDismissed,
+  summarizeWeek,
+  yearAgoToday,
+} from "../lib/weekly-digest";
 import type { DeviceContext } from "../lib/parse-timeline";
 
 /** 一覧に最初から載せる日数。カレンダーで遡ったぶんは都度足す。 */
 const RECENT_DAYS = 14;
+
+/** 週次ダイジェストを閉じた週(月曜の日付)。端末ローカルの表示状態。 */
+const DIGEST_DISMISS_KEY = "weekly-digest-dismissed";
 
 async function loadTimeline(extraDates: string[]): Promise<TimelineItem[]> {
   const dates = await typedInvoke("list_timeline_dates");
@@ -214,6 +223,8 @@ export default function Timeline(): JSX.Element {
   const [notes, { refetch: refetchNotes }] = createResource(async () =>
     toNoteItems(await typedInvoke("list_notes")),
   );
+  // 「1年前の今日」の判定用。読み込むのは直近だけなので、全日付は別に聞く
+  const [allDates] = createResource(() => typedInvoke("list_timeline_dates"));
 
   // 初回は createResource が読む。defer しないとマウント直後に同じ全読みを
   // もう一度走らせ、起動時の IPC がまるごと倍になる
@@ -244,6 +255,31 @@ export default function Timeline(): JSX.Element {
 
   const days = createMemo(() => groupTimelineByDay(visible()));
   const originNotes = createMemo(() => notesByOriginDate(notes() ?? []));
+
+  // ---- 週次ダイジェスト(週に一度、閉じるまで先頭に出る)----
+  const [digestDismissed, setDigestDismissed] = createSignal(
+    localStorage.getItem(DIGEST_DISMISS_KEY),
+  );
+  const weekSummary = createMemo(() => summarizeWeek(entries(), today));
+  const yearAgo = createMemo(() => yearAgoToday(today, allDates() ?? []));
+  const digestVisible = createMemo(() => {
+    if (isDigestDismissed(digestDismissed(), today)) {
+      return false;
+    }
+    // 語ることが何も無い週に空のカードを出さない
+    return weekSummary().count > 0 || yearAgo() !== null;
+  });
+
+  const dismissDigest = (): void => {
+    const key = digestWeekKey(today);
+    localStorage.setItem(DIGEST_DISMISS_KEY, key);
+    setDigestDismissed(key);
+  };
+
+  const jumpToDay = (iso: string): void => {
+    setExtraDates((dates) => (dates.includes(iso) ? dates : [...dates, iso]));
+    setJumpTo(iso);
+  };
 
   // 検索やパレットからの着地 (?day=)。カレンダーで選んだときと同じ経路に
   // 流す — 直近 14 日より前ならデータを足し、その日の見出しまでスクロール
@@ -404,6 +440,52 @@ export default function Timeline(): JSX.Element {
     <div class="timeline">
       <div class="timeline-scroll">
         <div class="timeline-column">
+          <Show when={digestVisible()}>
+            <section class="digest-card" aria-label="今週のふりかえり">
+              <header class="digest-head">
+                <span class="digest-title">今週のふりかえり</span>
+                <button
+                  type="button"
+                  class="icon-button digest-close"
+                  title="今週は閉じる"
+                  aria-label="今週は閉じる"
+                  onClick={dismissDigest}
+                >
+                  <Icon name="x" size={14} />
+                </button>
+              </header>
+              <Show when={weekSummary().count > 0}>
+                <p class="digest-line">
+                  {weekSummary().days}日で{weekSummary().count}件を記録
+                </p>
+              </Show>
+              <Show when={weekSummary().topTags.length > 0}>
+                <div class="digest-tags">
+                  <For each={weekSummary().topTags}>
+                    {(tag) => (
+                      <button
+                        type="button"
+                        class="digest-tag"
+                        onClick={() => setTagFilter(tag.tag)}
+                      >
+                        #{tag.tag}
+                        <span class="digest-tag-count">{tag.count}</span>
+                      </button>
+                    )}
+                  </For>
+                </div>
+              </Show>
+              <Show when={yearAgo()}>
+                {(iso) => (
+                  <button type="button" class="digest-year-ago" onClick={() => jumpToDay(iso())}>
+                    <Icon name="clock-counter-clockwise" size={13} />
+                    1年前の今日の記録を見る
+                  </button>
+                )}
+              </Show>
+            </section>
+          </Show>
+
           <TagFilter
             tags={knownTags()}
             active={tagFilter()}


### PR DESCRIPTION
## なぜやるか

capture-to-writing 計画の Phase 5 (1e)。書きっぱなしの記録を振り返る入り口がなかった。

## やったこと

- タイムライン先頭に週 1 回のふりかえりカード: 今週の件数・日数、よく使ったタグ上位 3(押すと絞り込み)、記録がある場合のみ「1年前の今日」ジャンプ
- すべて読み込み済みデータからの集計で、core にもデータファイルにも書き込みなし
- 閉じた状態は「その週の月曜の日付」で localStorage に保持(端末ローカル)。週が変われば出し直し、語ることがない週はカード自体を出さない

## やらなかったこと

- 集計範囲の拡張(月次など)や既読管理の同期 — 表示の好みは端末ごとで良い
