### PR TITLE
perf(timeline): render the weekly digest without a layout shift

### DIFF
--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -47,7 +47,18 @@ const RECENT_DAYS = 14;
 /** 週次ダイジェストを閉じた週(月曜の日付)。端末ローカルの表示状態。 */
 const DIGEST_DISMISS_KEY = "weekly-digest-dismissed";
 
-async function loadTimeline(extraDates: string[]): Promise<TimelineItem[]> {
+interface TimelineData {
+  items: TimelineItem[];
+  /** 記録のある全日付(新しい順)。ダイジェストの「1年前の今日」判定が使う。 */
+  dates: string[];
+}
+
+/**
+ * 直近の日々と全日付一覧を 1 つの値で返す。別々のリソースに分けると
+ * 描画が別フラッシュになり、先に出た日リストへ後からダイジェストが
+ * 割り込んでレイアウトシフトを起こす。
+ */
+async function loadTimeline(extraDates: string[]): Promise<TimelineData> {
   const dates = await typedInvoke("list_timeline_dates");
   const wanted = [...new Set([...dates.slice(0, RECENT_DAYS), ...extraDates])].toSorted((a, b) =>
     b.localeCompare(a),
@@ -57,7 +68,7 @@ async function loadTimeline(extraDates: string[]): Promise<TimelineItem[]> {
       toTimelineItems(date, await typedInvoke("read_timeline_by_date", { date })),
     ),
   );
-  return days.flat();
+  return { items: days.flat(), dates };
 }
 
 interface EntryProps {
@@ -223,8 +234,6 @@ export default function Timeline(): JSX.Element {
   const [notes, { refetch: refetchNotes }] = createResource(async () =>
     toNoteItems(await typedInvoke("list_notes")),
   );
-  // 「1年前の今日」の判定用。読み込むのは直近だけなので、全日付は別に聞く
-  const [allDates] = createResource(() => typedInvoke("list_timeline_dates"));
 
   // 初回は createResource が読む。defer しないとマウント直後に同じ全読みを
   // もう一度走らせ、起動時の IPC がまるごと倍になる
@@ -239,7 +248,7 @@ export default function Timeline(): JSX.Element {
     ),
   );
 
-  const entries = createMemo(() => timeline() ?? []);
+  const entries = createMemo(() => timeline()?.items ?? []);
   // 地名は記録の一部ではないので、これを待って一覧を出さない。座標のまま先に
   // 並べ、引けたものから名前に差し替わる。
   createEffect(() => void places.load(entries().map((item) => item.context)));
@@ -261,11 +270,13 @@ export default function Timeline(): JSX.Element {
     localStorage.getItem(DIGEST_DISMISS_KEY),
   );
   const weekSummary = createMemo(() => summarizeWeek(entries(), today));
-  const yearAgo = createMemo(() => yearAgoToday(today, allDates() ?? []));
+  const yearAgo = createMemo(() => yearAgoToday(today, timeline()?.dates ?? []));
   const digestVisible = createMemo(() => {
     if (isDigestDismissed(digestDismissed(), today)) {
       return false;
     }
+    // items と dates は同じリソースの 1 値なので、カードと日リストは
+    // 必ず同じフラッシュで描画される(後から割り込んで押し下げない)
     // 語ることが何も無い週に空のカードを出さない
     return weekSummary().count > 0 || yearAgo() !== null;
   });
@@ -305,15 +316,20 @@ export default function Timeline(): JSX.Element {
     document.querySelector(`[data-day="${iso}"]`)?.scrollIntoView({ block: "start" });
     setJumpTo(null);
   });
-  const recordedDates = createMemo(() => [...new Set((timeline() ?? []).map((i) => i.date))]);
+  const recordedDates = createMemo(() => [
+    ...new Set((timeline()?.items ?? []).map((i) => i.date)),
+  ]);
 
   const contextsFor = (iso: string): (DeviceContext | null)[] =>
-    (timeline() ?? []).filter((i) => i.date === iso).map((i) => i.context);
+    (timeline()?.items ?? []).filter((i) => i.date === iso).map((i) => i.context);
 
   /** 書いた日だけ読み直す。全日の読み直しは保存 1 回に日数ぶんの IPC を払う。 */
   const reloadDay = async (date: string): Promise<void> => {
     const items = toTimelineItems(date, await typedInvoke("read_timeline_by_date", { date }));
-    mutate((prev) => replaceDayItems(prev ?? [], date, items));
+    mutate((prev) => ({
+      items: replaceDayItems(prev?.items ?? [], date, items),
+      dates: prev?.dates ?? [],
+    }));
   };
 
   const capture = async (text: string): Promise<void> => {
@@ -440,6 +456,16 @@ export default function Timeline(): JSX.Element {
     <div class="timeline">
       <div class="timeline-scroll">
         <div class="timeline-column">
+          <TagFilter
+            tags={knownTags()}
+            active={tagFilter()}
+            matched={visible().length}
+            onToggle={setTagFilter}
+          />
+
+          {/* TagFilter より下に置く: 上に挿すと、データが遅れて届いたとき
+              最初の描画に存在した行が押し下げられてレイアウトシフトになる。
+              ここなら日リストと同じ「後から現れる領域」の先頭に収まる */}
           <Show when={digestVisible()}>
             <section class="digest-card" aria-label="今週のふりかえり">
               <header class="digest-head">
@@ -485,13 +511,6 @@ export default function Timeline(): JSX.Element {
               </Show>
             </section>
           </Show>
-
-          <TagFilter
-            tags={knownTags()}
-            active={tagFilter()}
-            matched={visible().length}
-            onToggle={setTagFilter}
-          />
 
           <Show when={days().length} fallback={<EmptyTimeline filtered={Boolean(tagFilter())} />}>
             <div class="timeline-toolbar">


### PR DESCRIPTION
## なぜやるか

capture-to-writing 5 フェーズ(#111〜#115)マージ後の性能検証。本番ビルド+モック注入で機能追加前(40043fb)と比較したところ、IPC が遅い端末を想定したシナリオ(list_notes 400ms / list_timeline_dates 150ms)で起動 CLS が 0.0000 → 0.0207 に退行していた。原因は週次ダイジェストカードが TagFilter の上に後から挿入され、初回描画に存在した行を押し下げること。

## やったこと

- カードを TagFilter の下(日リストと同じ「後から現れる領域」の先頭)へ移動
- 「1年前の今日」用の全日付一覧を独立リソースにせず `loadTimeline` の返り値 `{items, dates}` に同梱。別リソースだと描画フラッシュが分かれ、先に出た日リストへカードが割り込む(中間案の実測 CLS 0.1476)。同梱なら必ず同一フラッシュで描画され、起動 IPC も 1 本減る

計測(本番 dist +モック注入、390×844):

| 指標 | 機能追加前 | 修正前 | 修正後 |
|---|---|---|---|
| 起動 CLS(遅延 IPC) | 0.0000 | 0.0207 | **0.0000** |
| 起動 CLS(即時 IPC) | 0.0000 | 0.0000 | 0.0000 |
| 打鍵コスト(長文) | 0.17ms/キー | 0.15ms/キー | 同等 |
| 打鍵コスト(長文+30リンク) | — | 0.31ms/キー | 同等 |
| 起動チャンク gzip | 30.15 kB | 31.97 kB | 31.97 kB |

## やらなかったこと

- ライブラリ導入(評価の上で見送り):
  - `prosemirror-autocomplete`(66KB): トリガー検出のみでポップアップ UI・挿入・IME Enter ガード(#102)は自前のまま必要。置き換えても大半のコードが残る
  - `prosemirror-suggest`(307KB + remirror 系): 「軽量」優先に反する
  - `markdown-it-wikilinks`(git 依存 reurl を含む): 静的サイト向け href 生成が前提で、「不変 ID +描画時タイトル解決」の設計と不一致。自前 50 行・依存ゼロが優位
- origin チップ・打鍵コストの追加最適化: 実測で問題なし(チップの遅延挿入はビューポート外のみで CLS 0、リンク 30 個でも 0.31ms/キー)

## 資料

- 計測方法: 本番 dist に ipc-mock をインライン注入して vite preview で配信、buffered `PerformanceObserver({type:'layout-shift'})` と `execCommand('insertText')` の同期時間で前後比較
