### PR TITLE
feat(timeline): let promoted notes be unlinked and stop stale chips after deletion

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,7 +15,7 @@ pub use note::error::NoteError;
 pub use note::{
     NoteSummary, create_draft_note, create_note_from_entry, delete_note, list_notes, read_note,
     read_note_by_filename, read_note_meta, repair_notes, update_note, update_note_meta,
-    update_note_view,
+    update_note_origin, update_note_view,
 };
 pub use search::{HitKind, SearchHit, find_backlinks, search_all};
 pub use timeline::error::TimelineError;

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -91,6 +91,16 @@ pub fn update_note_view(
     Notes::new(base_dir.to_path_buf()).update_view(filename, view)
 }
 
+/// 昇格元エントリとの繋がりだけを差し替える。`None` で関係を解いて
+/// 独立したノートに戻す。time / tags / context / 本文には触れない。
+pub fn update_note_origin(
+    base_dir: &Path,
+    filename: &NoteFilename,
+    origin: Option<&str>,
+) -> Result<(), CoreError> {
+    Notes::new(base_dir.to_path_buf()).update_origin(filename, origin)
+}
+
 /// 過去の編集で本文に混入した化けメタデータを直す。直したファイル数を返す。
 pub fn repair_notes(base_dir: &Path) -> Result<usize, CoreError> {
     repair::repair_all(&crate::utils::paths::notes_dir(base_dir))
@@ -526,6 +536,87 @@ mod tests {
 
         let meta = read_note_meta(tmp.path(), &filename).unwrap();
         assert_eq!(meta.view, Some("mindmap".to_string()));
+    }
+
+    fn promoted_note(tmp: &TempDir) -> NoteFilename {
+        let path = create_note_from_entry(
+            tmp.path(),
+            "エントリ本文",
+            &[],
+            &mock_context(),
+            "2026-08-13T08:30:00",
+        )
+        .unwrap();
+        filename_of(&path)
+    }
+
+    #[test]
+    fn update_note_origin_none_clears_the_key() {
+        let tmp = TempDir::new().unwrap();
+        let filename = promoted_note(&tmp);
+
+        update_note_origin(tmp.path(), &filename, None).unwrap();
+
+        let content =
+            fs::read_to_string(tmp.path().join("data/notes").join(filename.as_str())).unwrap();
+        assert!(!content.contains("origin"));
+    }
+
+    /// 解除は関係を断つだけで、ノートそのものの記録には触れない。
+    #[test]
+    fn update_note_origin_keeps_body_time_and_context() {
+        let tmp = TempDir::new().unwrap();
+        let filename = promoted_note(&tmp);
+        let before = read_note_meta(tmp.path(), &filename).unwrap();
+
+        update_note_origin(tmp.path(), &filename, None).unwrap();
+
+        let meta = read_note_meta(tmp.path(), &filename).unwrap();
+        assert_eq!(meta.time, before.time);
+        assert_eq!(meta.context.unwrap().battery, Some(50));
+        assert!(
+            read_note_by_filename(tmp.path(), &filename)
+                .unwrap()
+                .contains("エントリ本文")
+        );
+    }
+
+    /// Undo(繋ぎ直し)の経路。解除した値をそのまま書き戻せる。
+    #[test]
+    fn update_note_origin_restores_the_link() {
+        let tmp = TempDir::new().unwrap();
+        let filename = promoted_note(&tmp);
+        update_note_origin(tmp.path(), &filename, None).unwrap();
+
+        update_note_origin(tmp.path(), &filename, Some("2026-08-13T08:30:00")).unwrap();
+
+        let meta = read_note_meta(tmp.path(), &filename).unwrap();
+        assert_eq!(meta.origin, Some("2026-08-13T08:30:00".to_string()));
+    }
+
+    #[test]
+    fn update_note_origin_not_found() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("data/notes")).unwrap();
+        let filename = NoteFilename::parse("nonexistent.md").unwrap();
+
+        let result = update_note_origin(tmp.path(), &filename, None);
+
+        assert!(matches!(result, Err(CoreError::NotFound(_))));
+    }
+
+    /// 本文の保存で昇格元との繋がりが消えると、タイムラインのチップが
+    /// 編集のたびに消えてしまう。
+    #[test]
+    fn update_note_keeps_the_origin() {
+        let tmp = TempDir::new().unwrap();
+        let filename = promoted_note(&tmp);
+        let path = tmp.path().join("data/notes").join(filename.as_str());
+
+        update_note(&path, "書き直した本文", &mock_context()).unwrap();
+
+        let meta = read_note_meta(tmp.path(), &filename).unwrap();
+        assert_eq!(meta.origin, Some("2026-08-13T08:30:00".to_string()));
     }
 
     #[test]

