### PR TITLE
feat(widget): let quick captures carry the device context

### DIFF
--- a/tauri-app/android-widget/README.md
+++ b/tauri-app/android-widget/README.md
@@ -40,9 +40,25 @@ The base directory is `Context.getDataDir()`, **not** `filesDir` — Tauri's
 `PathPlugin` answers `getDataDir` with the former, and writing to `files/`
 would build a second timeline the app never reads.
 
-Entries written from the widget carry no battery, network or location: the
-sheet has no WebView to ask, and `Context` omits absent fields, so they are
-shorter than in-app entries rather than wrong.
+### What the entry knows about the device
+
+The sheet has no WebView, and on Android the Rust side sees neither battery nor
+network, so `WidgetContext` gathers what Kotlin can and hands it over as the
+same JSON `ClientContext` takes from the app:
+
+| Field                    | Source                                       | Permission                       |
+| ------------------------ | -------------------------------------------- | -------------------------------- |
+| `battery` / `isCharging` | sticky `ACTION_BATTERY_CHANGED`              | none                             |
+| `networkType`            | `ConnectivityManager` transports             | `ACCESS_NETWORK_STATE` (already) |
+| `osVersion`              | `Build.VERSION.RELEASE`                      | none                             |
+| `locale`                 | `Locale.getDefault()`, normalized to `ja_JP` | none                             |
+| `latitude` / `longitude` | last known fix, **only if already granted**  | location, never requested here   |
+
+Nothing is measured or awaited. A permission dialog on the home screen, or a
+wait for a GPS fix, costs more than the value it buys in a sheet meant to be
+typed into the instant it opens — so an entry written before the app has ever
+been granted location simply carries none. `Context` omits absent fields, so a
+thinner entry is shorter than an in-app one rather than wrong.
 
 ## What the widgets read
 

