### PR TITLE
refactor(timeline): make entries read-only

### DIFF
--- a/tauri-app/dev/ipc-mock.js
+++ b/tauri-app/dev/ipc-mock.js
@@ -193,13 +193,6 @@
       const line = `- [${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}] ${text}`;
       timeline.set(iso, [...(timeline.get(iso) ?? []), line]);
     },
-    update_timeline_entry: ({ date, index, text }) => {
-      const lines = timeline.get(date) ?? [];
-      const raw = lines[index] ?? "";
-      const head = raw.match(/^- \[\d{2}:\d{2}:\d{2}\] /)?.[0] ?? "- [00:00:00] ";
-      const tail = raw.includes(" {") ? raw.slice(raw.lastIndexOf(" {")) : "";
-      lines[index] = `${head}${text}${tail}`;
-    },
     delete_timeline_entry: ({ date, index }) => {
       const lines = timeline.get(date) ?? [];
       lines.splice(index, 1);

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -172,19 +172,6 @@ fn read_timeline_by_date(handle: AppHandle, date: String) -> Result<Vec<String>,
 }
 
 #[tauri::command]
-fn update_timeline_entry(
-    handle: AppHandle,
-    date: String,
-    index: usize,
-    text: String,
-) -> Result<(), String> {
-    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
-    let naive = chrono::NaiveDate::parse_from_str(&date, "%Y-%m-%d").map_err(|e| e.to_string())?;
-    magical_merchant_core::update_timeline_entry(&base_dir, naive, index, &text)
-        .map_err(|e| e.to_string())
-}
-
-#[tauri::command]
 fn delete_timeline_entry(handle: AppHandle, date: String, index: usize) -> Result<(), String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
     let naive = chrono::NaiveDate::parse_from_str(&date, "%Y-%m-%d").map_err(|e| e.to_string())?;