--- a/core/src/note/repository.rs
+++ b/core/src/note/repository.rs
@@ -173,6 +173,26 @@ impl Notes {
         Ok(())
     }
 
+    /// 昇格元エントリとの繋がりだけを差し替えて書き戻す。他のメタデータと
+    /// 本文には触れない。`update_view` と同じく、frontmatter が読めない
+    /// ファイルには書かない。
+    pub(crate) fn update_origin(
+        &self,
+        filename: &NoteFilename,
+        origin: Option<&str>,
+    ) -> Result<(), CoreError> {
+        let path = self.existing_note_path(filename)?;
+        let content = fs::read_to_string(&path)?;
+        let (existing, body) = frontmatter::parse::<NoteFrontmatter>(&content)?;
+
+        let fm = NoteFrontmatter {
+            origin: origin.map(str::to_string),
+            ..existing
+        };
+        write_atomic(&path, frontmatter::render(&fm, body)?)?;
+        Ok(())
+    }
+
     pub(crate) fn delete(&self, filename: &NoteFilename) -> Result<(), CoreError> {
         fs::remove_file(self.existing_note_path(filename)?)?;
         Ok(())

--- a/tauri-app/dev/ipc-mock.js
+++ b/tauri-app/dev/ipc-mock.js
@@ -334,6 +334,12 @@
         note.view = view;
       }
     },
+    set_note_origin: ({ filename, origin }) => {
+      const note = notes.get(filename);
+      if (note) {
+        note.origin = origin ?? undefined;
+      }
+    },
     delete_note: ({ filename }) => {
       notes.delete(filename);
     },

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -147,6 +147,19 @@ fn set_note_view(handle: AppHandle, filename: String, view: Option<String>) -> R
         .map_err(|e| e.to_string())
 }
 
