### PR TITLE
feat(i18n): a japanese/english interface from one message table

### DIFF
--- a/.claude/skills/ui-design/SKILL.md
+++ b/.claude/skills/ui-design/SKILL.md
@@ -32,6 +32,11 @@ Spacing/typography/radius use Open Props (`var(--size-*)`, `var(--radius-*)`,
 - Toasts go through `shell.showToast(text, undo?)`; destructive actions get a
   5s undo tombstone (see Workspace.remove) rather than a confirm dialog
 - Comments in code explain _why_ (in Japanese, matching the codebase style)
+- **No user-visible string is written inline.** Add it to both tables in
+  `lib/i18n.ts` and read it with `t()` — inside JSX or a memo, so switching
+  the language redraws. Sentences with numbers are functions, not templates.
+  Tests run in Japanese (`src/test-setup.ts`); say `setLocale("en")` to see
+  the other side
 
 ## Layout rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ ready to record the moment it opens (widgets exist for exactly this).
   leading `# heading`); Milkdown editor is lazy-loaded on first edit;
   per-note mindmap view via frontmatter `view`
 - **Command palette** (⌘K): in-memory commands + debounced `search_all`
+- **Language**: Japanese and English only, from one table (`lib/i18n.ts`).
+  Every user-visible string goes through `t()`; the choice lives in Settings
 - There is **no Tasks mode**. Do not add one or reference it.
 
 ## Invariants (never break)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
   search with highlighted matches, exact landing on the note or day
 - **Optional sync** — Cloudflare Workers + R2, conflict-safe, with Android
   home-screen widgets and a read-only MCP server for AI assistants
+- **Japanese and English** — the interface follows your system language and
+  can be pinned either way in Settings
 
 Everything is a plain Markdown file on disk. See the
 **[feature tour](docs/features.md)** for screenshots of each surface.

--- a/docs/features.md
+++ b/docs/features.md
@@ -91,6 +91,13 @@ to that day.
 
 ![Command palette](images/palette.png)
 
+## Language
+
+The interface speaks Japanese or English. It follows the system language on
+first launch and can be pinned either way in Settings → LANGUAGE; the choice
+takes effect immediately, without a restart. Only the interface changes —
+what you wrote stays exactly as you wrote it, and so do your tags.
+
 ## Sync (optional)
 
 A Cloudflare Worker + R2 backend syncs the Markdown files across devices.

--- a/tauri-app/src/components/CalendarPopover.tsx
+++ b/tauri-app/src/components/CalendarPopover.tsx
@@ -5,11 +5,12 @@ import {
   buildMonthGrid,
   formatMonthTitle,
   shiftMonth,
-  WEEKDAY_LABELS,
+  weekdayLabels,
   summarizeDay,
 } from "../lib/calendar";
 import type { DaySummary } from "../lib/calendar";
 import { toIsoDate } from "../lib/day-labels";
+import { t } from "../lib/i18n";
 import { getNetworkIcon } from "../lib/parse-timeline";
 import type { DeviceContext } from "../lib/parse-timeline";
 
@@ -40,23 +41,33 @@ export default function CalendarPopover(props: CalendarPopoverProps): JSX.Elemen
 
   const pickedLabel = createMemo(() => {
     const [, m, d] = picked().split("-");
-    return `${Number(m)}月${Number(d)}日`;
+    return t().calendar.monthDay(Number(m), Number(d));
   });
 
   return (
     <div class="popover calendar-popover">
       <div class="calendar-header">
-        <button type="button" class="icon-button" aria-label="前の月" onClick={() => step(-1)}>
+        <button
+          type="button"
+          class="icon-button"
+          aria-label={t().calendar.prevMonth}
+          onClick={() => step(-1)}
+        >
           <Icon name="caret-left" size={14} />
         </button>
         <span class="calendar-title">{formatMonthTitle(year(), month())}</span>
-        <button type="button" class="icon-button" aria-label="次の月" onClick={() => step(1)}>
+        <button
+          type="button"
+          class="icon-button"
+          aria-label={t().calendar.nextMonth}
+          onClick={() => step(1)}
+        >
           <Icon name="caret-right" size={14} />
         </button>
       </div>
 
       <div class="calendar-grid">
-        <For each={WEEKDAY_LABELS}>{(label) => <span class="calendar-weekday">{label}</span>}</For>
+        <For each={weekdayLabels()}>{(label) => <span class="calendar-weekday">{label}</span>}</For>
         <For each={grid()}>
           {(cell) => (
             <button
@@ -81,7 +92,7 @@ export default function CalendarPopover(props: CalendarPopoverProps): JSX.Elemen
 
       <div class="calendar-summary">
         <span class="calendar-summary-title">
-          {pickedLabel()} — {summary().count}件
+          {pickedLabel()} — {t().timeline.entryCount(summary().count)}
         </span>
         <Show when={summary().count > 0}>
           <span class="calendar-summary-row">

--- a/tauri-app/src/components/CaptureBar.tsx
+++ b/tauri-app/src/components/CaptureBar.tsx
@@ -1,6 +1,7 @@
 import { createSignal, createMemo, For, Show } from "solid-js";
 import type { JSX } from "solid-js";
 import Icon from "./Icon";
+import { t } from "../lib/i18n";
 import { isImeComposing } from "../lib/ime";
 import { matchTagPrefix, tagDraftAt } from "../lib/tags";
 import type { TagCount } from "../lib/tags";
@@ -143,8 +144,8 @@ export default function CaptureBar(props: CaptureBarProps): JSX.Element {
   return (
     <div class="capture-bar">
       <Show when={rows() > 0}>
-        <div class="tag-suggest" role="listbox" aria-label="タグ候補">
-          <span class="tag-suggest-label">タグ</span>
+        <div class="tag-suggest" role="listbox" aria-label={t().capture.suggestLabel}>
+          <span class="tag-suggest-label">{t().common.tags}</span>
           <For each={suggestions()}>
             {(suggestion, i) => (
               <button
@@ -175,7 +176,7 @@ export default function CaptureBar(props: CaptureBarProps): JSX.Element {
                 complete(draft() ?? "");
               }}
             >
-              +「#{draft()}」を新規タグとして確定
+              {t().capture.newTag(draft() ?? "")}
             </button>
           </Show>
         </div>
@@ -185,7 +186,7 @@ export default function CaptureBar(props: CaptureBarProps): JSX.Element {
         ref={textareaRef}
         rows={1}
         class="capture-input"
-        placeholder="What's on your mind?"
+        placeholder={t().capture.placeholder}
         value={text()}
         onInput={(e) => {
           setText(e.currentTarget.value);

--- a/tauri-app/src/components/CommandPalette.tsx
+++ b/tauri-app/src/components/CommandPalette.tsx
@@ -5,6 +5,7 @@ import type { IconName } from "./Icon";
 import { typedInvoke } from "../lib/commands";
 import type { SearchHit } from "../lib/commands";
 import { createDebouncedAccessor } from "../lib/debounce";
+import { t } from "../lib/i18n";
 import { isImeComposing } from "../lib/ime";
 import { toNoteItems } from "../lib/items";
 import { countNoteTags, dayJumpHits, recentNoteHits } from "../lib/palette-home";
@@ -121,7 +122,7 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
         key: `tag:${tag.tag}`,
         icon: "magnifying-glass",
         label: `#${tag.tag}`,
-        meta: `${tag.count}件`,
+        meta: t().palette.count(tag.count),
         run: () => {
           // タグは着地先が一つに決まらないので、検索として引き継ぐ
           setQuery(tag.tag);
@@ -129,10 +130,10 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
         },
       }));
       return [
-        { title: "コマンド", rows: commands },
-        { title: "日付", rows: days },
-        { title: "最近のノート", rows: recent },
-        { title: "タグ", rows: tags },
+        { title: t().palette.commands, rows: commands },
+        { title: t().palette.dates, rows: days },
+        { title: t().palette.recentNotes, rows: recent },
+        { title: t().common.tags, rows: tags },
       ].filter((section) => section.rows.length > 0);
     }
 
@@ -145,8 +146,8 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
       run: () => props.onSelectHit(hit),
     }));
     return [
-      { title: "コマンド", rows: commands },
-      { title: "ノート・エントリ", rows: hitRows },
+      { title: t().palette.commands, rows: commands },
+      { title: t().palette.hits, rows: hitRows },
     ].filter((section) => section.rows.length > 0);
   });
 
@@ -191,14 +192,14 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
         }
       }}
     >
-      <div class="palette" role="dialog" aria-modal="true" aria-label="検索・コマンド">
+      <div class="palette" role="dialog" aria-modal="true" aria-label={t().palette.dialogLabel}>
         <div class="palette-input-row">
           <Icon name="magnifying-glass" size={17} />
           <input
             ref={inputRef}
             type="text"
             class="palette-input"