@@ -310,7 +297,6 @@ pub fn run() {
             read_timeline,
             list_timeline_dates,
             read_timeline_by_date,
-            update_timeline_entry,
             delete_timeline_entry,
             search_all,
             resolve_places,

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -69,7 +69,6 @@ interface CommandMap {
   read_timeline: { args: void; result: string[] };
   list_timeline_dates: { args: void; result: string[] };
   read_timeline_by_date: { args: { date: string }; result: string[] };
-  update_timeline_entry: { args: { date: string; index: number; text: string }; result: void };
   delete_timeline_entry: { args: { date: string; index: number }; result: void };
   search_all: { args: { query: string }; result: SearchHit[] };
   /** このノートを `[[ID]]` で指している記録。開くたびに走査で導出される。 */
@@ -112,7 +111,6 @@ export type CommandName = keyof CommandMap;
 /** ノート/タイムラインのファイルを書き換えるコマンド。 */
 const MUTATING: ReadonlySet<CommandName> = new Set<CommandName>([
   "save_quick_capture",
-  "update_timeline_entry",
   "delete_timeline_entry",
   "create_draft",
   "update_draft",

--- a/tauri-app/src/lib/i18n.ts
+++ b/tauri-app/src/lib/i18n.ts
@@ -44,8 +44,6 @@ const ja = {
     dark: "ダーク",
   },
   timeline: {
-    editHint: "クリックでそのまま編集 · Esc で確定",
-    savedTick: "✓ 保存しました",
     promote: "ノートにする",
     emptyFiltered: "このタグの記録はまだありません。",
     emptyToday: "今日はまだ何も記録していません。",
@@ -244,8 +242,6 @@ const en: Messages = {
     dark: "Dark",
   },
   timeline: {
-    editHint: "Click to edit · Esc to commit",
-    savedTick: "✓ Saved",
     promote: "Turn into a note",
     emptyFiltered: "Nothing recorded with this tag yet.",
     emptyToday: "Nothing recorded today yet.",

--- a/tauri-app/src/styles/timeline.css
+++ b/tauri-app/src/styles/timeline.css
@@ -79,11 +79,6 @@
   font-variant-numeric: tabular-nums;
 }
 
-.entry--active .entry-time {
-  color: var(--app-text);
-  font-weight: 600;
-}
-
 .entry-rail {
   position: relative;
   display: block;
@@ -110,15 +105,6 @@
   box-sizing: border-box;
 }
 
-.entry--active .entry-rail-dot {
-  left: 9px;
-  top: 5px;
-  width: 10px;
-  height: 10px;
-  background: var(--app-accent);
-  border: none;
-}
-
 .entry--selected .entry-rail-dot {
   background: var(--app-accent);
   border-color: var(--app-accent);
@@ -137,23 +123,11 @@
      1 行が長くなりすぎないという意味でも、この列はここで止めたい */
   max-width: 552px;
   margin: 0;
-  padding: 0;
-  border: none;
-  background: none;
-  text-align: start;
-  font-family: inherit;
   font-size: 15px;
   line-height: 1.75;
   color: var(--app-text);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
-  cursor: text;
-  border-radius: var(--radius-2);
-}
-
-.entry-text:focus-visible {
-  outline: 2px solid var(--app-accent);
-  outline-offset: 2px;
 }
 
 .entry-meta {
@@ -358,44 +332,6 @@
   background: var(--app-hairline);
 }
 
-/* ---------------- in-place editor ---------------- */
-
-.entry-editor {
-  border: 1px solid var(--app-text-faint);
-  border-radius: 10px;
-  padding: 14px 16px 12px;
-  background: var(--app-input-bg);
-}
-
-.entry-editor:focus-within {
-  box-shadow: 0 0 0 3px var(--app-accent-soft);
-}
-
-.entry-editor-input {
-  display: block;
-  width: 100%;
-  min-height: 3lh;
-  border: none;
-  outline: none;
-  resize: none;
-  padding: 0;
-  background: none;
-  color: var(--app-text);
-  font-family: inherit;
-  font-size: 15px;
-  line-height: 1.75;
-  field-sizing: content;
-}
-
-.entry-editor-foot {
-  display: flex;
-  justify-content: space-between;
-  gap: var(--size-2);
-  margin-top: 8px;
-  font-size: 11.5px;
-  color: var(--app-text-faint);
-}
-
 /* ---------------- empty ---------------- */
 
 .timeline-empty {
@@ -499,10 +435,6 @@
 
   .entry-rail-dot {
     left: 8px;
-  }
-
-  .entry--active .entry-rail-dot {
-    left: 7px;
   }
 
   .entry-time {

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -74,28 +74,19 @@ async function loadTimeline(extraDates: string[]): Promise<TimelineData> {
 
 interface EntryProps {
   item: TimelineItem;
-  editing: boolean;
   selecting: boolean;
   selected: boolean;
-  draft: () => string;
-  saved: () => boolean;
-  onDraft: (text: string) => void;
-  onEdit: () => void;
-  onCommit: () => void;
   onToggle: () => void;
   onPromote: () => void;
 }
 
 function Entry(props: EntryProps): JSX.Element {
   const meta = createMemo(() => entryMeta(props.item.context, places.nameOf));
-  // モバイルの入り口は長押し。タップは今まで通りその場編集
+  // モバイルの入り口は長押し。タップには何も割り当てない
   const press = createLongPress(() => props.onPromote());
 
   return (
-    <article
-      class="entry"
-      classList={{ "entry--active": props.editing, "entry--selected": props.selected }}
-    >
+    <article class="entry" classList={{ "entry--selected": props.selected }}>
       <span class="entry-time">{props.item.time.slice(0, 5)}</span>
       <span class="entry-rail" aria-hidden="true">
         <span class="entry-rail-line" />
@@ -103,32 +94,8 @@ function Entry(props: EntryProps): JSX.Element {
       </span>
 
       <div class="entry-body">
-        <Show when={props.editing}>
-          <div class="entry-editor">
-            <textarea
-              class="entry-editor-input"
-              ref={(el) => queueMicrotask(() => el.focus())}
-              value={props.draft()}
-              onInput={(e) => props.onDraft(e.currentTarget.value)}
-              onBlur={() => props.onCommit()}
-              onKeyDown={(e) => {
-                if (e.key === "Escape") {
-                  e.preventDefault();
-                  e.currentTarget.blur();
-                }
-              }}
-            />
-            <div class="entry-editor-foot">
-              <span>{t().timeline.editHint}</span>
-              <Show when={props.saved()}>
-                <span>{t().timeline.savedTick}</span>
-              </Show>
-            </div>
-          </div>
-        </Show>
-
-        <Show when={!props.editing && props.selecting}>
-          {/* 選択モード中は本文クリックが編集ではなく選択のトグルになる */}
+        <Show when={props.selecting}>
+          {/* 選択モード中だけ本文がクリックできる。押すと選択のトグル */}
           <button
             type="button"
             class="entry-select"
@@ -142,23 +109,17 @@ function Entry(props: EntryProps): JSX.Element {
           </button>
         </Show>
 
-        <Show when={!props.editing && !props.selecting}>
-          {/* 本文そのものが編集の入口。button なのはキーボードから開けるようにするため */}
-          <button
-            type="button"
+        <Show when={!props.selecting}>
+          {/* 記録は書き換えない。本文は読むだけで、触れる先はノートへの昇格だけ */}
+          <p
             class="entry-text"
             onPointerDown={(e) => press.onPointerDown(e)}
             onPointerUp={() => press.onPointerUp()}
             onPointerMove={() => press.onPointerMove()}
             onPointerCancel={() => press.onPointerCancel()}
-            onClick={() => {
-              if (press.shouldClick()) {
-                props.onEdit();
-              }
-            }}
           >
             <TagText text={props.item.text} />
-          </button>
+          </p>
           <Show when={meta().length}>
             <div class="entry-meta">
               <For each={meta()}>
@@ -216,10 +177,7 @@ export default function Timeline(): JSX.Element {
   const [jumpTo, setJumpTo] = createSignal<string | null>(null);
   /** 絞り込み中のタグ。1 つだけ選べる。 */
   const [tagFilter, setTagFilter] = createSignal<string | null>(null);
-  const [editing, setEditing] = createSignal<TimelineItem | null>(null);
-  const [draft, setDraft] = createSignal("");
-  const [saved, setSaved] = createSignal(false);
-  /** 選択モード。入っている間は本文クリックが編集ではなく選択になる。 */
+  /** 選択モード。入っている間だけ本文がクリックで選択できる。 */
   const [selecting, setSelecting] = createSignal(false);
   const [selected, setSelected] = createSignal<ReadonlySet<string>>(new Set());
   /** 削除前のワンクッション。確認バーが出ている間だけ true。 */
@@ -336,28 +294,6 @@ export default function Timeline(): JSX.Element {
     await reloadDay(toIsoDate(new Date()));
   };
 
-  // ---- その場編集（Esc / フォーカスを外すと確定）----
-  const startEditing = (item: TimelineItem): void => {
-    setDraft(item.text);
-    setSaved(false);
-    setEditing(item);
-  };
-
-  const commitEdit = async (): Promise<void> => {
-    const item = editing();
-    const text = draft();
-    setEditing(null);
-    if (!item || text === item.text) {
-      return;
-    }
-    await typedInvoke("update_timeline_entry", { date: item.date, index: item.index, text });
-    setSaved(true);
-    await reloadDay(item.date);
-  };
-
-  // タブを切り替えても書きかけを捨てない。blur はアンマウントでは飛ばない。
-  onCleanup(() => void commitEdit());
-
   /**
    * エントリを昇格させてノートを作り、そのまま書き始められる状態で開く。
    * エントリ側のファイルには何も書かない — ノートの frontmatter `origin`
@@ -383,12 +319,6 @@ export default function Timeline(): JSX.Element {
   };
 
   // ---- まとめて削除（選択 → 確認 → 実行）----
-  const startSelecting = (): void => {
-    // 書きかけを確定してから入る。編集と選択が同時だと本文クリックの意味が曖昧になる
-    void commitEdit();
-    setSelecting(true);
-  };
-
   const exitSelecting = (): void => {
     setSelecting(false);
     setSelected(new Set<string>());
@@ -519,7 +449,11 @@ export default function Timeline(): JSX.Element {
                 when={!selecting()}
                 fallback={<span class="timeline-toolbar-hint">{t().timeline.selectHint}</span>}
               >
-                <button type="button" class="timeline-toolbar-button" onClick={startSelecting}>
+                <button
+                  type="button"
+                  class="timeline-toolbar-button"
+                  onClick={() => setSelecting(true)}
+                >
                   <Icon name="check-square" size={14} />
                   {t().timeline.select}
                 </button>
@@ -562,14 +496,8 @@ export default function Timeline(): JSX.Element {
                       {(item) => (
                         <Entry
                           item={item}
-                          editing={editing()?.id === item.id}
                           selecting={selecting()}
                           selected={selected().has(item.id)}
-                          draft={draft}
-                          saved={saved}
-                          onDraft={setDraft}
-                          onEdit={() => startEditing(item)}
-                          onCommit={() => void commitEdit()}
                           onToggle={() => toggleSelected(item.id)}
                           onPromote={() => void promote(item)}
                         />


### PR DESCRIPTION
## なぜやるか

タイムラインは「その瞬間に書いたこと」をそのまま残す記録で、あとから書き換えられると Notes との境目が曖昧になる。加えてタップ＝編集が、ノートへ昇格させる長押しと同じ場所を取り合っていた。記録側は編集できなくてよい、という判断。

## やったこと

- エントリ本文を `button` から `p` に戻し、その場編集の状態・UI・CSS を削除
- エントリからの出口は据え置き。長押し（タッチ）／ホバーのアイコン（PC）でノートへ昇格、選択モードでまとめて削除
- 到達不能になった `update_timeline_entry` の IPC 経路（Tauri コマンド・型定義・dev モック）を削除
- 文言 `editHint` / `savedTick` を削除

## やらなかったこと

- `core` 側の `update_timeline_entry` は残した。core はフレームワーク非依存でテストを持つ層で、UI の入口を閉じたことと core の能力は別の話
- 記録を訂正する代替手段は足していない。消して書き直す道は残っている