+/// 昇格元エントリとの繋がりだけを書き換える。`None` で関係を解く。
+#[tauri::command]
+fn set_note_origin(
+    handle: AppHandle,
+    filename: String,
+    origin: Option<String>,
+) -> Result<(), String> {
+    let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    let filename = NoteFilename::parse(&filename).map_err(|e| e.to_string())?;
+    magical_merchant_core::update_note_origin(&base_dir, &filename, origin.as_deref())
+        .map_err(|e| e.to_string())
+}
+
 #[tauri::command]
 fn read_timeline(handle: AppHandle) -> Result<Vec<String>, String> {
     let base_dir = handle.path().app_data_dir().map_err(|e| e.to_string())?;
@@ -293,6 +306,7 @@ pub fn run() {
             read_note_meta,
             find_backlinks,
             update_note_meta,
+            set_note_origin,
             set_note_view,
             read_timeline,
             list_timeline_dates,

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -94,6 +94,8 @@ interface CommandMap {
   read_note_meta: { args: { filename: string }; result: NoteMeta };
   update_note_meta: { args: { filename: string; time: string; tags: string[] }; result: void };
   set_note_view: { args: { filename: string; view: string | null }; result: void };
+  /** 昇格元エントリとの繋がりを書き換える。`null` で関係を解く。 */
+  set_note_origin: { args: { filename: string; origin: string | null }; result: void };
   delete_note: { args: { filename: string }; result: void };
   save_document: { args: { body: string; tags: string[] } & ClientArgs; result: void };
   sync_start: { args: void; result: void };
@@ -116,6 +118,7 @@ const MUTATING: ReadonlySet<CommandName> = new Set<CommandName>([
   "update_draft",
   "update_note_meta",
   "set_note_view",
+  "set_note_origin",
   "delete_note",
   "save_document",
 ]);

--- a/tauri-app/src/lib/i18n.ts
+++ b/tauri-app/src/lib/i18n.ts
@@ -45,6 +45,8 @@ const ja = {
   },
   timeline: {
     promote: "ノートにする",
+    unlink: (title: string) => `「${title}」との関係を解除`,
+    unlinked: "ノートとの関係を解除しました",
     emptyFiltered: "このタグの記録はまだありません。",
     emptyToday: "今日はまだ何も記録していません。",
     emptyFilteredHint: "上のチップで絞り込みを外せます。",
@@ -243,6 +245,8 @@ const en: Messages = {
   },
   timeline: {
     promote: "Turn into a note",
+    unlink: (title: string) => `Unlink “${title}”`,
+    unlinked: "Note unlinked from this day",
     emptyFiltered: "Nothing recorded with this tag yet.",
     emptyToday: "Nothing recorded today yet.",
     emptyFilteredHint: "Drop the filter with the chips above.",

--- a/tauri-app/src/styles/timeline.css
+++ b/tauri-app/src/styles/timeline.css
@@ -179,29 +179,75 @@
 }
 
 .origin-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  border: 1px solid var(--app-border);
+  border-radius: 999px;
+  background: var(--app-surface);
+  color: var(--app-text-muted);
+}
+
+.origin-chip:hover,
+.origin-chip:focus-within {
+  background: var(--app-accent-soft);
+  color: var(--app-text);
+}
+
+.origin-chip-open {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   max-width: 100%;
   padding: 4px 10px;
-  border: 1px solid var(--app-border);
-  border-radius: 999px;
-  background: var(--app-surface);
-  color: var(--app-text-muted);
+  border: none;
+  background: none;
+  color: inherit;
   font-family: inherit;
   font-size: 12px;
   cursor: pointer;
-}
-
-.origin-chip:hover {
-  background: var(--app-accent-soft);
-  color: var(--app-text);
 }
 
 .origin-chip-title {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* 関係の解除。矢印の場所にホバーでだけ現れる、隠しアクションの流儀 */
+.origin-chip-unlink {
+  position: absolute;
+  top: 50%;
+  right: 6px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border: none;
+  border-radius: 999px;
+  background: none;
+  color: var(--app-text-faint);
+  cursor: pointer;
+  transform: translateY(-50%);
+}
+
+.origin-chip-unlink:hover {
+  color: var(--app-danger);
+}
+
+/* タッチ環境に × は出さない — チップの長押しが解除の入り口。
+   visibility で矢印の幅を残し、置き換えでチップ幅が動かないようにする */
+@media (hover: hover) {
+  .origin-chip:hover .origin-chip-arrow,
+  .origin-chip:focus-within .origin-chip-arrow {
+    visibility: hidden;
+  }
+
+  .origin-chip:hover .origin-chip-unlink,
+  .origin-chip:focus-within .origin-chip-unlink {
+    display: inline-flex;
+  }
 }
 
 /* ---------------- selection mode ---------------- */

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -318,6 +318,26 @@ export default function Timeline(): JSX.Element {
     navigate(`${ROUTES.NOTES}?file=${encodeURIComponent(note.filename)}`);
   };
 
+  /**
+   * 昇格元エントリとの関係を解く。消えるのは繋がりの記録だけで、
+   * ノート本体には触れない。戻すときは同じ値を書き戻すだけなので、
+   * 削除と同じく確認ではなく Undo で受ける。
+   */
+  const unlinkNote = async (note: NoteItem): Promise<void> => {
+    const { origin } = note;
+    if (!origin) {
+      return;
+    }
+    await typedInvoke("set_note_origin", { filename: note.filename, origin: null });
+    await refetchNotes();
+    shell.showToast(t().timeline.unlinked, () => {
+      void (async () => {
+        await typedInvoke("set_note_origin", { filename: note.filename, origin });
+        await refetchNotes();
+      })();
+    });
+  };
+
   // ---- まとめて削除（選択 → 確認 → 実行）----
   const exitSelecting = (): void => {
     setSelecting(false);
@@ -477,17 +497,43 @@ export default function Timeline(): JSX.Element {
                     <Show when={originNotes().get(day.date)?.length}>
                       <div class="origin-chips">
                         <For each={originNotes().get(day.date)}>
-                          {(note) => (
-                            <button
-                              type="button"
-                              class="origin-chip"
-                              onClick={() => openNote(note)}
-                            >
-                              <Icon name="file-text" size={13} />
-                              <span class="origin-chip-title">{note.title}</span>
-                              <span aria-hidden="true">→</span>
-                            </button>
-                          )}
+                          {(note) => {
+                            // モバイルの解除は長押し。PC はホバーで出る × が受ける
+                            const press = createLongPress(() => void unlinkNote(note));
+                            return (
+                              <span class="origin-chip">
+                                <button
+                                  type="button"
+                                  class="origin-chip-open"
+                                  onClick={() => {
+                                    // 長押しで解除した直後の click で開かない
+                                    if (press.shouldClick()) {
+                                      openNote(note);
+                                    }
+                                  }}
+                                  onPointerDown={(e) => press.onPointerDown(e)}
+                                  onPointerUp={() => press.onPointerUp()}
+                                  onPointerMove={() => press.onPointerMove()}
+                                  onPointerCancel={() => press.onPointerCancel()}
+                                >
+                                  <Icon name="file-text" size={13} />
+                                  <span class="origin-chip-title">{note.title}</span>
+                                  <span class="origin-chip-arrow" aria-hidden="true">
+                                    →
+                                  </span>
+                                </button>
+                                <button
+                                  type="button"
+                                  class="origin-chip-unlink"
+                                  title={t().timeline.unlink(note.title)}
+                                  aria-label={t().timeline.unlink(note.title)}
+                                  onClick={() => void unlinkNote(note)}
+                                >
+                                  <Icon name="x" size={12} />
+                                </button>
+                              </span>
+                            );
+                          }}
                         </For>
                       </div>
                     </Show>

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -465,6 +465,10 @@ export default function Workspace(): JSX.Element {
         await typedInvoke("delete_note", { filename: item.filename });
         await refetchNotes();
         setHidden((ids) => ids.filter((id) => id !== item.id));
+        // タイムラインの origin チップはノート一覧から導出される。Undo の
+        // 猶予中に他のビューへ移られるとこの refetch は届かないので、版を
+        // 上げて向こうの一覧も読み直させる
+        shell.refreshData();
       })();
     }, UNDO_MS);
 


### PR DESCRIPTION
## なぜやるか

タイムラインから昇格させたノートと元エントリの関係(frontmatter `origin`)に出口がなかった。

- 一度昇格させると関係を解く手段がなく、チップはノート本体を消す以外に外せない
- その削除も Undo 猶予(5秒)の後にコミットされるため、猶予中にタイムラインへ移ると、消したはずのノートのチップが残り続け、押すと存在しないノートに遷移する

## やったこと

- core に `update_note_origin` を追加(`None` で関係を解除。`update_note_view` と同じ形で、他のメタデータと本文には触れない)
- `set_note_origin` コマンドとして公開し、`typedInvoke` の型と IPC モックを配線
- タイムラインの origin チップに解除アクションを追加
  - PC: ホバーで矢印が × に置き換わる(隠しアクションの流儀、チップ幅は動かさない)
  - モバイル: チップの長押し(エントリの昇格と同じ入り口)
  - 解除は確認ではなく Undo 付きトースト。同じ値を書き戻すだけなので復元できる
- ノート削除のコミット後に `shell.refreshData()` を呼び、マウント中のビュー(タイムライン)にノート一覧を読み直させる

ブラウザハーネス(IPC モック)で、解除 → チップ消滅 → Undo で復元、および削除 → 5秒後にチップ消滅までを実操作で確認済み。

## やらなかったこと

- Notes(Workspace)側から origin を見せる・解除する UI。関係が見えるのはタイムラインのチップだけなので、入り口もそこに揃えた
- 昇格元エントリ側の削除に関係を連動させること。エントリのファイルには何も書かない現設計(チップはノートから毎回導出)は維持
- MCP への書き込みコマンド公開(既存方針どおり読み取りのみ)
