### PR TITLE
fix(widget): keep the capture sheet above the keyboard

### DIFF
--- a/tauri-app/android-widget/src/main/java/com/magical_merchant/app/widget/QuickCaptureActivity.kt
+++ b/tauri-app/android-widget/src/main/java/com/magical_merchant/app/widget/QuickCaptureActivity.kt
@@ -1,6 +1,7 @@
 package com.magical_merchant.app.widget
 
 import android.app.Activity
+import android.os.Build
 import android.os.Bundle
 import android.view.Gravity
 import android.view.View
@@ -10,6 +11,9 @@ import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import com.magical_merchant.app.R
 
 /**
@@ -33,11 +37,47 @@ class QuickCaptureActivity : Activity() {
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
 
         // The scrim dismisses; the sheet swallows the tap so it does not.
-        findViewById<View>(R.id.quick_capture_scrim).setOnClickListener { finish() }
+        val scrim = findViewById<View>(R.id.quick_capture_scrim)
+        scrim.setOnClickListener { finish() }
         findViewById<View>(R.id.quick_capture_sheet).setOnClickListener { }
         findViewById<ImageButton>(R.id.quick_capture_send).setOnClickListener { save(input) }
 
+        keepClearOfTheKeyboard(scrim)
         showTagChips(input)
+    }
+
+    /**
+     * Holds the sheet above the keyboard and the navigation bar.
+     *
+     * The manifest's `adjustResize` does not lift a translucent window: the
+     * sheet stays pinned to the bottom of the screen and the keyboard draws
+     * over it, leaving one line of the input peeking out (#125). Rather than
+     * hope the framework resizes, take the placing over — ask the decor to stop
+     * fitting the system windows and pad the scrim by the insets ourselves, so
+     * exactly one mechanism moves the sheet.
+     *
+     * IME insets only exist from API 30. Below it the framework's resize is all
+     * there is, so leave that path alone rather than swap it for nothing.
+     */
+    private fun keepClearOfTheKeyboard(scrim: View) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            return
+        }
+
+        // The decor would otherwise eat the insets before the scrim sees them,
+        // and it is what stops the framework from resizing the window under us.
+        // It also lets the scrim run under the status bar, which is what a scrim
+        // over the home screen should do anyway.
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
+        ViewCompat.setOnApplyWindowInsetsListener(scrim) { view, insets ->
+            val ime = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom
+            // Not the sum: the IME already reaches the bottom of the screen, so
+            // adding the navigation bar to it would float the sheet.
+            view.setPadding(view.paddingLeft, view.paddingTop, view.paddingRight, maxOf(ime, bars))
+            insets
+        }
     }
 
     /**

--- a/tauri-app/android-widget/src/main/res/layout/activity_quick_capture.xml
+++ b/tauri-app/android-widget/src/main/res/layout/activity_quick_capture.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- The capture sheet (design 1b): a scrim over the home screen with a rounded
-     card pinned to the bottom, so `adjustResize` lifts it onto the IME. -->
+     card pinned to the bottom. What lifts the card onto the IME is the scrim's
+     bottom padding, set from the window insets in QuickCaptureActivity — the
+     manifest's `adjustResize` does not resize a translucent window. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/quick_capture_scrim"
     android:layout_width="match_parent"


### PR DESCRIPTION
## なぜやるか

closes #125

ウィジェットのキャプチャシートがキーボードの裏に潜り、入力欄が 1 行だけ覗く状態になっていた。送信ボタンも見切れていて、開いた瞬間に書けることが取り柄のシートがキーボードの出た時点で使えなくなっていた。

原因は **半透明 Activity では `adjustResize` がウィンドウを持ち上げない** こと。`Theme.QuickCapture` は `windowIsTranslucent=true` なので、マニフェストに `android:windowSoftInputMode="adjustResize"` と書いてあっても効いていない。レイアウトのコメントにも「so `adjustResize` lifts it onto the IME」と前提が書かれていて、そこが崩れていた。

## やったこと

- フレームワーク任せをやめ、`QuickCaptureActivity` がインセットを見て自分で置くようにした
  - `WindowCompat.setDecorFitsSystemWindows(window, false)` — インセットがデコレーションに食われる前にスクリムへ届き、同時にフレームワークが裏でリサイズすることも止まる。動かす仕組みが 1 つだけになるので二重に持ち上がらない
  - スクリムの下パディングを `max(ime, systemBars)` にする。合計ではないのは、IME のインセットが既に画面下端まで届いていて、足すとナビゲーションバーぶん浮くから
- API 30 で区切った。IME インセットが存在し始めるのがそこで、それ未満はフレームワークのリサイズしか手が無いため、そちらは触らない
- 前提が変わったレイアウトのコメントを直した

## やらなかったこと

- **#54（アプリ内ツールバーがキーボードに追従する件）は別のまま**。同じ「フレームワークがリサイズしてくれない」問題だが、あちらは `MainActivity` の `enableEdgeToEdge()` が入口で、対象も WebView の中にある。Kotlin 側でウィンドウを縮めるのか CSS へインセットを渡すのかの判断が要るので、この PR には混ぜない
- **単体テスト無し**。ウィジェットのソースは生成プロジェクトへ流し込む形（`apply-widget.go`）でテスト基盤が無く、ここで確かめたいのは端末のインセット挙動そのもの。実機確認が唯一の検証になる

## 資料

- 実機確認: moto g52j 5G / Android 12 (API 31)。カード全体が送信ボタンごとキーボードの上に乗ることを確認
- #54 — 同系統の問題。この PR の調査で分かった訂正（Android 15 の edge-to-edge 強制ではなく `enableEdgeToEdge()` が原因）をコメントに追記済み
