### PR TITLE
chore: opt renovate out of silent mode

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,11 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:recommended", ":semanticCommitTypeAll(chore)"],
+
+  // Mend の App は All repositories でインストールすると silent (dryRun=lookup) で
+  // 起動し、PR も dependency dashboard も作らない。ここで明示的に打ち消す
+  mode: "full",
+
   timezone: "Asia/Tokyo",
   schedule: ["before 6am on monday"],
   labels: ["dependencies"],


### PR DESCRIPTION
## なぜやるか

`renovate.json5` を入れた 8/16 以降、Renovate が一度も PR を出していない。ジョブログを読むと、スキャンは完走していて 115 依存・73 件の更新・10 ブランチぶんまで算出できているのに、最後の一歩で全部捨てられていた。

```
Silent mode enabled so repo is considered onboarded
Repository is running with mode=silent and will not make Issues or PRs by default
Branch renovate/cargo-dependencies creation is disabled because mode=silent
Dependency Dashboard issue is not created, updated or closed when mode=silent
```

Mend の App を **All repositories** でインストールすると、各リポジトリが `mode=silent` (`dryRun=lookup`) で起動する。管理者がうっかり全リポジトリをオンボードして PR を撒くのを防ぐための既定で、スキャンはするが branch も PR も dependency dashboard も一切作らない。`mode` は Mend のランナーが env config で注入しているが、リポジトリ設定は env config より後にマージされるので、ここで打ち消せる。

## やったこと

- `renovate.json5` に `mode: "full"` を追加

## やらなかったこと

- App のインストールを `Only select repositories` に切り替える手は取らなかった。有効化の意思が GitHub の設定画面の中だけに残り、git にも履歴にも出ないため。リポジトリ設定なら再インストールしても移管しても壊れず、他のリポジトリは silent のまま = 意図しない PR 洪水も起きない
- Dependabot alerts は無効のまま（ログの `No vulnerability alerts enabled for repo`）。有効にすると脆弱性のある依存を schedule 無視で上げてくれるが、これは別の判断なので分ける

## 資料

- [Mend-hosted Apps Configuration — installing into all repositories leads to silent mode](https://docs.renovatebot.com/mend-hosted/hosted-apps-config/#installing-renovate-into-all-repositories-leads-to-silent-mode)
- [Support silent/full modes · renovatebot/renovate#26724](https://github.com/renovatebot/renovate/issues/26724)