--- a/tauri-app/android-widget/src/main/java/com/magical_merchant/app/widget/QuickCaptureActivity.kt
+++ b/tauri-app/android-widget/src/main/java/com/magical_merchant/app/widget/QuickCaptureActivity.kt
@@ -89,7 +89,7 @@ class QuickCaptureActivity : Activity() {
 
         // The sheet stays open on failure: dismissing would throw away text the
         // user cannot retype from anywhere, and the widget has no drafts.
-        if (!WidgetBridge.saveQuickCapture(WidgetBridge.baseDir(this), text)) {
+        if (!WidgetBridge.saveCapture(this, text)) {
             Toast.makeText(this, R.string.quick_capture_failed, Toast.LENGTH_SHORT).show()
             return
         }

--- a/tauri-app/android-widget/src/main/java/com/magical_merchant/app/widget/WidgetBridge.kt
+++ b/tauri-app/android-widget/src/main/java/com/magical_merchant/app/widget/WidgetBridge.kt
@@ -33,8 +33,14 @@ internal object WidgetBridge {
         System.loadLibrary("magical_merchant_app_lib")
     }
 
-    /** Appends [text] to today's timeline file under [baseDir]. False on failure. */
-    external fun saveQuickCapture(baseDir: String, text: String): Boolean
+    /**
+     * Appends [text] to today's timeline file under [baseDir]. False on failure.
+     *
+     * [clientJson] is [WidgetContext]'s output — what Kotlin could see of the
+     * device. Call [saveCapture] rather than this: forgetting the JSON here
+     * still compiles and still saves, it just silently drops the metadata.
+     */
+    external fun saveQuickCapture(baseDir: String, text: String, clientJson: String): Boolean
 
     /** Today's last entry and tags, as JSON. Reads one day file. */
     external fun readCaptureData(baseDir: String): String?
@@ -52,6 +58,10 @@ internal object WidgetBridge {
      * never reads and sync never uploads.
      */
     fun baseDir(context: Context): String = context.applicationContext.dataDir.absolutePath
+
+    /** Saves [text] with everything [WidgetContext] could gather. False on failure. */
+    fun saveCapture(context: Context, text: String): Boolean =
+        saveQuickCapture(baseDir(context), text, WidgetContext.collect(context))
 
     /**
      * Reads and parses. Never throws: these run from widget callbacks that have

--- a/tauri-app/android-widget/src/main/java/com/magical_merchant/app/widget/WidgetContext.kt
+++ b/tauri-app/android-widget/src/main/java/com/magical_merchant/app/widget/WidgetContext.kt
@@ -1,0 +1,134 @@
+package com.magical_merchant.app.widget
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.location.LocationManager
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.BatteryManager
+import android.os.Build
+import java.util.Locale
+import org.json.JSONObject
+
+/**
+ * What the capture sheet can tell the entry about where it was written.
+ *
+ * In the app the WebView answers this (`lib/client-context.ts`); the widget has
+ * no WebView, and the Rust side sees nothing on Android — no `battery` crate,
+ * no SystemConfiguration. Without this, a widget entry carries only `os` and
+ * `arch` while an in-app entry carries battery, network and place.
+ *
+ * The JSON keys are the ones `ClientContext` (src-tauri/src/device.rs)
+ * deserializes, so this and the WebView speak the same shape. `networkType` is
+ * an externally tagged enum there: the string has to be one of WiFi, Ethernet,
+ * Mobile, Offline or the whole object fails to parse.
+ *
+ * Everything here is synchronous. The sheet is open for as long as it takes to
+ * type one line, and a value that arrives after `finish()` is a value the entry
+ * never gets — which is why location is read from the last known fix rather
+ * than measured.
+ */
+internal object WidgetContext {
+    /** Whatever could be gathered, as JSON. Never throws; `{}` at worst. */
+    fun collect(context: Context): String = runCatching { build(context) }.getOrElse { "{}" }
+
+    private fun build(context: Context): String {
+        val json = JSONObject()
+
+        putBattery(json, context)
+        networkType(context)?.let { json.put("networkType", it) }
+        json.put("osVersion", Build.VERSION.RELEASE)
+        json.put("locale", locale())
+        putLocation(json, context)
+
+        return json.toString()
+    }
+
+    /**
+     * A null receiver reads the sticky ACTION_BATTERY_CHANGED without
+     * registering anything, so there is nothing to unregister and no
+     * RECEIVER_EXPORTED flag to decide on.
+     */
+    private fun putBattery(json: JSONObject, context: Context) {
+        val status = context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+            ?: return
+
+        val level = status.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+        val scale = status.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+        if (level >= 0 && scale > 0) {
+            json.put("battery", level * 100 / scale)
+        }
+
+        // Full counts as charging, as it does on macOS: the point of the field
+        // is whether the entry was written on mains power.
+        when (status.getIntExtra(BatteryManager.EXTRA_STATUS, -1)) {
+            BatteryManager.BATTERY_STATUS_CHARGING, BatteryManager.BATTERY_STATUS_FULL ->
+                json.put("isCharging", true)
+            BatteryManager.BATTERY_STATUS_DISCHARGING, BatteryManager.BATTERY_STATUS_NOT_CHARGING ->
+                json.put("isCharging", false)
+        }
+    }
+
+    /**
+     * Which way the phone was reachable. Reads transports, not the SSID, so no
+     * location permission is involved — the same trade the macOS side makes.
+     */
+    private fun networkType(context: Context): String? {
+        val manager = context.getSystemService(ConnectivityManager::class.java) ?: return null
+        val network = manager.activeNetwork ?: return "Offline"
+        val capabilities = manager.getNetworkCapabilities(network) ?: return "Offline"
+
+        return when {
+            !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) -> "Offline"
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> "WiFi"
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> "Mobile"
+            capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> "Ethernet"
+            // VPN over something unnamed, Bluetooth tethering, USB. Rounding an
+            // unknown transport to WiFi would make the record lie, so drop it.
+            else -> null
+        }
+    }
+
+    /** `ja_JP`, the shape `navigator.language` is normalized to in the app. */
+    private fun locale(): String = Locale.getDefault().let { locale ->
+        if (locale.country.isEmpty()) locale.language else "${locale.language}_${locale.country}"
+    }
+
+    /**
+     * The last fix the OS already has, if location is permitted at all.
+     *
+     * Never requests the permission and never asks for a new fix. The sheet is
+     * meant to be typed into the moment it opens; a permission dialog on the
+     * home screen, or a wait for GPS, costs more than the coordinate is worth.
+     * An entry written before the app has ever been granted location simply has
+     * none, which is the same as today.
+     */
+    private fun putLocation(json: JSONObject, context: Context) {
+        if (!locationPermitted(context)) {
+            return
+        }
+
+        val manager = context.getSystemService(LocationManager::class.java) ?: return
+        val fix = manager.allProviders
+            .mapNotNull { provider ->
+                runCatching { manager.getLastKnownLocation(provider) }.getOrNull()
+            }
+            .maxByOrNull { it.time } ?: return
+
+        json.put("latitude", fix.latitude)
+        json.put("longitude", fix.longitude)
+    }
+
+    /**
+     * Coarse is enough. The recorded coordinate is only ever read back through
+     * the geocoder, which stops at the municipality.
+     */
+    private fun locationPermitted(context: Context): Boolean =
+        context.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED ||
+            context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+}

--- a/tauri-app/src-tauri/src/device.rs
+++ b/tauri-app/src-tauri/src/device.rs
@@ -201,6 +201,66 @@ const fn get_network() -> Option<NetworkType> {
     None
 }
 
+/// ウィジェットが JSON 1 本で渡してくる実行環境。
+///
+/// `WebView` の無い経路なので構造体をそのまま渡せず、JNI の文字列に詰めて
+/// もらう。読めなければ既定値、つまり「何も分からなかった」に倒す。ここで
+/// 失敗させても打った文が消えるだけで、メタデータが無くてもキャプチャの
+/// 保存そのものは成立する。
+///
+/// 呼ぶのは Android の JNI ブリッジだけだが、ここに置いて全プラットフォームで
+/// ビルドする。CI に Android ターゲットは無く、テストする値打ちがあるのは
+/// パースの部分だから。
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+pub(crate) fn parse_client_context(json: &str) -> ClientContext {
+    serde_json::from_str(json).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod client_context_tests {
+    use super::*;
+
+    #[test]
+    fn reads_every_field_the_widget_can_fill() {
+        let client = parse_client_context(
+            r#"{"latitude":35.68,"longitude":139.76,"battery":42,"isCharging":true,
+                "networkType":"WiFi","osVersion":"16","locale":"ja_JP"}"#,
+        );
+
+        assert_eq!(client.latitude, Some(35.68));
+        assert_eq!(client.longitude, Some(139.76));
+        assert_eq!(client.battery, Some(42));
+        assert_eq!(client.is_charging, Some(true));
+        assert_eq!(client.network_type, Some(NetworkType::WiFi));
+        assert_eq!(client.os_version.as_deref(), Some("16"));
+        assert_eq!(client.locale.as_deref(), Some("ja_JP"));
+    }
+
+    /// 位置情報だけは許可が下りていないことがある。欠けたキーは
+    /// 「分からなかった」であって、保存の失敗ではない。
+    #[test]
+    fn leaves_absent_keys_unknown() {
+        let client = parse_client_context(r#"{"battery":7,"networkType":"Offline"}"#);
+
+        assert_eq!(client.battery, Some(7));
+        assert_eq!(client.network_type, Some(NetworkType::Offline));
+        assert_eq!(client.latitude, None);
+        assert_eq!(client.longitude, None);
+        assert_eq!(client.os_version, None);
+    }
+
+    #[test]
+    fn falls_back_to_unknown_when_the_json_is_unreadable() {
+        for json in ["", "{", "null", "[]"] {
+            let client = parse_client_context(json);
+
+            assert_eq!(client.battery, None, "{json}");
+            assert_eq!(client.network_type, None, "{json}");
+            assert_eq!(client.locale, None, "{json}");
+        }
+    }
+}
+
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
     use super::*;

--- a/tauri-app/src-tauri/src/widget_bridge.rs
+++ b/tauri-app/src-tauri/src/widget_bridge.rs
@@ -11,7 +11,7 @@ use jni::objects::{JClass, JString};
 use jni::sys::{JNI_FALSE, JNI_TRUE, jboolean};
 use std::path::Path;
 
-use crate::device::{self, ClientContext};
+use crate::device;
 use crate::widget_summary;
 
 /// Appends `text` to today's timeline file under `base_dir`.
@@ -22,6 +22,10 @@ use crate::widget_summary;
 /// Renaming the Kotlin package or object without renaming this function leaves
 /// the `external fun` unresolved until the first tap.
 ///
+/// `client_json` is what Kotlin could gather (`WidgetContext.collect`), in the
+/// same shape the `WebView` sends. Android's native side sees neither battery
+/// nor network, so without it a widget entry would carry only `os` and `arch`.
+///
 /// Returns false rather than throwing: the caller keeps the sheet open on
 /// failure so the typed text is not lost, and a Java exception crossing back
 /// through an `AppWidgetProvider` tap would take the launcher's process with it.
@@ -31,15 +35,19 @@ pub extern "system" fn Java_com_magical_1merchant_app_widget_WidgetBridge_saveQu
     _class: JClass<'_>,
     base_dir: JString<'_>,
     text: JString<'_>,
+    client_json: JString<'_>,
 ) -> jboolean {
     let (Ok(base_dir), Ok(text)) = (env.get_string(&base_dir), env.get_string(&text)) else {
         return JNI_FALSE;
     };
 
-    // The widget has no WebView to ask, so battery, network, and location stay
-    // empty here while the in-app bar fills them. Nothing downstream requires
-    // them — `Context` skips absent fields when it serializes.
-    let context = device::get_context(ClientContext::default());
+    // An unreadable string is the same as an unreadable JSON: the entry is
+    // saved without the metadata rather than not saved at all.
+    let client = env
+        .get_string(&client_json)
+        .map(|json| device::parse_client_context(&String::from(json)))
+        .unwrap_or_default();
+    let context = device::get_context(client);
     let saved = magical_merchant_core::save_timeline_entry(
         Path::new(&String::from(base_dir)),
         &String::from(text),


### PR DESCRIPTION
## なぜやるか

closes #122

ホーム画面のウィジェットから書いたエントリには `os` と `arch` しか残っていなかった。シートには聞ける WebView が無く、Android ではネイティブ側もバッテリーもネットワークも見えないため、アプリ内のキャプチャバーが記録しているものが丸ごと欠けていた。同じ日の同じメモでも、どこから打ったかで「知らない端末で書かれた記録」になってしまう。

issue で先に技術的な可否を調べた結果、**位置情報以外は追加権限なしで全部取れる**ことが分かったので実装した。

## やったこと

- `WidgetContext.kt` を追加し、Kotlin から届く範囲の端末情報を集める。JSON のキーは `ClientContext`（`src-tauri/src/device.rs`）が WebView から受けているものと同じにしたので、パーサは 1 つのまま
- JNI の `saveQuickCapture` に `clientJson` を追加。Rust 側は `parse_client_context` で読み、読めなければ既定値に倒す（メタデータが無くても保存そのものは成立する）
- 取得元と権限は `android-widget/README.md` の表に残した

| 項目 | 取得元 | 権限 |
| --- | --- | --- |
| `battery` / `isCharging` | sticky `ACTION_BATTERY_CHANGED` | 不要 |
| `networkType` | `ConnectivityManager` の transport | `ACCESS_NETWORK_STATE`（既に宣言済み） |
| `osVersion` | `Build.VERSION.RELEASE` | 不要 |
| `locale` | `Locale.getDefault()` を `ja_JP` 形に正規化 | 不要 |
| `latitude` / `longitude` | last known fix、**許可済みのときだけ** | 位置情報。ここでは要求しない |

副次的に、ウィジェットの `DeviceIdentity` にも `osVersion` / `locale` が入るようになった。これまで日ファイルの device 一覧にアプリとウィジェットが別端末として 2 行並んでいたのが、今後は 1 行にまとまる。

## やらなかったこと

- **位置情報の許可要求と測位待ち**。ホーム画面のシートで権限ダイアログを出すのも GPS の応答を待つのも、「開いた瞬間に書ける」という北極星に対して座標の価値が見合わない。アプリで一度許可していれば last known が乗るし、そうでなければ従来どおり座標なしになる
- **Kotlin 側のユニットテスト**。ウィジェットのソースは生成プロジェクトへ流し込む形（`apply-widget.go`）でテスト基盤が無い。テストする値打ちのあるパース部分は Rust 側に置いて 3 件書いた

## 資料

- #122 — 可否調査（どの API で何が取れるか、位置情報だけ質が違う理由）