-            placeholder="検索・コマンド…"
+            placeholder={t().header.searchPlaceholder}
             value={query()}
             onInput={(e) => {
               setQuery(e.currentTarget.value);
@@ -254,7 +255,7 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
           </For>
 
           <Show when={query().trim() && !hits.loading && !hits()?.length}>
-            <p class="palette-empty">一致するものがありません</p>
+            <p class="palette-empty">{t().palette.empty}</p>
           </Show>
         </div>
       </div>

--- a/tauri-app/src/components/FirstRunCard.tsx
+++ b/tauri-app/src/components/FirstRunCard.tsx
@@ -2,6 +2,7 @@ import { createSignal, Show } from "solid-js";
 import type { JSX } from "solid-js";
 import Icon from "./Icon";
 import { typedInvoke } from "../lib/commands";
+import { t } from "../lib/i18n";
 import { isImeComposing } from "../lib/ime";
 
 const DISMISSED_KEY = "first-run-dismissed";
@@ -56,12 +57,12 @@ export default function FirstRunCard(props: FirstRunCardProps): JSX.Element {
         <div class="first-run" role="dialog" aria-modal="true" aria-labelledby="first-run-title">
           <Icon name="cloud-check" size={24} />
           <h2 id="first-run-title" class="first-run-title">
-            同期はあとからでも設定できます
+            {t().firstRun.title}
           </h2>
           <p class="first-run-body">
-            設定しなければ、書いたものはこの端末の中だけに残ります。それで困らないなら、このまま使い始めて構いません。
+            {t().firstRun.body}
             <br />
-            複数の端末で同じ記録を見たくなったら、Workers の URL をここか設定画面で入れてください。
+            {t().firstRun.hint}
           </p>
 
           <input
@@ -89,10 +90,10 @@ export default function FirstRunCard(props: FirstRunCardProps): JSX.Element {
               disabled={!url().trim() || saving()}
               onClick={connect}
             >
-              接続
+              {t().firstRun.connect}
             </button>
             <button type="button" class="button-secondary" onClick={close}>
-              あとで
+              {t().firstRun.later}
             </button>
           </div>
         </div>

--- a/tauri-app/src/components/MarkdownPreview.tsx
+++ b/tauri-app/src/components/MarkdownPreview.tsx
@@ -1,4 +1,5 @@
 import { createSignal, createEffect, on, onCleanup, onMount, Show } from "solid-js";
+import { t } from "../lib/i18n";
 import { renderMarkdown } from "../lib/markdown";
 import { resolvedTheme } from "../lib/theme";
 import Icon from "./Icon";
@@ -44,8 +45,8 @@ function DiagramZoom(props: { diagram: ZoomedDiagram; onClose: () => void }): JS
       <button
         type="button"
         class="icon-button mermaid-zoom-close"
-        title="閉じる"
-        aria-label="閉じる"
+        title={t().common.close}
+        aria-label={t().common.close}
         onClick={() => props.onClose()}
       >
         <Icon name="x" size={18} />

--- a/tauri-app/src/components/MarkdownToolbar.tsx
+++ b/tauri-app/src/components/MarkdownToolbar.tsx
@@ -10,6 +10,7 @@ import {
 } from "@milkdown/kit/preset/commonmark";
 import type { Command } from "@milkdown/kit/prose/state";
 import { deleteCurrentBlock, exitCodeBlock } from "../lib/block-commands";
+import { t } from "../lib/i18n";
 import Icon from "./Icon";
 import type { JSX } from "solid-js";
 
@@ -152,8 +153,8 @@ export default function MarkdownToolbar(props: MarkdownToolbarProps): JSX.Elemen
             type="button"
             onPointerDown={(e) => e.preventDefault()}
             onClick={() => execCommand(exitCodeBlock)}
-            aria-label="ブロックから抜ける"
-            title="ブロックから抜ける"
+            aria-label={t().editor.exitBlock}
+            title={t().editor.exitBlock}
           >
             <Icon name="arrow-line-down" size={18} />
           </button>
@@ -161,8 +162,8 @@ export default function MarkdownToolbar(props: MarkdownToolbarProps): JSX.Elemen
             type="button"
             onPointerDown={(e) => e.preventDefault()}
             onClick={() => execCommand(deleteCurrentBlock)}
-            aria-label="ブロックを削除"
-            title="ブロックを削除"
+            aria-label={t().editor.deleteBlock}
+            title={t().editor.deleteBlock}
           >
             <Icon name="trash" size={18} />
           </button>

--- a/tauri-app/src/components/NoteMetaPopover.tsx
+++ b/tauri-app/src/components/NoteMetaPopover.tsx
@@ -2,6 +2,7 @@ import { createEffect, createResource, createSignal, For, Show } from "solid-js"
 import type { JSX } from "solid-js";
 import Icon from "./Icon";
 import { typedInvoke } from "../lib/commands";
+import { t } from "../lib/i18n";
 import { isImeComposing } from "../lib/ime";
 import {
   addTag,
@@ -80,12 +81,12 @@ export default function NoteMetaPopover(props: NoteMetaPopoverProps): JSX.Elemen
 
   return (
     <div class="popover note-meta-popover">
-      <Show when={!meta.error} fallback={<p class="note-meta-error">メタデータを読み取れません</p>}>
+      <Show when={!meta.error} fallback={<p class="note-meta-error">{t().meta.unreadable}</p>}>
         <Show when={meta()}>
           {(m) => (
             <>
               <label class="note-meta-field">
-                <span class="note-meta-label">作成日時</span>
+                <span class="note-meta-label">{t().meta.createdAt}</span>
                 <input
                   type="datetime-local"
                   class="note-meta-input"
@@ -99,14 +100,14 @@ export default function NoteMetaPopover(props: NoteMetaPopoverProps): JSX.Elemen
               <Show when={m().updated}>
                 {(updated) => (
                   <div class="note-meta-field">
-                    <span class="note-meta-label">更新日時</span>
+                    <span class="note-meta-label">{t().meta.updatedAt}</span>
                     <span class="note-meta-readonly">{formatRecordedAt(updated())}</span>
                   </div>
                 )}
               </Show>
 
               <div class="note-meta-field">
-                <span class="note-meta-label">タグ</span>
+                <span class="note-meta-label">{t().common.tags}</span>
                 <div class="note-meta-tags">
                   <For each={tags()}>
                     {(tag) => (
@@ -115,8 +116,10 @@ export default function NoteMetaPopover(props: NoteMetaPopoverProps): JSX.Elemen
                         <button
                           type="button"
                           class="note-meta-tag-remove"
-                          aria-label={`タグ ${tag} を外す`}
-                          onClick={() => setTags((current) => current.filter((t) => t !== tag))}
+                          aria-label={t().meta.removeTag(tag)}
+                          onClick={() =>
+                            setTags((current) => current.filter((kept) => kept !== tag))
+                          }
                         >
                           <Icon name="x" size={10} />
                         </button>
@@ -127,7 +130,7 @@ export default function NoteMetaPopover(props: NoteMetaPopoverProps): JSX.Elemen
                 <input
                   type="text"
                   class="note-meta-input"
-                  placeholder="タグを追加"
+                  placeholder={t().meta.addTag}
                   value={tagInput()}
                   onInput={(e) => setTagInput(e.currentTarget.value)}
                   onKeyDown={(e) => {
@@ -138,12 +141,12 @@ export default function NoteMetaPopover(props: NoteMetaPopoverProps): JSX.Elemen
                     }
                   }}
                 />
-                <span class="note-meta-hint">作成時の記録。本文の #タグ は本文側で編集</span>
+                <span class="note-meta-hint">{t().meta.tagsHint}</span>
               </div>
 
               <Show when={contextRows(m().context).length > 0}>
                 <div class="note-meta-field">
-                  <span class="note-meta-label">記録時の環境</span>
+                  <span class="note-meta-label">{t().meta.context}</span>
                   <div class="note-meta-context">
                     <For each={contextRows(m().context)}>
                       {(row) => (
@@ -159,24 +162,22 @@ export default function NoteMetaPopover(props: NoteMetaPopoverProps): JSX.Elemen
 
               <Show when={props.revertable}>
                 <div class="note-meta-field">
-                  <span class="note-meta-label">この端末のバックアップ</span>
+                  <span class="note-meta-label">{t().meta.backup}</span>
                   <button
                     type="button"
                     class="button-secondary note-meta-revert"
                     onClick={() => props.onRevert?.()}
                   >
                     <Icon name="clock-counter-clockwise" size={14} />
-                    編集前に戻す
+                    {t().meta.revert}
                   </button>
-                  <span class="note-meta-hint">
-                    直前の編集で上書きした本文と入れ替える。もう一度押すと戻る
-                  </span>
+                  <span class="note-meta-hint">{t().meta.revertHint}</span>
                 </div>
               </Show>
 
               <div class="note-meta-actions">
                 <Show when={failed()}>
-                  <span class="note-meta-error">保存できませんでした</span>
+                  <span class="note-meta-error">{t().meta.saveFailed}</span>
                 </Show>
                 <button
                   type="button"
@@ -184,7 +185,7 @@ export default function NoteMetaPopover(props: NoteMetaPopoverProps): JSX.Elemen
                   disabled={saving()}
                   onClick={() => void save()}
                 >
-                  保存
+                  {t().common.save}
                 </button>
               </div>
             </>

--- a/tauri-app/src/components/SyncPopover.tsx
+++ b/tauri-app/src/components/SyncPopover.tsx
@@ -3,6 +3,7 @@ import type { JSX } from "solid-js";
 import { useNavigate } from "@solidjs/router";
 import Icon from "./Icon";
 import type { IconName } from "./Icon";
+import { t } from "../lib/i18n";
 import { formatRelativeTime } from "../lib/sync";
 import type { SyncState } from "../lib/sync";
 import { ROUTES } from "../lib/routes";
@@ -22,12 +23,15 @@ const FACE_ICONS: Record<Face, IconName> = {
   failed: "cloud-warning",
 };
 
-const FACE_TITLES: Record<Face, string> = {
-  synced: "すべて同期済み",
-  syncing: "同期中…",
-  offline: "同期していません",
-  failed: "同期に失敗しました",
-};
+function faceTitle(face: Face): string {
+  const labels = t().sync;
+  return {
+    synced: labels.synced,
+    syncing: labels.syncing,
+    offline: labels.notSyncing,
+    failed: labels.failed,
+  }[face];
+}
 
 export default function SyncPopover(props: SyncPopoverProps): JSX.Element {
   const navigate = useNavigate();
@@ -53,13 +57,11 @@ export default function SyncPopover(props: SyncPopoverProps): JSX.Element {
     <div class="popover sync-popover" data-face={face()}>
       <div class="sync-popover-head">
         <Icon name={FACE_ICONS[face()]} size={16} />
-        <span class="sync-popover-title">{FACE_TITLES[face()]}</span>
+        <span class="sync-popover-title">{faceTitle(face())}</span>
       </div>
 
       <Show when={face() === "offline"}>
-        <p class="sync-popover-body">
-          書いたものはこの端末の中だけに残ります。他の端末と揃えたいときだけ設定してください。
-        </p>
+        <p class="sync-popover-body">{t().sync.localOnly}</p>
       </Show>
 
       {/* 失敗の理由は言い換えず、返ってきた文をそのまま見せる */}
@@ -68,12 +70,16 @@ export default function SyncPopover(props: SyncPopoverProps): JSX.Element {
       </Show>
 
       <Show when={props.sync.lastSyncedAt()}>
-        {(at) => <p class="sync-popover-detail">最終同期 {formatRelativeTime(at(), new Date())}</p>}
+        {(at) => (
+          <p class="sync-popover-detail">
+            {t().sync.lastSync(formatRelativeTime(at(), new Date()))}
+          </p>
+        )}
       </Show>
 
       <Show when={face() !== "offline"}>
         <label class="sync-popover-toggle">
-          <span>保存時に自動同期</span>
+          <span>{t().sync.autoSync}</span>
           <input
             type="checkbox"
             checked={props.sync.autoSync()}
@@ -95,7 +101,7 @@ export default function SyncPopover(props: SyncPopoverProps): JSX.Element {
                 void props.sync.syncNow();
               }}
             >
-              {face() === "failed" ? "再試行" : "今すぐ同期"}
+              {face() === "failed" ? t().sync.retry : t().sync.now}
             </button>
           }
         >
@@ -107,7 +113,7 @@ export default function SyncPopover(props: SyncPopoverProps): JSX.Element {
               navigate(ROUTES.SETTINGS);
             }}
           >
-            設定を開く
+            {t().sync.openSettings}
           </button>
         </Show>
       </div>

--- a/tauri-app/src/components/TagFilter.tsx
+++ b/tauri-app/src/components/TagFilter.tsx
@@ -1,6 +1,7 @@
 import { For, Show } from "solid-js";
 import type { JSX } from "solid-js";
 import Icon from "./Icon";
+import { t } from "../lib/i18n";
 import type { TagCount } from "../lib/tags";
 
 interface TagFilterProps {
@@ -43,9 +44,9 @@ export default function TagFilter(props: TagFilterProps): JSX.Element {
         <Show when={props.active}>
           {(active) => (
             <span class="tag-filter-status">
-              #{active()} で絞り込み中 · {props.matched}件
+              {t().tagFilter.filtering(active(), props.matched)}
               <button type="button" class="link-button" onClick={() => props.onToggle(null)}>
-                すべて
+                {t().common.all}
               </button>
             </span>
           )}

--- a/tauri-app/src/components/UndoToast.tsx
+++ b/tauri-app/src/components/UndoToast.tsx
@@ -1,5 +1,6 @@
 import { Show } from "solid-js";
 import type { JSX } from "solid-js";
+import { t } from "../lib/i18n";
 import { useShell } from "../lib/shell";
 
 export default function UndoToast(): JSX.Element {
@@ -20,7 +21,7 @@ export default function UndoToast(): JSX.Element {
                   undo()();
                 }}
               >
-                元に戻す
+                {t().common.undo}
               </button>
             )}
           </Show>

--- a/tauri-app/src/layouts/AppLayout.tsx
+++ b/tauri-app/src/layouts/AppLayout.tsx
@@ -10,7 +10,8 @@ import UndoToast from "../components/UndoToast";
 import FirstRunCard from "../components/FirstRunCard";
 import { ShellProvider, useShell } from "../lib/shell";
 import { createSyncState, syncIconName } from "../lib/sync";
-import { applyTheme, nextTheme, readStoredTheme, THEME_ICONS, THEME_LABELS } from "../lib/theme";
+import { applyTheme, nextTheme, readStoredTheme, THEME_ICONS } from "../lib/theme";
+import { t } from "../lib/i18n";
 import type { Theme } from "../lib/theme";
 import { MODE_ICONS, MODE_LABELS, ROUTES } from "../lib/routes";
 import type { RoutePath } from "../lib/routes";
@@ -160,7 +161,7 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
 
         <button type="button" class="search-field" onClick={() => shell.openPalette()}>
           <Icon name="magnifying-glass" size={15} />
-          <span class="search-field-label">検索・コマンド…</span>
+          <span class="search-field-label">{t().header.searchPlaceholder}</span>
           <span class="key-badge">⌘K</span>
         </button>
 
@@ -169,8 +170,8 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
           <button
             type="button"
             class="icon-button header-action header-action--search"
-            title="検索"
-            aria-label="検索"
+            title={t().header.search}
+            aria-label={t().header.search}
             onClick={() => shell.openPalette()}
           >
             <Icon name="magnifying-glass" size={18} />
@@ -180,8 +181,8 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
             <button
               type="button"
               class="icon-button header-action"
-              title="日付ジャンプ"
-              aria-label="日付ジャンプ"
+              title={t().header.jumpToDate}
+              aria-label={t().header.jumpToDate}
               aria-expanded={shell.popover() === "calendar"}
               onClick={() => shell.togglePopover("calendar")}
             >
@@ -191,8 +192,8 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
           <button
             type="button"
             class="icon-button header-action"
-            title="同期"
-            aria-label="同期"
+            title={t().header.sync}
+            aria-label={t().header.sync}
             aria-expanded={shell.popover() === "sync"}
             onClick={() => shell.togglePopover("sync")}
           >
@@ -202,12 +203,12 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
           <button
             type="button"
             class="icon-button header-action header-action--theme"
-            aria-label={`テーマ: ${THEME_LABELS[theme()]}`}
+            aria-label={t().header.theme(t().theme[theme()])}
             onClick={() => setTheme(nextTheme(theme()))}
           >
             <Icon name={THEME_ICONS[theme()]} size={18} />
             <span class="header-tooltip" aria-hidden="true">
-              {THEME_LABELS[theme()]}
+              {t().theme[theme()]}
             </span>
           </button>
           <A
@@ -251,14 +252,14 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
           commands={[
             {
               id: "new-note",
-              label: "新規ノート",
+              label: t().palette.newNote,
               icon: "note-pencil",
               shortcut: "⌘N",
               run: newNote,
             },
             {
               id: "sync-now",
-              label: "今すぐ同期",
+              label: t().sync.now,
               icon: "cloud-arrow-up",
               run: () => {
                 shell.closePalette();

--- a/tauri-app/src/lib/calendar.ts
+++ b/tauri-app/src/lib/calendar.ts
@@ -1,3 +1,4 @@
+import { t } from "./i18n";
 import type { DeviceContext } from "./parse-timeline";
 
 export interface MonthCell {
@@ -7,7 +8,10 @@ export interface MonthCell {
   inMonth: boolean;
 }
 
-export const WEEKDAY_LABELS = ["月", "火", "水", "木", "金", "土", "日"] as const;
+/** 曜日の見出し。週の始まりは月曜で固定する。 */
+export function weekdayLabels(): readonly string[] {
+  return t().calendar.weekdays;
+}
 
 const DAYS_IN_GRID = 42;
 
@@ -43,7 +47,7 @@ export function shiftMonth(year: number, month: number, delta: number): [number,
 }
 
 export function formatMonthTitle(year: number, month: number): string {
-  return `${year}年${month + 1}月`;
+  return t().calendar.monthTitle(year, month);
 }
 
 interface Tally {

--- a/tauri-app/src/lib/code-block-view-plugin.ts
+++ b/tauri-app/src/lib/code-block-view-plugin.ts
@@ -3,6 +3,7 @@ import { codeBlockSchema } from "@milkdown/kit/preset/commonmark";
 import { TextSelection } from "@milkdown/kit/prose/state";
 import copyIcon from "@phosphor-icons/core/assets/regular/copy.svg?raw";
 import checkIcon from "@phosphor-icons/core/assets/regular/check.svg?raw";
+import { t } from "./i18n";
 import { renderDiagrams } from "./mermaid";
 import { isMermaidLanguage, createDebouncedDiagramRenderer } from "./mermaid-preview";
 import { createCopyFeedback } from "./copy-feedback";
@@ -124,7 +125,7 @@ class CodeBlockPreviewView implements NodeView {
     button.className = "code-copy-button";
     button.contentEditable = "false";
     button.tabIndex = -1;
-    button.setAttribute("aria-label", "コードをコピー");
+    button.setAttribute("aria-label", t().editor.copyCode);
     button.innerHTML = copyIcon;
     button.addEventListener("mousedown", (event) => {
       event.preventDefault();
@@ -150,8 +151,8 @@ class CodeBlockPreviewView implements NodeView {
     input.type = "text";
     input.className = "code-language-input";
     input.setAttribute("list", LANGUAGE_DATALIST_ID);
-    input.setAttribute("aria-label", "言語");
-    input.placeholder = "言語";
+    input.setAttribute("aria-label", t().editor.language);
+    input.placeholder = t().editor.language;
     input.spellcheck = false;
     input.autocapitalize = "off";
     input.tabIndex = -1;
@@ -229,7 +230,7 @@ class CodeBlockPreviewView implements NodeView {
       // 描けていない間はソースを隠さない(隠すと直せない)
       this.dom.classList.remove("has-diagram");
       if (!this.lastSvg) {
-        this.showNotice("図を描画できません");
+        this.showNotice(t().editor.diagramFailed);
       }
       return;
     }

--- a/tauri-app/src/lib/day-labels.test.ts
+++ b/tauri-app/src/lib/day-labels.test.ts
@@ -7,8 +7,26 @@ import {
   formatNoteGroupLabel,
   formatDateTime,
 } from "./day-labels";
+import { setLocale } from "./i18n";
 
 const TODAY = new Date(2026, 7, 4); // 2026-08-04
+
+// 見出しは言語ごとに語も並びも変わる。日本語だけ見ていると、英語で
+// 「8月4日 Monday」のような混ざった行が出ても気付けない
+describe("in english", () => {
+  it("names the day in english", () => {
+    setLocale("en");
+    expect(formatDayHeading("2026-08-04", TODAY)).toStrictEqual({
+      label: "Today",
+      date: "Aug 4 Tuesday",
+    });
+  });
+
+  it("names the note group in english", () => {
+    setLocale("en");
+    expect(formatNoteGroupLabel("2026-07-20", TODAY)).toBe("Earlier");
+  });
+});
 
 describe("parseIsoDate", () => {
   it("reads the date in local time, not UTC", () => {

--- a/tauri-app/src/lib/day-labels.ts
+++ b/tauri-app/src/lib/day-labels.ts
@@ -1,3 +1,5 @@
+import { t } from "./i18n";
+
 /** `YYYY-MM-DD` を UTC ではなくローカル日付として読む。 */
 export function parseIsoDate(iso: string): Date | null {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
@@ -21,23 +23,21 @@ export function daysBetween(from: Date, to: Date): number {
   return Math.round((b.getTime() - a.getTime()) / 86_400_000);
 }
 
-const WEEKDAYS = ["日曜日", "月曜日", "火曜日", "水曜日", "木曜日", "金曜日", "土曜日"];
-
 /** 日グループの見出し。見出し語と、その下に添える日付に分けて返す。 */
 export function formatDayHeading(iso: string, today: Date): { label: string; date: string } {
   const date = parseIsoDate(iso);
   if (!date) {
     return { label: iso, date: "" };
   }
-  const day = `${date.getMonth() + 1}月${date.getDate()}日`;
-  const weekday = WEEKDAYS[date.getDay()];
+  const day = t().day.monthDay(date.getMonth() + 1, date.getDate());
+  const weekday = t().day.weekdays[date.getDay()];
   const diff = daysBetween(date, today);
 
   if (diff === 0) {
-    return { label: "今日", date: `${day} ${weekday}` };
+    return { label: t().day.today, date: `${day} ${weekday}` };
   }
   if (diff === 1) {
-    return { label: "昨日", date: `${day} ${weekday}` };
+    return { label: t().day.yesterday, date: `${day} ${weekday}` };
   }
   // ここまで来ると「N 日前」は数えないと分からない。日付を見出しに上げる。
   return { label: day, date: weekday };
@@ -47,19 +47,19 @@ export function formatDayHeading(iso: string, today: Date): { label: string; dat
 export function formatNoteGroupLabel(iso: string, today: Date): string {
   const date = parseIsoDate(iso);
   if (!date) {
-    return "日付なし";
+    return t().day.noDate;
   }
   const diff = daysBetween(date, today);
   if (diff < 0) {
-    return "今週";
+    return t().day.thisWeek;
   }
   if (diff < 7) {
-    return "今週";
+    return t().day.thisWeek;
   }
   if (diff < 14) {
-    return "先週";
+    return t().day.lastWeek;
   }
-  return "それ以前";
+  return t().day.earlier;
 }
 
 /** 詳細ペインのメタバー。「2026-08-04 15:27」 */

--- a/tauri-app/src/lib/i18n.test.ts
+++ b/tauri-app/src/lib/i18n.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { locale, messages, resolveLocale, setLocale, t } from "./i18n";
+
+afterEach(() => setLocale("ja"));
+
+describe("resolveLocale", () => {
+  it("follows the system language when the preference is system", () => {
+    expect(resolveLocale("system", "ja-JP")).toBe("ja");
+    expect(resolveLocale("system", "en-US")).toBe("en");
+  });
+
+  // 対応しているのは日本語と英語だけ。知らない言語は英語に倒す
+  it("falls back to english for a language we do not have", () => {
+    expect(resolveLocale("system", "de-DE")).toBe("en");
+  });
+
+  it("keeps an explicit choice whatever the system says", () => {
+    expect(resolveLocale("en", "ja-JP")).toBe("en");
+    expect(resolveLocale("ja", "en-US")).toBe("ja");
+  });
+});
+
+describe("t", () => {
+  it("returns the table for the active locale", () => {
+    setLocale("ja");
+    expect(t().common.save).toBe("保存");
+    setLocale("en");
+    expect(t().common.save).toBe("Save");
+  });
+
+  it("keeps the locale readable for anything that needs it", () => {
+    setLocale("en");
+    expect(locale()).toBe("en");
+  });
+
+  it("fills in the numbers a sentence needs", () => {
+    setLocale("en");
+    expect(t().timeline.selectedCount(3)).toContain("3");
+  });
+});
+
+/** 値の形だけを取り出す。文字列は "string"、関数は "function" になる。 */
+function shapeOf(value: unknown): unknown {
+  if (typeof value !== "object" || value === null) {
+    return typeof value;
+  }
+  return Object.fromEntries(
+    Object.entries(value)
+      .map(([key, inner]) => [key, shapeOf(inner)])
+      .toSorted(([a], [b]) => String(a).localeCompare(String(b))),
+  );
+}
+
+const JAPANESE = /[ぁ-んァ-ヶ一-龥]/u;
+
+/** 日本語の混じっている文字列のキーを、`a.b.c` の形で集める。 */
+function japaneseKeys(value: unknown, path: string): string[] {
+  if (typeof value === "string") {
+    return JAPANESE.test(value) ? [path] : [];
+  }
+  if (typeof value !== "object" || value === null) {
+    return [];
+  }
+  return Object.entries(value).flatMap(([key, inner]) => japaneseKeys(inner, `${path}.${key}`));
+}
+
+describe("the two tables", () => {
+  // 片方にしかないキーは、その言語でだけ画面が空になる。型でも防いでいるが、
+  // 入れ子の取りこぼしはここで気付きたい
+  it("have the same shape", () => {
+    expect(shapeOf(messages.en)).toStrictEqual(shapeOf(messages.ja));
+  });
+
+  it("leaves no english string in japanese characters", () => {
+    // 言語の選択肢だけは、その言語自身の名前で出す
+    expect(japaneseKeys(messages.en, "en")).toStrictEqual(["en.settings.languageJa"]);
+  });
+});

--- a/tauri-app/src/lib/i18n.ts
+++ b/tauri-app/src/lib/i18n.ts
@@ -1,0 +1,449 @@
+/**
+ * 画面に出る言葉。日本語と英語だけを持つ。
+ *
+ * ライブラリは入れていない。必要なのは「表を 2 つ持って、片方を返す」
+ * ことだけで、複数形の規則も日付書式の交渉も要らない — 数の入る文は
+ * 関数にしてある。テーマ(`theme.ts`)と同じく、選択は localStorage に
+ * 残し、system は端末の設定に従う。
+ *
+ * `t()` は signal を読む。JSX や createMemo の中から呼べば、言語を
+ * 切り替えた瞬間に描き直される — 文字列を配る関数(`day-labels.ts` など)を
+ * 経由していても追跡は切れない。
+ */
+
+import { createSignal } from "solid-js";
+
+export type Locale = "ja" | "en";
+/** 設定に残す値。`system` は端末の言語に従う。 */
+export type LocalePreference = Locale | "system";
+
+const ja = {
+  common: {
+    save: "保存",
+    saving: "保存中…",
+    saved: "保存しました",
+    delete: "削除",
+    cancel: "キャンセル",
+    back: "戻る",
+    close: "閉じる",
+    undo: "元に戻す",
+    all: "すべて",
+    tags: "タグ",
+  },
+  header: {
+    searchPlaceholder: "検索・コマンド…",
+    search: "検索",
+    jumpToDate: "日付ジャンプ",
+    sync: "同期",
+    theme: (name: string) => `テーマ: ${name}`,
+    settings: "Settings",
+  },
+  theme: {
+    system: "システム",
+    light: "ライト",
+    dark: "ダーク",
+  },
+  timeline: {
+    editHint: "クリックでそのまま編集 · Esc で確定",
+    savedTick: "✓ 保存しました",
+    promote: "ノートにする",
+    emptyFiltered: "このタグの記録はまだありません。",
+    emptyToday: "今日はまだ何も記録していません。",
+    emptyFilteredHint: "上のチップで絞り込みを外せます。",
+    emptyHint: "下の入力欄に書くと、時刻とともにここに並びます。",
+    deleted: (count: number) => `${count}件のエントリを削除しました`,
+    digestTitle: "今週のふりかえり",
+    digestClose: "今週は閉じる",
+    digestSummary: (days: number, count: number) => `${days}日で${count}件を記録`,
+    lastYear: "1年前の今日の記録を見る",
+    selectHint: "消すエントリを選んでください",
+    select: "選択",
+    entryCount: (count: number) => `${count}件`,
+    bulkDelete: "まとめて削除",
+    selectedCount: (count: number) => `${count}件選択中`,
+    deleteCount: (count: number) => `削除 (${count}件)`,
+    confirmDelete: (count: number) => `${count}件のエントリを削除します。よろしいですか？`,
+    confirmDeleteYes: "削除する",
+  },
+  capture: {
+    placeholder: "いま何を記録する？",
+    suggestLabel: "タグ候補",
+    newTag: (draft: string) => `+「#${draft}」を新規タグとして確定`,
+  },
+  tagFilter: {
+    filtering: (tag: string, matched: number) => `#${tag} で絞り込み中 · ${matched}件`,
+  },
+  notes: {
+    empty: "ノートがありません",
+    emptyHint: "新規から始めると、ここに並びます。",
+    new: "新規",
+    noSelection: "項目がありません",
+    backToList: "一覧に戻る",
+    showEditor: "エディタで表示",
+    showMindmap: "マインドマップで表示",
+    info: "ノート情報",
+    finishEditing: "編集を終える",
+    titlePlaceholder: "タイトル",
+    bodyPlaceholder: "ノートを書く…",
+    backlinks: (count: number) => `リンクされている記録 (${count})`,
+    untitled: "(空のメモ)",
+    deleted: "ノートを削除しました",
+    reverted: "編集前の内容に戻しました",
+    revertFailed: "戻せませんでした",
+  },
+  meta: {
+    unreadable: "メタデータを読み取れません",
+    createdAt: "作成日時",
+    updatedAt: "更新日時",
+    removeTag: (tag: string) => `タグ ${tag} を外す`,
+    addTag: "タグを追加",
+    tagsHint: "作成時の記録。本文の #タグ は本文側で編集",
+    context: "記録時の環境",
+    backup: "この端末のバックアップ",
+    revert: "編集前に戻す",
+    revertHint: "直前の編集で上書きした本文と入れ替える。もう一度押すと戻る",
+    saveFailed: "保存できませんでした",
+    os: "OS",
+    battery: "バッテリー",
+    charging: "充電中",
+    network: "ネットワーク",
+    hostname: "ホスト名",
+    location: "位置",
+    locale: "ロケール",
+    wifi: "Wi-Fi",
+    ethernet: "有線",
+    mobile: "モバイル回線",
+    offline: "オフライン",
+  },
+  sync: {
+    synced: "すべて同期済み",
+    syncing: "同期中…",
+    notSyncing: "同期していません",
+    failed: "同期に失敗しました",
+    localOnly:
+      "書いたものはこの端末の中だけに残ります。他の端末と揃えたいときだけ設定してください。",
+    lastSync: (when: string) => `最終同期 ${when}`,
+    autoSync: "保存時に自動同期",
+    retry: "再試行",
+    now: "今すぐ同期",
+    openSettings: "設定を開く",
+    notConfigured: "同期は未設定です",
+    notSignedIn: "ログインしていません",
+    justNow: "たった今",
+    minutesAgo: (minutes: number) => `${minutes}分前`,
+    hoursAgo: (hours: number) => `${hours}時間前`,
+    daysAgo: (days: number) => `${days}日前`,
+  },
+  settings: {
+    title: "設定",
+    notSet: "未設定",
+    signedIn: "ログイン済み",
+    notSignedIn: "未ログイン",
+    signInGoogle: "Google でログイン",
+    signOut: "ログアウト",
+    signInHint: "ログインするには、先に Workers URL を保存してください。",
+    signedInMessage: "ログインしました",
+    signInFailed: (reason: string) => `ログインに失敗しました: ${reason}`,
+    saveFailed: (reason: string) => `保存できませんでした: ${reason}`,
+    continueInBrowser: "ブラウザで続けてください…",
+    signedOutMessage: "ログアウトしました",
+    signOutFailed: (reason: string) => `ログアウトできませんでした: ${reason}`,
+    language: "言語",
+    languageSystem: "システム",
+    languageJa: "日本語",
+    languageEn: "English",
+  },
+  palette: {
+    dialogLabel: "検索・コマンド",
+    commands: "コマンド",
+    dates: "日付",
+    recentNotes: "最近のノート",
+    hits: "ノート・エントリ",
+    empty: "一致するものがありません",
+    count: (count: number) => `${count}件`,
+    newNote: "新規ノート",
+  },
+  editor: {
+    copyCode: "コードをコピー",
+    language: "言語",
+    diagramFailed: "図を描画できません",
+    exitBlock: "ブロックから抜ける",
+    deleteBlock: "ブロックを削除",
+  },
+  firstRun: {
+    title: "同期はあとからでも設定できます",
+    body: "設定しなければ、書いたものはこの端末の中だけに残ります。それで困らないなら、このまま使い始めて構いません。",
+    hint: "複数の端末で同じ記録を見たくなったら、Workers の URL をここか設定画面で入れてください。",
+    connect: "接続",
+    later: "あとで",
+  },
+  calendar: {
+    prevMonth: "前の月",
+    nextMonth: "次の月",
+    /** 週の始まりは月曜。曜日の見出しは 1 文字ぶんの幅しかない */
+    weekdays: ["月", "火", "水", "木", "金", "土", "日"],
+    monthTitle: (year: number, month: number) => `${year}年${month + 1}月`,
+    monthDay: (month: number, day: number) => `${month}月${day}日`,
+  },
+  day: {
+    today: "今日",
+    yesterday: "昨日",
+    noDate: "日付なし",
+    thisWeek: "今週",
+    lastWeek: "先週",
+    earlier: "それ以前",
+    weekdays: ["日曜日", "月曜日", "火曜日", "水曜日", "木曜日", "金曜日", "土曜日"],
+    /** 日グループの見出しに出す暦日。 */
+    monthDay: (month: number, day: number) => `${month}月${day}日`,
+  },
+};
+
+export type Messages = typeof ja;
+
+const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+const SHORT_MONTHS = MONTHS.map((month) => month.slice(0, 3));
+
+const en: Messages = {
+  common: {
+    save: "Save",
+    saving: "Saving…",
+    saved: "Saved",
+    delete: "Delete",
+    cancel: "Cancel",
+    back: "Back",
+    close: "Close",
+    undo: "Undo",
+    all: "All",
+    tags: "Tags",
+  },
+  header: {
+    searchPlaceholder: "Search or run a command…",
+    search: "Search",
+    jumpToDate: "Jump to a date",
+    sync: "Sync",
+    theme: (name: string) => `Theme: ${name}`,
+    settings: "Settings",
+  },
+  theme: {
+    system: "System",
+    light: "Light",
+    dark: "Dark",
+  },
+  timeline: {
+    editHint: "Click to edit · Esc to commit",
+    savedTick: "✓ Saved",
+    promote: "Turn into a note",
+    emptyFiltered: "Nothing recorded with this tag yet.",
+    emptyToday: "Nothing recorded today yet.",
+    emptyFilteredHint: "Drop the filter with the chips above.",
+    emptyHint: "Write in the field below and it lands here with the time.",
+    deleted: (count: number) => `Deleted ${count} ${count === 1 ? "entry" : "entries"}`,
+    digestTitle: "This week",
+    digestClose: "Hide until next week",
+    digestSummary: (days: number, count: number) =>
+      `${count} ${count === 1 ? "record" : "records"} over ${days} days`,
+    lastYear: "See this day a year ago",
+    selectHint: "Choose the entries to delete",
+    select: "Select",
+    entryCount: (count: number) => `${count}`,
+    bulkDelete: "Delete several",
+    selectedCount: (count: number) => `${count} selected`,
+    deleteCount: (count: number) => `Delete (${count})`,
+    confirmDelete: (count: number) =>
+      `Delete ${count} ${count === 1 ? "entry" : "entries"}. Are you sure?`,
+    confirmDeleteYes: "Delete",
+  },
+  capture: {
+    placeholder: "What's on your mind?",
+    suggestLabel: "Tag suggestions",
+    newTag: (draft: string) => `+ Use “#${draft}” as a new tag`,
+  },
+  tagFilter: {
+    filtering: (tag: string, matched: number) => `Filtered by #${tag} · ${matched}`,
+  },
+  notes: {
+    empty: "No notes yet",
+    emptyHint: "Start one with New and it lands here.",
+    new: "New",
+    noSelection: "Nothing to show",
+    backToList: "Back to the list",
+    showEditor: "Show as text",
+    showMindmap: "Show as a mindmap",
+    info: "Note info",
+    finishEditing: "Finish editing",
+    titlePlaceholder: "Title",
+    bodyPlaceholder: "Write a note…",
+    backlinks: (count: number) => `Records linking here (${count})`,
+    untitled: "(empty note)",
+    deleted: "Note deleted",
+    reverted: "Restored the body from before the edit",
+    revertFailed: "Could not restore it",
+  },
+  meta: {
+    unreadable: "Cannot read the metadata",
+    createdAt: "Created",
+    updatedAt: "Updated",
+    removeTag: (tag: string) => `Remove the tag ${tag}`,
+    addTag: "Add a tag",
+    tagsHint: "Recorded at creation. Edit #tags in the body itself",
+    context: "Recorded surroundings",
+    backup: "Backup on this device",
+    revert: "Restore the pre-edit body",
+    revertHint: "Swaps in the body your last edit overwrote. Press again to swap back",
+    saveFailed: "Could not save it",
+    os: "OS",
+    battery: "Battery",
+    charging: "charging",
+    network: "Network",
+    hostname: "Hostname",
+    location: "Location",
+    locale: "Locale",
+    wifi: "Wi-Fi",
+    ethernet: "Ethernet",
+    mobile: "Mobile data",
+    offline: "Offline",
+  },
+  sync: {
+    synced: "Everything is synced",
+    syncing: "Syncing…",
+    notSyncing: "Not syncing",
+    failed: "Sync failed",
+    localOnly:
+      "Everything you write stays on this device. Set this up only when you want other devices to match.",
+    lastSync: (when: string) => `Last synced ${when}`,
+    autoSync: "Sync automatically on save",
+    retry: "Try again",
+    now: "Sync now",
+    openSettings: "Open settings",
+    notConfigured: "Sync is not set up",
+    notSignedIn: "Not signed in",
+    justNow: "just now",
+    minutesAgo: (minutes: number) => `${minutes} min ago`,
+    hoursAgo: (hours: number) => `${hours} h ago`,
+    daysAgo: (days: number) => `${days} d ago`,
+  },
+  settings: {
+    title: "Settings",
+    notSet: "Not set",
+    signedIn: "Signed in",
+    notSignedIn: "Not signed in",
+    signInGoogle: "Sign in with Google",
+    signOut: "Sign out",
+    signInHint: "Save the Workers URL before signing in.",
+    signedInMessage: "Signed in",
+    signInFailed: (reason: string) => `Could not sign in: ${reason}`,
+    saveFailed: (reason: string) => `Could not save: ${reason}`,
+    continueInBrowser: "Continue in your browser…",
+    signedOutMessage: "Signed out",
+    signOutFailed: (reason: string) => `Could not sign out: ${reason}`,
+    language: "Language",
+    languageSystem: "System",
+    languageJa: "日本語",
+    languageEn: "English",
+  },
+  palette: {
+    dialogLabel: "Search and commands",
+    commands: "Commands",
+    dates: "Dates",
+    recentNotes: "Recent notes",
+    hits: "Notes and entries",
+    empty: "Nothing matches",
+    count: (count: number) => `${count}`,
+    newNote: "New note",
+  },
+  editor: {
+    copyCode: "Copy the code",
+    language: "Language",
+    diagramFailed: "Cannot draw this diagram",
+    exitBlock: "Leave the block",
+    deleteBlock: "Delete the block",
+  },
+  firstRun: {
+    title: "You can set up sync later",
+    body: "Without it, everything you write stays on this device. If that is fine, start writing as you are.",
+    hint: "When you want the same records on more than one device, put the Workers URL here or in settings.",
+    connect: "Connect",
+    later: "Later",
+  },
+  calendar: {
+    prevMonth: "Previous month",
+    nextMonth: "Next month",
+    weekdays: ["M", "T", "W", "T", "F", "S", "S"],
+    monthTitle: (year: number, month: number) => `${MONTHS[month] ?? String(month + 1)} ${year}`,
+    monthDay: (month: number, day: number) => `${SHORT_MONTHS[month - 1] ?? month} ${day}`,
+  },
+  day: {
+    today: "Today",
+    yesterday: "Yesterday",
+    noDate: "No date",
+    thisWeek: "This week",
+    lastWeek: "Last week",
+    earlier: "Earlier",
+    weekdays: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+    monthDay: (month: number, day: number) => `${SHORT_MONTHS[month - 1] ?? month} ${day}`,
+  },
+};
+
+export const messages: Record<Locale, Messages> = { ja, en };
+
+const STORAGE_KEY = "locale";
+
+function isPreference(value: unknown): value is LocalePreference {
+  return value === "system" || value === "ja" || value === "en";
+}
+
+export function readStoredLocale(): LocalePreference {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  return isPreference(saved) ? saved : "system";
+}
+
+/**
+ * 実際に使う言語。持っていない言語の端末は英語に倒す — 日本語を
+ * 既定にすると、読めない人が読めない設定画面から言語を探すことになる。
+ */
+export function resolveLocale(preference: LocalePreference, systemLanguage: string): Locale {
+  if (preference !== "system") {
+    return preference;
+  }
+  return systemLanguage.toLowerCase().startsWith("ja") ? "ja" : "en";
+}
+
+const [locale, setResolved] = createSignal<Locale>(
+  resolveLocale(readStoredLocale(), globalThis.navigator?.language ?? "en"),
+);
+
+export { locale };
+
+// index.html は `lang="ja"` で出荷される。読み上げと日本語の行組みが
+// 言語と食い違わないよう、決まった時点で書き換える
+document.documentElement.lang = locale();
+
+/** いま使う言葉の表。JSX から呼べば、切り替えたときに描き直される。 */
+export function t(): Messages {
+  return messages[locale()];
+}
+
+/** 表示だけを切り替える。設定として残すのは `applyLocale`。 */
+export function setLocale(next: Locale): void {
+  setResolved(next);
+  document.documentElement.lang = next;
+}
+
+export function applyLocale(preference: LocalePreference): void {
+  setLocale(resolveLocale(preference, globalThis.navigator?.language ?? "en"));
+  localStorage.setItem(STORAGE_KEY, preference);
+}

--- a/tauri-app/src/lib/items.ts
+++ b/tauri-app/src/lib/items.ts
@@ -1,5 +1,6 @@
 import type { Note } from "./commands";
 import { formatNoteGroupLabel } from "./day-labels";
+import { t } from "./i18n";
 import { parseTimelineEntry } from "./parse-timeline";
 import { isPreservedEmptyLine } from "./preserved-empty-line";
 import type { DeviceContext } from "./parse-timeline";
@@ -36,7 +37,8 @@ export interface ItemGroup {
   items: Item[];
 }
 
-const UNTITLED = "(空のメモ)";
+/** 題を持たない記録の呼び名。一覧の行が空欄になるのを避けるためだけのもの。 */
+const untitled = (): string => t().notes.untitled;
 
 function firstLine(text: string): string {
   // Milkdown は空行を <br /> 行として保存する。タイトルはそれも読み飛ばす
@@ -75,7 +77,7 @@ export function toNoteItems(notes: Note[]): NoteItem[] {
     path: note.path,
     date: note.time?.slice(0, 10) ?? "",
     time: note.time?.slice(11, 16) ?? "",
-    title: firstLine(note.preview) || UNTITLED,
+    title: firstLine(note.preview) || untitled(),
     tags: note.tags,
     preview: note.preview,
     origin: note.origin,
@@ -193,7 +195,7 @@ export function itemMeta(item: Item): string {
     return [item.time.slice(0, 5), item.context?.os].filter(Boolean).join(" · ");
   }
   const date = item.date ? item.date.slice(5).replace("-", "/") : "";
-  const tags = item.tags.map((t) => `#${t}`).join(" ");
+  const tags = item.tags.map((tag) => `#${tag}`).join(" ");
   return [date, tags].filter(Boolean).join(" · ");
 }
 
@@ -208,5 +210,5 @@ export function noteCreatedLabel(item: NoteItem): string {
 }
 
 export function itemTitle(item: Item): string {
-  return item.kind === "timeline" ? firstLine(item.text) || UNTITLED : item.title;
+  return item.kind === "timeline" ? firstLine(item.text) || untitled() : item.title;
 }

--- a/tauri-app/src/lib/note-meta.ts
+++ b/tauri-app/src/lib/note-meta.ts
@@ -8,6 +8,8 @@
  */
 
 import type { NoteContext } from "./commands";
+import { t } from "./i18n";
+import { networkLabel } from "./parse-timeline";
 import { normalizeTag } from "./tags";
 
 /** RFC 3339 の time を datetime-local input の値(分まで)にする。 */
@@ -54,13 +56,6 @@ export function addTag(tags: string[], raw: string): string[] {
   return [...tags, tag];
 }
 
-const NETWORK_LABELS: Record<string, string> = {
-  WiFi: "Wi-Fi",
-  Ethernet: "有線",
-  Mobile: "モバイル回線",
-  Offline: "オフライン",
-};
-
 export interface ContextRow {
   label: string;
   value: string;
@@ -71,33 +66,31 @@ export function contextRows(ctx: NoteContext | undefined): ContextRow[] {
   if (!ctx) {
     return [];
   }
+  const labels = t().meta;
   const rows: ContextRow[] = [];
   if (ctx.os) {
-    rows.push({ label: "OS", value: [ctx.os, ctx.os_version].filter(Boolean).join(" ") });
+    rows.push({ label: labels.os, value: [ctx.os, ctx.os_version].filter(Boolean).join(" ") });
   }
   if (ctx.battery !== undefined) {
     rows.push({
-      label: "バッテリー",
-      value: `${ctx.battery}%${ctx.is_charging ? " (充電中)" : ""}`,
+      label: labels.battery,
+      value: `${ctx.battery}%${ctx.is_charging ? ` (${labels.charging})` : ""}`,
     });
   }
   if (ctx.network_type) {
-    rows.push({
-      label: "ネットワーク",
-      value: NETWORK_LABELS[ctx.network_type] ?? ctx.network_type,
-    });
+    rows.push({ label: labels.network, value: networkLabel(ctx.network_type) });
   }
   if (ctx.hostname) {
-    rows.push({ label: "ホスト名", value: ctx.hostname });
+    rows.push({ label: labels.hostname, value: ctx.hostname });
   }
   if (ctx.location) {
     rows.push({
-      label: "位置",
+      label: labels.location,
       value: `${ctx.location.latitude.toFixed(4)}, ${ctx.location.longitude.toFixed(4)}`,
     });
   }
   if (ctx.locale) {
-    rows.push({ label: "ロケール", value: ctx.locale });
+    rows.push({ label: labels.locale, value: ctx.locale });
   }
   return rows;
 }

--- a/tauri-app/src/lib/palette-home.ts
+++ b/tauri-app/src/lib/palette-home.ts
@@ -8,6 +8,7 @@
 
 import type { SearchHit } from "./commands";
 import { toIsoDate } from "./day-labels";
+import { t } from "./i18n";
 import type { NoteItem } from "./items";
 import type { TagCount } from "./tags";
 
@@ -53,8 +54,8 @@ export function dayJumpHits(recordedDates: string[], today: Date): DayJump[] {
   const dates = new Set(recordedDates);
   const yesterday = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 1);
   const candidates: [string, string][] = [
-    ["今日", toIsoDate(today)],
-    ["昨日", toIsoDate(yesterday)],
+    [t().day.today, toIsoDate(today)],
+    [t().day.yesterday, toIsoDate(yesterday)],
   ];
   return candidates
     .filter(([, iso]) => dates.has(iso))

--- a/tauri-app/src/lib/parse-timeline.ts
+++ b/tauri-app/src/lib/parse-timeline.ts
@@ -1,4 +1,5 @@
 import type { IconName } from "../components/Icon";
+import { t } from "./i18n";
 
 export interface DeviceContext {
   battery?: number;
@@ -87,6 +88,31 @@ export function getNetworkIcon(ctx: DeviceContext): IconName | null {
     }
     default: {
       return null;
+    }
+  }
+}
+
+/**
+ * 回線の呼び名。記録に残っているのは `WiFi` のような素の値で、これは
+ * 読むための言い換え。タイムラインの行にもメタデータパネルにも出る。
+ */
+export function networkLabel(type: string): string {
+  const labels = t().meta;
+  switch (type) {
+    case "WiFi": {
+      return labels.wifi;
+    }
+    case "Ethernet": {
+      return labels.ethernet;
+    }
+    case "Mobile": {
+      return labels.mobile;
+    }
+    case "Offline": {
+      return labels.offline;
+    }
+    default: {
+      return type;
     }
   }
 }

--- a/tauri-app/src/lib/sync.ts
+++ b/tauri-app/src/lib/sync.ts
@@ -4,6 +4,7 @@ import { listen } from "@tauri-apps/api/event";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { onLocalMutation, typedInvoke } from "./commands";
 import { EVENTS } from "./events";
+import { t } from "./i18n";
 import { describeSyncError, describeSyncResult } from "./sync-status";
 import type { SyncResultPayload } from "./sync-status";
 import type { IconName } from "../components/Icon";
@@ -45,16 +46,16 @@ export function syncIconName(status: SyncStatus): IconName {
 export function formatRelativeTime(from: Date, now: Date): string {
   const minutes = Math.floor((now.getTime() - from.getTime()) / 60_000);
   if (minutes < 1) {
-    return "たった今";
+    return t().sync.justNow;
   }
   if (minutes < 60) {
-    return `${minutes}分前`;
+    return t().sync.minutesAgo(minutes);
   }
   const hours = Math.floor(minutes / 60);
   if (hours < 24) {
-    return `${hours}時間前`;
+    return t().sync.hoursAgo(hours);
   }
-  return `${Math.floor(hours / 24)}日前`;
+  return t().sync.daysAgo(Math.floor(hours / 24));
 }
 
 export function createSyncState(onSynced: () => void): SyncState {
@@ -72,19 +73,19 @@ export function createSyncState(onSynced: () => void): SyncState {
       setAutoSyncSignal(config.auto_sync);
       if (!config.workers_url) {
         setStatus("needs-setup");
-        setMessage("同期は未設定です");
+        setMessage(t().sync.notConfigured);
         return;
       }
       if (!(await typedInvoke("auth_status"))) {
         setStatus("needs-setup");
-        setMessage("ログインしていません");
+        setMessage(t().sync.notSignedIn);
         return;
       }
       setStatus("idle");
       setMessage("");
     } catch {
       setStatus("needs-setup");
-      setMessage("同期は未設定です");
+      setMessage(t().sync.notConfigured);
     }
   };
 
@@ -103,7 +104,7 @@ export function createSyncState(onSynced: () => void): SyncState {
       return;
     }
     setStatus("syncing");
-    setMessage("同期中…");
+    setMessage(t().sync.syncing);
     try {
       await typedInvoke("sync_start");
       // 結果は sync-complete / sync-error イベントで反映する

--- a/tauri-app/src/lib/theme.ts
+++ b/tauri-app/src/lib/theme.ts
@@ -17,12 +17,6 @@ export function nextTheme(current: Theme): Theme {
   return THEMES[(at + 1) % THEMES.length];
 }
 
-export const THEME_LABELS: Record<Theme, string> = {
-  system: "システム",
-  light: "ライト",
-  dark: "ダーク",
-};
-
 export const THEME_ICONS: Record<Theme, IconName> = {
   system: "circle-half",
   light: "sun",

--- a/tauri-app/src/lib/timeline-meta.ts
+++ b/tauri-app/src/lib/timeline-meta.ts
@@ -1,5 +1,5 @@
 import type { IconName } from "../components/Icon";
-import { getBatteryIcon, getNetworkIcon } from "./parse-timeline";
+import { getBatteryIcon, getNetworkIcon, networkLabel } from "./parse-timeline";
 import type { DeviceContext } from "./parse-timeline";
 
 /** エントリ本文の下に並べる、記録時の状況ひとつ。 */
@@ -10,13 +10,6 @@ export interface MetaSegment {
 
 /** 座標に付ける地名を引くもの。まだ引けていなければ undefined。 */
 export type PlaceLookup = (location: { latitude: number; longitude: number }) => string | undefined;
-
-const NETWORK_LABELS = {
-  WiFi: "Wi-Fi",
-  Ethernet: "有線",
-  Mobile: "モバイル回線",
-  Offline: "オフライン",
-} as const;
 
 function deviceSegment(ctx: DeviceContext): MetaSegment | null {
   if (!ctx.os) {
@@ -53,7 +46,7 @@ function networkSegment(ctx: DeviceContext): MetaSegment | null {
   if (!icon || !ctx.network_type) {
     return null;
   }
-  return { icon, label: NETWORK_LABELS[ctx.network_type] };
+  return { icon, label: networkLabel(ctx.network_type) };
 }
 
 function batterySegment(ctx: DeviceContext): MetaSegment | null {

--- a/tauri-app/src/styles/settings.css
+++ b/tauri-app/src/styles/settings.css
@@ -39,6 +39,35 @@
   gap: 6px;
 }
 
+/* 3 つしかない選択肢。開いて選ぶメニューにするほどのものではない */
+.settings-choices {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.settings-choice {
+  padding: 7px 14px;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-2);
+  background: var(--app-input-bg);
+  color: var(--app-text-muted);
+  font-family: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.settings-choice:hover {
+  background: var(--app-surface-2);
+}
+
+.settings-choice--on {
+  background: var(--app-accent-soft);
+  border-color: var(--app-accent);
+  color: var(--app-text);
+  font-weight: 600;
+}
+
 .settings-field-label {
   font-size: 13px;
   color: var(--app-text-muted);

--- a/tauri-app/src/test-setup.ts
+++ b/tauri-app/src/test-setup.ts
@@ -1,0 +1,12 @@
+/**
+ * テストは日本語で走る。
+ *
+ * 言語は端末の設定から決まる(`i18n.ts`)ので、そのままだと画面の文言を
+ * 見るテストが「実行した端末の言語」で結果を変える。ここで固定して、
+ * 英語を見たいテストだけが自分で `setLocale("en")` と言うようにする。
+ */
+
+import { beforeEach } from "vitest";
+import { setLocale } from "./lib/i18n";
+
+beforeEach(() => setLocale("ja"));

--- a/tauri-app/src/views/Settings.tsx
+++ b/tauri-app/src/views/Settings.tsx
@@ -1,6 +1,8 @@
-import { createSignal, onMount, onCleanup, Show } from "solid-js";
+import { createSignal, For, onMount, onCleanup, Show } from "solid-js";
 import { typedInvoke } from "../lib/commands";
 import { EVENTS } from "../lib/events";
+import { applyLocale, readStoredLocale, t } from "../lib/i18n";
+import type { LocalePreference } from "../lib/i18n";
 import { listen } from "@tauri-apps/api/event";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import "../styles/settings.css";
@@ -12,6 +14,13 @@ export default function Settings(): JSX.Element {
   const [editable, setEditable] = createSignal(false);
   const [saving, setSaving] = createSignal(false);
   const [message, setMessage] = createSignal("");
+  const [localePreference, setLocalePreference] =
+    createSignal<LocalePreference>(readStoredLocale());
+
+  const chooseLocale = (preference: LocalePreference): void => {
+    setLocalePreference(preference);
+    applyLocale(preference);
+  };
 
   const unlisteners: UnlistenFn[] = [];
 
@@ -44,13 +53,13 @@ export default function Settings(): JSX.Element {
     unlisteners.push(
       await listen(EVENTS.AUTH_SUCCESS, () => {
         setAuthenticated(true);
-        flash("ログインしました");
+        flash(t().settings.signedInMessage);
       }),
     );
     unlisteners.push(
       await listen<string>(EVENTS.AUTH_ERROR, (e) => {
         setAuthenticated(false);
-        setMessage(`ログインに失敗しました: ${e.payload}`);
+        setMessage(t().settings.signInFailed(String(e.payload)));
       }),
     );
   });
@@ -70,16 +79,16 @@ export default function Settings(): JSX.Element {
       await typedInvoke("save_sync_config", {
         config: { ...current, workers_url: workersUrl() },
       });
-      flash("保存しました");
+      flash(t().common.saved);
     } catch (error) {
-      setMessage(`保存できませんでした: ${error}`);
+      setMessage(t().settings.saveFailed(String(error)));
     } finally {
       setSaving(false);
     }
   };
 
   const login = async (): Promise<void> => {
-    setMessage("ブラウザで続けてください…");
+    setMessage(t().settings.continueInBrowser);
     try {
       // デスクトップ(ループバック)はコマンド完了時点でトークン保存済み。
       // Android はブラウザを開くだけで、完了はディープリンクの auth-success で通知される
@@ -87,10 +96,10 @@ export default function Settings(): JSX.Element {
       const status = await typedInvoke("auth_status");
       setAuthenticated(status);
       if (status) {
-        flash("ログインしました");
+        flash(t().settings.signedInMessage);
       }
     } catch (error) {
-      setMessage(`ログインに失敗しました: ${error}`);
+      setMessage(t().settings.signInFailed(String(error)));
     }
   };
 
@@ -98,16 +107,45 @@ export default function Settings(): JSX.Element {
     try {
       await typedInvoke("auth_logout");
       setAuthenticated(false);
-      flash("ログアウトしました");
+      flash(t().settings.signedOutMessage);
     } catch (error) {
-      setMessage(`ログアウトできませんでした: ${error}`);
+      setMessage(t().settings.signOutFailed(String(error)));
     }
   };
 
   return (
     <div class="settings-scroll">
       <div class="settings">
-        <h1 class="settings-title">設定</h1>
+        <h1 class="settings-title">{t().settings.title}</h1>
+
+        <section class="settings-section">
+          <h2 class="settings-section-label">LANGUAGE</h2>
+          {/* テーマと違い巡回では選べない。押すたびに読めない言語を通る */}
+          <div class="settings-choices" role="radiogroup" aria-label={t().settings.language}>
+            <For
+              each={
+                [
+                  ["system", t().settings.languageSystem],
+                  ["ja", t().settings.languageJa],
+                  ["en", t().settings.languageEn],
+                ] as [LocalePreference, string][]
+              }
+            >
+              {([preference, label]) => (
+                <button
+                  type="button"
+                  role="radio"
+                  class="settings-choice"
+                  classList={{ "settings-choice--on": localePreference() === preference }}
+                  aria-checked={localePreference() === preference}
+                  onClick={() => chooseLocale(preference)}
+                >
+                  {label}
+                </button>
+              )}
+            </For>
+          </div>
+        </section>
 
         <section class="settings-section">
           <h2 class="settings-section-label">SERVER</h2>
@@ -116,7 +154,7 @@ export default function Settings(): JSX.Element {
             fallback={
               <p class="settings-readonly">
                 Workers URL
-                <span>{workersUrl() || "未設定"}</span>
+                <span>{workersUrl() || t().settings.notSet}</span>
               </p>
             }
           >
@@ -137,7 +175,7 @@ export default function Settings(): JSX.Element {
                 onClick={() => void save()}
                 disabled={saving()}
               >
-                {saving() ? "保存中…" : "保存"}
+                {saving() ? t().common.saving : t().common.save}
               </button>
             </div>
           </Show>
@@ -148,7 +186,7 @@ export default function Settings(): JSX.Element {
 
           <p class="settings-status">
             <span class="settings-dot" classList={{ "settings-dot--on": authenticated() }} />
-            {authenticated() ? "ログイン済み" : "未ログイン"}
+            {authenticated() ? t().settings.signedIn : t().settings.notSignedIn}
           </p>
 
           <div class="settings-actions">
@@ -161,18 +199,18 @@ export default function Settings(): JSX.Element {
                   onClick={() => void login()}
                   disabled={!workersUrl().trim()}
                 >
-                  Google でログイン
+                  {t().settings.signInGoogle}
                 </button>
               }
             >
               <button type="button" class="button-secondary" onClick={() => void logout()}>
-                ログアウト
+                {t().settings.signOut}
               </button>
             </Show>
           </div>
 
           <Show when={!authenticated() && !workersUrl().trim()}>
-            <p class="settings-hint">ログインするには、先に Workers URL を保存してください。</p>
+            <p class="settings-hint">{t().settings.signInHint}</p>
           </Show>
         </section>
 

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -19,6 +19,7 @@ import { typedInvoke } from "../lib/commands";
 import { getClientContext } from "../lib/client-context";
 import { useShell } from "../lib/shell";
 import { formatDayHeading, toIsoDate } from "../lib/day-labels";
+import { t } from "../lib/i18n";
 import {
   groupTimelineByDay,
   notesByOriginDate,
@@ -118,9 +119,9 @@ function Entry(props: EntryProps): JSX.Element {
               }}
             />
             <div class="entry-editor-foot">
-              <span>クリックでそのまま編集 · Esc で確定</span>
+              <span>{t().timeline.editHint}</span>
               <Show when={props.saved()}>
-                <span>✓ 保存しました</span>
+                <span>{t().timeline.savedTick}</span>
               </Show>
             </div>
           </div>
@@ -175,8 +176,8 @@ function Entry(props: EntryProps): JSX.Element {
             <button
               type="button"
               class="icon-button entry-action"
-              title="ノートにする"
-              aria-label="ノートにする"
+              title={t().timeline.promote}
+              aria-label={t().timeline.promote}
               onClick={() => props.onPromote()}
             >
               <Icon name="note-pencil" size={15} />
@@ -194,12 +195,10 @@ function EmptyTimeline(props: { filtered: boolean }): JSX.Element {
       <span class="timeline-empty-rail" aria-hidden="true" />
       <div>
         <p class="timeline-empty-title">
-          {props.filtered ? "このタグの記録はまだありません。" : "今日はまだ何も記録していません。"}
+          {props.filtered ? t().timeline.emptyFiltered : t().timeline.emptyToday}
         </p>
         <p class="timeline-empty-hint">
-          {props.filtered
-            ? "上のチップで絞り込みを外せます。"
-            : "下の入力欄に書くと、時刻とともにここに並びます。"}
+          {props.filtered ? t().timeline.emptyFilteredHint : t().timeline.emptyHint}
         </p>
       </div>
     </div>
@@ -424,9 +423,11 @@ export default function Timeline(): JSX.Element {
         // oxlint-disable-next-line no-await-in-loop
         await typedInvoke("delete_timeline_entry", { date: target.date, index: target.index });
       }
-      await Promise.all([...new Set(plan.map((t) => t.date))].map((date) => reloadDay(date)));
+      await Promise.all(
+        [...new Set(plan.map((target) => target.date))].map((date) => reloadDay(date)),
+      );
       exitSelecting();
-      shell.showToast(`${plan.length}件のエントリを削除しました`);
+      shell.showToast(t().timeline.deleted(plan.length));
     } finally {
       setDeleting(false);
     }
@@ -467,14 +468,14 @@ export default function Timeline(): JSX.Element {
               最初の描画に存在した行が押し下げられてレイアウトシフトになる。
               ここなら日リストと同じ「後から現れる領域」の先頭に収まる */}
           <Show when={digestVisible()}>
-            <section class="digest-card" aria-label="今週のふりかえり">
+            <section class="digest-card" aria-label={t().timeline.digestTitle}>
               <header class="digest-head">
-                <span class="digest-title">今週のふりかえり</span>
+                <span class="digest-title">{t().timeline.digestTitle}</span>
                 <button
                   type="button"
                   class="icon-button digest-close"
-                  title="今週は閉じる"
-                  aria-label="今週は閉じる"
+                  title={t().timeline.digestClose}
+                  aria-label={t().timeline.digestClose}
                   onClick={dismissDigest}
                 >
                   <Icon name="x" size={14} />
@@ -482,7 +483,7 @@ export default function Timeline(): JSX.Element {
               </header>
               <Show when={weekSummary().count > 0}>
                 <p class="digest-line">
-                  {weekSummary().days}日で{weekSummary().count}件を記録
+                  {t().timeline.digestSummary(weekSummary().days, weekSummary().count)}
                 </p>
               </Show>
               <Show when={weekSummary().topTags.length > 0}>
@@ -505,7 +506,7 @@ export default function Timeline(): JSX.Element {
                 {(iso) => (
                   <button type="button" class="digest-year-ago" onClick={() => jumpToDay(iso())}>
                     <Icon name="clock-counter-clockwise" size={13} />
-                    1年前の今日の記録を見る
+                    {t().timeline.lastYear}
                   </button>
                 )}
               </Show>
@@ -516,11 +517,11 @@ export default function Timeline(): JSX.Element {
             <div class="timeline-toolbar">
               <Show
                 when={!selecting()}
-                fallback={<span class="timeline-toolbar-hint">消すエントリを選んでください</span>}
+                fallback={<span class="timeline-toolbar-hint">{t().timeline.selectHint}</span>}
               >
                 <button type="button" class="timeline-toolbar-button" onClick={startSelecting}>
                   <Icon name="check-square" size={14} />
-                  選択
+                  {t().timeline.select}
                 </button>
               </Show>
             </div>
@@ -533,7 +534,9 @@ export default function Timeline(): JSX.Element {
                     <header class="day-heading">
                       <h2 class="day-heading-label">{heading().label}</h2>
                       <span class="day-heading-date">{heading().date}</span>
-                      <span class="day-heading-count">{day.items.length}件</span>
+                      <span class="day-heading-count">
+                        {t().timeline.entryCount(day.items.length)}
+                      </span>
                     </header>
 
                     {/* この日のエントリから育ったノートへの入り口 */}
@@ -582,12 +585,14 @@ export default function Timeline(): JSX.Element {
 
       <div class="capture-dock">
         <Show when={selecting()} fallback={<CaptureBar onSend={capture} knownTags={knownTags()} />}>
-          <div class="select-bar" role="toolbar" aria-label="まとめて削除">
+          <div class="select-bar" role="toolbar" aria-label={t().timeline.bulkDelete}>
             <Show
               when={confirming()}
               fallback={
                 <>
-                  <span class="select-bar-label">{selected().size}件選択中</span>
+                  <span class="select-bar-label">
+                    {t().timeline.selectedCount(selected().size)}
+                  </span>
                   <button
                     type="button"
                     class="select-bar-danger"
@@ -595,27 +600,25 @@ export default function Timeline(): JSX.Element {
                     onClick={() => setConfirming(true)}
                   >
                     <Icon name="trash" size={14} />
-                    削除 ({selected().size}件)
+                    {t().timeline.deleteCount(selected().size)}
                   </button>
                   <button type="button" class="select-bar-plain" onClick={exitSelecting}>
-                    キャンセル
+                    {t().common.cancel}
                   </button>
                 </>
               }
             >
-              <span class="select-bar-label">
-                {selected().size}件のエントリを削除します。よろしいですか？
-              </span>
+              <span class="select-bar-label">{t().timeline.confirmDelete(selected().size)}</span>
               <button
                 type="button"
                 class="select-bar-danger"
                 disabled={deleting()}
                 onClick={() => void runDelete()}
               >
-                削除する
+                {t().timeline.confirmDeleteYes}
               </button>
               <button type="button" class="select-bar-plain" onClick={() => setConfirming(false)}>
-                戻る
+                {t().common.back}
               </button>
             </Show>
           </div>

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -24,6 +24,7 @@ import type { ItemGroup, NoteItem } from "../lib/items";
 import { readNoteContent, toggledView, viewToFrontmatter } from "../lib/note-view";
 import type { NoteView } from "../lib/note-view";
 import { joinTitle, splitTitle } from "../lib/note-title";
+import { t } from "../lib/i18n";
 import { isImeComposing } from "../lib/ime";
 import {
   beginEditSession,
@@ -61,8 +62,8 @@ function EmptyNotes(): JSX.Element {
   return (
     <div class="notes-empty">
       <Icon name="note-pencil" size={24} />
-      <p class="notes-empty-title">ノートがありません</p>
-      <p class="notes-empty-body">新規から始めると、ここに並びます。</p>
+      <p class="notes-empty-title">{t().notes.empty}</p>
+      <p class="notes-empty-body">{t().notes.emptyHint}</p>
     </div>
   );
 }
@@ -385,7 +386,7 @@ export default function Workspace(): JSX.Element {
         client: await getDeviceSignals(),
       });
     } catch {
-      shell.showToast("戻せませんでした");
+      shell.showToast(t().notes.revertFailed);
       return;
     }
     writeBackup(localStorage, item.filename, current);
@@ -396,7 +397,7 @@ export default function Workspace(): JSX.Element {
     });
     shell.closePopovers();
     await refetchNotes();
-    shell.showToast("編集前の内容に戻しました");
+    shell.showToast(t().notes.reverted);
   };
 
   // タイムラインからの昇格 (?edit=1) は、本文が届き次第そのまま書き始める。
@@ -467,7 +468,7 @@ export default function Workspace(): JSX.Element {
       })();
     }, UNDO_MS);
 
-    shell.showToast("ノートを削除しました", () => {
+    shell.showToast(t().notes.deleted, () => {
       clearTimeout(commit);
       setHidden((ids) => ids.filter((id) => id !== item.id));
     });
@@ -480,7 +481,7 @@ export default function Workspace(): JSX.Element {
           <span class="list-pane-title">NOTES</span>
           <button type="button" class="new-note" onClick={() => void createNote()}>
             <Icon name="plus" size={12} />
-            新規
+            {t().notes.new}
           </button>
         </div>
 
@@ -516,14 +517,14 @@ export default function Workspace(): JSX.Element {
       </div>
 
       <div class="detail-pane">
-        <Show when={selected()} fallback={<div class="detail-empty">項目がありません</div>}>
+        <Show when={selected()} fallback={<div class="detail-empty">{t().notes.noSelection}</div>}>
           {(item) => (
             <>
               <div class="detail-meta-bar">
                 <button
                   type="button"
                   class="icon-button detail-back"
-                  aria-label="一覧に戻る"
+                  aria-label={t().notes.backToList}
                   onClick={() => {
                     // 編集したまま戻ると、一覧の上にツールバーだけが残る。
                     // 見えなくなった編集対象に効くボタンが浮いていることになる。
@@ -539,7 +540,7 @@ export default function Workspace(): JSX.Element {
                   <span class="detail-created">{noteCreatedLabel(item())}</span>
                   <Show when={editing() && saveStatus() !== "idle"}>
                     <span class="detail-save-status">
-                      {saveStatus() === "saving" ? "保存中…" : "保存しました"}
+                      {saveStatus() === "saving" ? t().common.saving : t().common.saved}
                     </span>
                   </Show>
                 </span>
@@ -549,9 +550,11 @@ export default function Workspace(): JSX.Element {
                     <button
                       type="button"
                       class="icon-button"
-                      title={noteView() === "mindmap" ? "エディタで表示" : "マインドマップで表示"}
+                      title={
+                        noteView() === "mindmap" ? t().notes.showEditor : t().notes.showMindmap
+                      }
                       aria-label={
-                        noteView() === "mindmap" ? "エディタで表示" : "マインドマップで表示"
+                        noteView() === "mindmap" ? t().notes.showEditor : t().notes.showMindmap
                       }
                       aria-pressed={noteView() === "mindmap"}
                       onClick={() => void toggleNoteView(item())}
@@ -565,8 +568,8 @@ export default function Workspace(): JSX.Element {
                   <button
                     type="button"
                     class="icon-button detail-meta-button"
-                    title="ノート情報"
-                    aria-label="ノート情報"
+                    title={t().notes.info}
+                    aria-label={t().notes.info}
                     aria-expanded={shell.popover() === "note-meta"}
                     onClick={() => shell.togglePopover("note-meta")}
                   >
@@ -577,8 +580,8 @@ export default function Workspace(): JSX.Element {
                     <button
                       type="button"
                       class="icon-button"
-                      title="編集を終える"
-                      aria-label="編集を終える"
+                      title={t().notes.finishEditing}
+                      aria-label={t().notes.finishEditing}
                       onClick={() => void stopEditing()}
                     >
                       <Icon name="check" size={17} />
@@ -587,8 +590,8 @@ export default function Workspace(): JSX.Element {
                   <button
                     type="button"
                     class="icon-button"
-                    title="削除"
-                    aria-label="削除"
+                    title={t().common.delete}
+                    aria-label={t().common.delete}
                     onClick={() => remove(item())}
                   >
                     <Icon name="trash" size={17} />
@@ -614,8 +617,8 @@ export default function Workspace(): JSX.Element {
               <input
                 type="text"
                 class="note-title-input"
-                placeholder="タイトル"
-                aria-label="タイトル"
+                placeholder={t().notes.titlePlaceholder}
+                aria-label={t().notes.titlePlaceholder}
                 value={noteTitle()}
                 onInput={(e) => editTitle(e.currentTarget.value)}
                 onChange={() => void commitTitle()}
@@ -648,7 +651,7 @@ export default function Workspace(): JSX.Element {
                           <Show when={(backlinks() ?? []).length > 0}>
                             <details class="backlinks">
                               <summary class="backlinks-summary">
-                                リンクされている記録 ({(backlinks() ?? []).length})
+                                {t().notes.backlinks((backlinks() ?? []).length)}
                               </summary>
                               <div class="backlinks-list">
                                 <For each={backlinks()}>
@@ -682,7 +685,7 @@ export default function Workspace(): JSX.Element {
                   }
                 >
                   <MilkdownEditor
-                    placeholder="ノートを書く…"
+                    placeholder={t().notes.bodyPlaceholder}
                     caret={tapCaret()}
                     noteLinks={linkTargets}
                     defaultValue={draft()}

--- a/tauri-app/vitest.config.ts
+++ b/tauri-app/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     ],
   },
   test: {
+    setupFiles: ["./src/test-setup.ts"],
     browser: {
       provider: playwright(),
       enabled: true,


### PR DESCRIPTION
## なぜやるか

画面の言葉が日本語しか無く、日本語を読まない人には使えないアプリでした。ドキュメントと README は英語なのに、入って最初に見えるものが全部日本語という食い違いもありました。

対応するのは日本語と英語の 2 つだけです。それ以上を見据えた仕組み（複数形の規則、日付書式の交渉、翻訳ファイルの読み込み）は入れていません。

## やったこと

**`lib/i18n.ts` に表を 2 つ**。ライブラリは足していません。要るのは「表を 2 つ持って、片方を返す」ことだけで、数の入る文（`${n}件選択中` → `${n} selected`）は関数にしてあります。日本語の表が型の出どころ（`type Messages = typeof ja`）なので、英語側にキーの取りこぼしがあればコンパイルが通りません。入れ子の形と「英語の表に日本語が残っていないこと」はテストでも見ています。

**`t()` は signal を読む**。JSX や `createMemo` の中から呼べば、言語を切り替えた瞬間に描き直されます — `formatDayHeading()` のように文字列を配る関数を経由していても追跡は切れません。再読み込みは要りません。

**初回はシステムの言語に従い、持っていない言語は英語に倒します**。日本語を既定にすると、日本語を読めない人が読めない設定画面から言語設定を探すことになるためです。設定 → LANGUAGE で固定でき、テーマと違って巡回ではなく 3 つのボタンにしました（巡回だと押すたびに読めない言語を通ります）。

**画面側は 165 箇所・23 ファイル**を表からの参照に置き換えました。タイムライン、ノート、メタデータパネル、パレット、同期、設定、エディタの操作系、曜日と月の表記まで。ついでに 2 つ直しています:

- キャプチャバーのプレースホルダだけ、日本語表示のときも英語のままでした
- 回線の呼び名（`Wi-Fi` / `有線` …）が `timeline-meta.ts` と `note-meta.ts` に二重に定義され、既にズレていました。`parse-timeline.ts` の 1 箇所に寄せています

**テストは日本語で走ります**（`src/test-setup.ts`）。言語は端末の設定から決まるので、固定しないと「実行した端末の言語」でテスト結果が変わります。英語を見たいテストだけが自分で `setLocale("en")` と言います。

## やらなかったこと

- **英語以外の言語**。表を足せば増やせますが、今回は増やしていません。
- **ユーザーが書いたものの翻訳**。変わるのは画面の言葉だけで、本文もタグもファイルの中身も一切触りません。
- **日付・数値の `Intl` 化**。月名と曜日は表に直接持たせました。2 言語ぶんなら表のほうが読めて、束も増えません。
- **Rust 側から返るメッセージ**（同期エラーの原文など）。言い換えずそのまま見せる既存の方針のままです。
- **`index.html` の `lang` 属性**は `ja` のまま出荷し、決まった時点で書き換えます。ビルド時には決められないためです。

## 資料

- 検証: ブラウザハーネス（`just tauri_app::dev-browser` + agent-browser）で、英語表示のタイムライン・ノート・メタデータパネル・設定を確認し、設定から日本語へ切り替えて再読み込み無しで戻ることと `document.documentElement.lang` が追従することを確認しました。
