### PR TITLE
fix(desktop): open the window at a desktop size

### DIFF
--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -13,8 +13,11 @@
     "windows": [
       {
         "title": "Magical Merchant",
-        "width": 400,
-        "height": 700
+        "width": 1080,
+        "height": 760,
+        "minWidth": 380,
+        "minHeight": 520,
+        "center": true
       }
     ],
     "security": {


### PR DESCRIPTION
## なぜやるか

既定のウィンドウが 400x700、つまり電話のサイズだった。デスクトップでもモバイルブレークポイント（`max-width: 767px`）の内側に入るため、モードタブと検索フィールドが隠れ、下タブが出て、すべてが 1 列に押し込まれた状態で起動していた。狭く見えたのは、実際にスマホ用のレイアウトがデスクトップで開いていたから。

## やったこと

- 起動サイズを 1080x760 に変更。いちばん幅を要求する Notes（300px の一覧ペイン + 640px の本文 + 左右 padding）が収まる幅
- `minWidth: 380` / `minHeight: 520` を設定。窓を狭めればこれまでのモバイルレイアウトにも戻せる
- `center: true` で初回起動位置を画面中央に

## やらなかったこと

- ウィンドウサイズ・位置の記憶（`tauri-plugin-window-state`）は入れていない。依存が 1 つ増えるので、必要になってから
- CSS のカラム幅（timeline 680px / ノート本文 640px）は据え置き。1 行を長くしすぎないための値で、窓が広くなっても読みやすさの上限は変わらない
