### PR TITLE
fix(nix): repair the macOS build and the check that should have caught it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,11 +158,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: nixbuild/nix-quick-install-action@v35
-      - uses: nix-community/cache-nix-action@v7
-        with:
-          primary-key: nix-${{ runner.os }}-pnpmdeps-${{ hashFiles('flake.lock', 'flake.nix', 'tauri-app/pnpm-lock.yaml') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-pnpmdeps-
-          gc-max-store-size-linux: 2G
+      # store キャッシュを張らない。FOD の出力パスは入力ではなく宣言した hash から
+      # 決まるので、hash が腐ったままでも前回の出力が復元されれば nix はそれを有効と
+      # 見なし、fetcher を一度も動かさないまま緑になる (実際 a1f8f48 がそうだった)。
+      # 空の store から始めれば取得は必ず走る。取得の検証がこのジョブの全部なので、
+      # ここでキャッシュが節約できるものは無い
       - name: pnpm deps hash is current
         run: nix build .#pnpm-deps --no-link
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,24 @@ jobs:
       - name: pnpm deps hash is current
         run: nix build .#pnpm-deps --no-link
 
+  # nix build .#default が macOS 配布そのもの。バンドラは codesign や xattr を
+  # 外部コマンドとして呼ぶので、ubuntu で緑でも darwin sandbox でだけ落ちる
+  nix-package-macos:
+    needs: changes
+    if: needs.changes.outputs.nix-package == 'true'
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - uses: nixbuild/nix-quick-install-action@v35
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-package-${{ hashFiles('flake.lock', 'flake.nix', 'nix/package.nix', 'Cargo.lock', 'tauri-app/pnpm-lock.yaml') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-package-
+          gc-max-store-size-macos: 4G
+      - name: the .app bundle builds
+        run: nix build .#default --no-link
+
   format:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -12,7 +12,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "magical-merchant";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = lib.fileset.toSource {
     root = ../.;
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     pnpm = pnpm_10;
     sourceRoot = "${finalAttrs.src.name}/tauri-app";
     fetcherVersion = 3;
-    hash = "sha256-MQ1tFmm80rItS5rl6zxU/Rxa7irTf7OoXbLjmpxte/o=";
+    hash = "sha256-t+83j0+oVZ/gMzo7sm7i8I+CTzoydBVsU9fzZK2l8jo=";
   };
 
   nativeBuildInputs = [
@@ -59,6 +59,10 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmRoot = "tauri-app";
 
   env.tauriBundleType = "app";
+
+  # The sandbox has neither codesign nor xattr, and a Developer ID signature
+  # cannot exist in a nix build anyway; the linker's ad-hoc one is enough
+  tauriBuildFlags = [ "--no-sign" ];
 
   meta = {
     description = "Minimal note-taking desktop app";


### PR DESCRIPTION
## なぜやるか

`nix profile install github:Xantibody/magical-merchant` が失敗する。macOS にこのアプリが届く経路はこれだけで、release ワークフローは Android APK しか出さない。

壊れていたのは 3 段。deep link プラグインを入れたとき `pnpmDeps.hash` を取り直しておらず `ERR_PNPM_NO_OFFLINE_TARBALL`、それを直すと `.app` バンドラが呼ぶ `xattr -crs`、越えると `codesign` で落ちる。どちらも darwin の sandbox に無い。nixpkgs に `xattr` は無く（python 版は `-r` を解さない）、`darwin.sigtool` の `codesign` は Mach-O 用でバンドルを署名しない。

そして、この 1 段目を検出するために 9cf5b6b で入れたはずの `nix-package` ジョブは、腐りを持ち込んだ a1f8f48 で success を返していた。FOD の出力パスは入力ではなく**宣言した hash** から決まる。lockfile が変わって drv が変わっても hash が古いままなら出力パスは同じで、`restore-prefixes-first-match` が前回の出力を復元すると nix はそれを有効と見なし fetcher を一度も動かさない。ガードが空回りしていた。

## やったこと

- `pnpmDeps.hash` を取り直す。ついでに `version` を実体に合わせる（0.1.0 → 0.2.0）
- `tauriBuildFlags = [ "--no-sign" ]`。`remove_extra_attr` は署名パスの中でしか呼ばれないので、これ一つで `xattr` と `codesign` の両方が消える
- `nix-package` から store キャッシュを外す。空の store から始めれば取得は必ず走る
- `nix-package-macos` ジョブを追加。`nix build .#default` は macOS 配布そのものなのに、どの CI でも走っていなかった

手元で確認したこと: `nix build .#default` が通り `.app` が起動する。ガードは、古いパスが store にあると stale hash でも exit 0、消すと exit 1 で hash mismatch。

## やらなかったこと

- **`codesign` を成立させる**。Developer ID も notarization も nix ビルド内では成立しないので、署名しても意味がない。実行ファイルには arm64 のリンカが必ず付ける ad-hoc 署名が乗っていて、macOS が起動に要求するのはそれだけ
- **`--rebuild` でガードを直す**。最小の修正に見えて違った。出力が store に無いと `checking is not possible` で落ちる（キャッシュを外せば毎回そうなる）
- **`nix-package-macos` を rust フィルタにも乗せる**。この種の破損は nixpkgs 更新＝ flake.lock 経由で来る。Rust のコンパイルエラーは rust ジョブの担当
- **release.yml から macOS 成果物を配る**。配布は今まで通り flake から

## 資料

- [tauri-bundler `remove_extra_attr`](https://github.com/tauri-apps/tauri/blob/tauri-cli-v2.11.4/crates/tauri-bundler/src/bundle/macos/app.rs#L156) — `xattr -crs` の呼び出しと、それが署名パスの内側にあること
