### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "magical-merchant-app"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "battery",
@@ -2448,7 +2448,7 @@ dependencies = [
 
 [[package]]
 name = "magical-merchant-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "magical-merchant-mcp-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magical-merchant-core"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Framework-independent core logic for the Magical Merchant note-taking app"
 license.workspace = true

--- a/mcp-cli/Cargo.toml
+++ b/mcp-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magical-merchant-mcp-cli"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "MCP server exposing Magical Merchant notes to AI agents"
 license.workspace = true

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magical-merchant",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magical-merchant-app"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Tauri desktop and mobile shell for the Magical Merchant note-taking app"
 license.workspace = true

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegram/nicegram-app-schemas/refs/heads/main/tauri/tauri.conf.json",
   "productName": "Magical Merchant",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "com.magical-merchant.app",
   "build": {
     "frontendDist": "../dist",

--- a/workers/package.json
+++ b/workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magical-merchant-sync",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## なぜやるか

v0.3.0 を出すための版上げ。リリースワークフローはタグ名と `tauri.conf.json` の `version` の一致を検証して落ちるので、タグを打つ前にこのコミットが要る。Android は versionCode をこの値から導くため、ずれた APK は入っている版を上書き更新できない。

v0.2.0 からの変更:

- デスクトップが電話サイズではなくデスクトップサイズの窓で開く (#130)
- ログインが外部ブラウザではなくアプリ内で完結する (#131)
- タイムラインのエントリが編集できる文章ではなく記録になった (#129)
- 新しいアプリアイコン。あわせて、これまで配信 APK が Tauri のロゴのままだった Android にも初めて届く (#132)

## やったこと

- 版を持つ 6 つのマニフェストと `Cargo.lock` を 0.3.0 に更新

`pnpm-lock.yaml` は自身の版を記録していないので変化しない。

## やらなかったこと

- タグ打ちは含まない。この PR をマージしたあと、`main` で `v0.3.0` を打つとリリースワークフローが走る
