### PR TITLE
feat(widget): テンプレートウィジェットを足す

### DIFF
--- a/tauri-app/android-widget/README.md
+++ b/tauri-app/android-widget/README.md
@@ -1,12 +1,14 @@
 # Android Home Screen Widgets
 
-Three widgets from the design (`2a` = Timeline capture bar, `2b` = notes):
+Four widgets from the design (`2a` = Timeline capture bar, `2b` = notes,
+`1e` = templates):
 
-| Widget                     | Size | Look                                                                        | Tap                                                      |
-| -------------------------- | ---- | --------------------------------------------------------------------------- | -------------------------------------------------------- |
-| `CaptureBarWidgetProvider` | 4×1  | `TIMELINE` + clock, rail, prompt, and today's last entry once there is one  | `QuickCaptureActivity` — writes without opening the app  |
-| `NotesNewWidgetProvider`   | 4×1  | `NOTES` + 「新しいノート」, rail, 「タップして書き始める」, plus square     | `magical-merchant://widget/new-note`                     |
-| `NotesListWidgetProvider`  | 4×2  | `NOTES` header with a plus, then the four most recent notes and their dates | row → `…/widget/note?file=…`, plus → `…/widget/new-note` |
+| Widget                     | Size | Look                                                                         | Tap                                                             |
+| -------------------------- | ---- | ---------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `CaptureBarWidgetProvider` | 4×1  | `TIMELINE` + clock, rail, prompt, and today's last entry once there is one   | `QuickCaptureActivity` — writes without opening the app         |
+| `NotesNewWidgetProvider`   | 4×1  | `NOTES` + 「新しいノート」, rail, 「タップして書き始める」, plus square      | `magical-merchant://widget/new-note`                            |
+| `NotesListWidgetProvider`  | 4×2  | `NOTES` header with a plus, then the four most recent notes and their dates  | row → `…/widget/note?file=…`, plus → `…/widget/new-note`        |
+| `TemplatesWidgetProvider`  | 4×3  | `TEMPLATES` header, then up to three templates — first filled, rest outlined | row → `…/widget/template?name=…`, header → `…/widget/templates` |
 
 Once the day has an entry the capture bar's prompt becomes 「続きを記録…」 with
 that entry's time and head below it, and the sheet grows chips for today's
@@ -32,7 +34,7 @@ Two names are load-bearing and fail only at runtime if they drift apart:
 - `System.loadLibrary("magical_merchant_app_lib")` must match `[lib] name` in
   `src-tauri/Cargo.toml`.
 - `Java_com_magical_1merchant_app_widget_WidgetBridge_saveQuickCapture` (and the
-  two read functions) is the JNI mangling of this package + object + method
+  three read functions) is the JNI mangling of this package + object + method
   (`_` in a package component escapes to `_1`). Renaming the Kotlin side means
   renaming the Rust symbol.
 
@@ -62,21 +64,34 @@ thinner entry is shorter than an in-app one rather than wrong.
 
 ## What the widgets read
 
-`readCaptureData` (today's last entry + tags) and `readNotes` (the recent list)
-are two calls on purpose, split along what each costs: the sheet reads one day
-file and has to open instantly, while the notes list reads every note. The
+`readCaptureData` (today's last entry + tags), `readNotes` (the recent list) and
+`readTemplates` (the buttons) are separate calls on purpose, split along what
+each costs: the sheet reads one day file and has to open instantly, the notes
+list reads every note, and the templates read opens only `data/templates/`. The
 notes read happens in `RemoteViewsFactory.onDataSetChanged`, which the platform
-calls off the main thread.
+calls off the main thread; the other two are cheap enough for `onUpdate`.
 
 Kotlin never takes a timeline line apart. `- [HH:MM:SS] text {json}` is parsed
 in [`../src-tauri/src/widget_summary.rs`](../src-tauri/src/widget_summary.rs)
 with the same core helpers the app uses.
 
-Both widgets set `updatePeriodMillis` to 30 minutes, the platform minimum. A
-capture from the sheet refreshes the bar immediately, but entries and notes
+They all set `updatePeriodMillis` to 30 minutes, the platform minimum. A capture
+from the sheet refreshes the bar immediately, but entries, notes and templates
 written _in the app_ have no way to tell a widget, so the poll is what catches
 them up. It costs a native-library load in our own process per period; the
 alternative — a stale bar until the launcher happens to rebind — reads as a bug.
+
+## What the templates widget does not decide
+
+A tap hands `…/widget/template?name=<stem>` to the app, which calls the same
+`create_from_template` the in-app menu does. Whether that makes a note or opens
+today's existing one is core's rule, not Kotlin's — the widget and the menu have
+to agree on "one daily note per day", and they only can while the decision has
+a single home. The widget likewise never resolves `{{date}}`.
+
+The templates it offers are simply the first three by name. Choosing them
+per-widget would need a configuration `Activity`; the name order is at least
+stable, so the same button keeps making the same note.
 
 ## Design tokens
 
@@ -103,7 +118,7 @@ placeholder 14sp, sheet input 15sp.
 
 `src-tauri/gen/android/` is gitignored and is recreated by `tauri android init`,
 so the sources live here instead. [`apply-widget.go`](apply-widget.go) copies
-`src/main/` into the generated project and registers the three `<receiver>`
+`src/main/` into the generated project and registers the four `<receiver>`
 elements, the `<activity>` and the list `<service>` in `AndroidManifest.xml`
 behind idempotent marker comments — the same approach as
 [`../android-signing`](../android-signing/README.md).

--- a/tauri-app/android-widget/apply-widget.go
+++ b/tauri-app/android-widget/apply-widget.go
@@ -3,7 +3,7 @@
 //
 // src-tauri/gen/android/ is gitignored and is recreated by `tauri android init`,
 // so widget sources cannot live there. They live in android-widget/src/main/
-// (tracked by git) and this patcher copies them in and registers the two
+// (tracked by git) and this patcher copies them in and registers the
 // <receiver> elements in the generated AndroidManifest.xml. Re-run it (via
 // `just android-widget-setup`) after any regeneration.
 //
@@ -30,9 +30,9 @@ const (
 
 const markerID = "widgets"
 
-// components is the manifest region: the two widget receivers and the capture
-// sheet they open. exported="false" throughout — the system's AppWidgetService
-// is exempt from the export check, and the sheet is only ever started through a
+// components is the manifest region: the widget receivers and the capture sheet
+// they open. exported="false" throughout — the system's AppWidgetService is
+// exempt from the export check, and the sheet is only ever started through a
 // PendingIntent this app created, which carries this app's identity.
 const components = `        <activity
             android:name=".widget.QuickCaptureActivity"
@@ -76,6 +76,18 @@ const components = `        <activity
             <meta-data
                 android:name="android.appwidget.provider"
                 android:resource="@xml/widget_notes_list_info" />
+        </receiver>
+
+        <receiver
+            android:name=".widget.TemplatesWidgetProvider"
+            android:exported="false"
+            android:label="@string/widget_templates_widget_label">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_templates_info" />
         </receiver>
 
         <!-- BIND_REMOTEVIEWS is what makes exported="false" safe here: only the

--- a/tauri-app/android-widget/src/main/java/com/magical_merchant/app/widget/TemplatesWidgetProvider.kt
+++ b/tauri-app/android-widget/src/main/java/com/magical_merchant/app/widget/TemplatesWidgetProvider.kt
@@ -1,0 +1,82 @@
+package com.magical_merchant.app.widget
+
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.Context
+import android.view.View
+import android.widget.RemoteViews
+import com.magical_merchant.app.R
+
+/**
+ * 1e — templates (4x3).
+ *
+ * A tap makes the note and opens it. What decides whether a note is created or
+ * an existing one is opened lives in core (`create_note_from_template`): the
+ * same template tapped twice in a day opens the first note rather than making a
+ * second. Kotlin knows nothing about that rule and must not learn it — the
+ * in-app menu and this widget have to agree, and they only can if the decision
+ * has one home.
+ *
+ * The rows are fixed in the layout rather than backed by a RemoteViewsService.
+ * There are at most three, and a service exists to keep a long list's read off
+ * the main thread — this read only opens the templates directory.
+ */
+class TemplatesWidgetProvider : AppWidgetProvider() {
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+    ) {
+        val templates = WidgetBridge.readTemplateRows(context)
+        val views = RemoteViews(context.packageName, R.layout.widget_templates).apply {
+            SLOTS.forEachIndexed { index, slot ->
+                val template = templates.getOrNull(index)
+                if (template == null) {
+                    setViewVisibility(slot.row, View.GONE)
+                    return@forEachIndexed
+                }
+                setViewVisibility(slot.row, View.VISIBLE)
+                setTextViewText(slot.name, template.name)
+                setOnClickPendingIntent(
+                    slot.row,
+                    deepLinkPendingIntent(
+                        context,
+                        ROW_REQUEST_BASE + index,
+                        WidgetDeepLink.template(template.name),
+                    ),
+                )
+            }
+
+            // テンプレを 1 つも作っていない端末が普通の状態。空の枠だけを
+            // 置くと壊れて見えるので、作りに行く先を出す
+            setViewVisibility(
+                R.id.widget_templates_empty,
+                if (templates.isEmpty()) View.VISIBLE else View.GONE,
+            )
+            setOnClickPendingIntent(
+                R.id.widget_templates_empty,
+                deepLinkPendingIntent(context, MANAGE_REQUEST, WidgetDeepLink.TEMPLATES),
+            )
+            setOnClickPendingIntent(
+                R.id.widget_templates_header,
+                deepLinkPendingIntent(context, MANAGE_REQUEST, WidgetDeepLink.TEMPLATES),
+            )
+        }
+        appWidgetIds.forEach { appWidgetManager.updateAppWidget(it, views) }
+    }
+
+    private data class Slot(val row: Int, val name: Int)
+
+    private companion object {
+        /** 先頭だけ塗りつぶし。押す先が 1 つ目だと分かるようにする。 */
+        val SLOTS = listOf(
+            Slot(R.id.widget_template_row_1, R.id.widget_template_name_1),
+            Slot(R.id.widget_template_row_2, R.id.widget_template_name_2),
+            Slot(R.id.widget_template_row_3, R.id.widget_template_name_3),
+        )
+
+        // 5 まではキャプチャバーとノートのウィジェットが使っている
+        const val ROW_REQUEST_BASE = 10
+        const val MANAGE_REQUEST = 20
+    }
+}

--- a/tauri-app/android-widget/src/main/java/com/magical_merchant/app/widget/WidgetBridge.kt
+++ b/tauri-app/android-widget/src/main/java/com/magical_merchant/app/widget/WidgetBridge.kt
@@ -6,6 +6,9 @@ import org.json.JSONObject
 /** 一覧に出すノート 1 件。 */
 internal data class NoteRow(val title: String, val filename: String, val date: String)
 
+/** ウィジェットのボタン 1 つぶんのテンプレ。名前がそのまま起動の引数になる。 */
+internal data class TemplateRow(val name: String)
+
 /** キャプチャバーとシートが描くぶん。読めなければ空。 */
 internal data class CaptureData(
     val lastTime: String = "",
@@ -48,6 +51,9 @@ internal object WidgetBridge {
     /** The most recent notes, as JSON. Reads the whole notes tree. */
     external fun readNotes(baseDir: String): String?
 
+    /** The templates to offer, as JSON. Reads only the templates directory. */
+    external fun readTemplates(baseDir: String): String?
+
     /**
      * The directory Tauri's `app_data_dir()` resolves to, so the widget and the
      * app read and write the same tree.
@@ -74,6 +80,9 @@ internal object WidgetBridge {
     fun readNoteRows(context: Context): List<NoteRow> =
         runCatching { parseNotes(read(context, ::readNotes)) }.getOrElse { emptyList() }
 
+    fun readTemplateRows(context: Context): List<TemplateRow> =
+        runCatching { parseTemplates(read(context, ::readTemplates)) }.getOrElse { emptyList() }
+
     private fun read(context: Context, call: (String) -> String?): String =
         runCatching { call(baseDir(context)) }.getOrNull().orEmpty().ifEmpty { "{}" }
 
@@ -88,6 +97,13 @@ internal object WidgetBridge {
             tags = List(tags?.length() ?: 0) { tags?.optString(it).orEmpty() }
                 .filter { it.isNotEmpty() },
         )
+    }
+
+    private fun parseTemplates(raw: String): List<TemplateRow> {
+        val templates = JSONObject(raw).optJSONArray("templates")
+        return List(templates?.length() ?: 0) { index ->
+            TemplateRow(name = templates?.optJSONObject(index)?.optString("name").orEmpty())
+        }.filter { it.name.isNotEmpty() }
     }
 
     private fun parseNotes(raw: String): List<NoteRow> {

--- a/tauri-app/android-widget/src/main/java/com/magical_merchant/app/widget/WidgetDeepLink.kt
+++ b/tauri-app/android-widget/src/main/java/com/magical_merchant/app/widget/WidgetDeepLink.kt
@@ -9,6 +9,18 @@ import android.net.Uri
 internal object WidgetDeepLink {
     const val NEW_NOTE = "magical-merchant://widget/new-note"
     const val NOTE = "magical-merchant://widget/note"
+
+    /** テンプレの管理画面。ボタンが 1 つも無いウィジェットの行き先でもある。 */
+    const val TEMPLATES = "magical-merchant://widget/templates"
+
+    /**
+     * [name] のテンプレからノートを作って開く。
+     *
+     * 名前は人が付けたファイル名で、空白も日本語も入る。素で繋ぐと
+     * クエリとして壊れるので必ず通す。
+     */
+    fun template(name: String): String =
+        "magical-merchant://widget/template?name=" + Uri.encode(name)
 }
 
 /**

--- a/tauri-app/android-widget/src/main/res/drawable/ic_file_text.xml
+++ b/tauri-app/android-widget/src/main/res/drawable/ic_file_text.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Phosphor Icons / file-text (regular). Traced from
+     @phosphor-icons/core/assets/regular/file-text.svg.
+
+     White fill on purpose: the two places this is used want different colours
+     (on the filled row and on the outlined ones), and android:tint in the
+     layout can only darken what it is given. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="256"
+    android:viewportHeight="256">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M213.66,82.34l-56-56A8,8,0,0,0,152,24H56A16,16,0,0,0,40,40V216a16,16,0,0,0,16,16H200a16,16,0,0,0,16-16V88A8,8,0,0,0,213.66,82.34ZM160,51.31,188.69,80H160ZM200,216H56V40h88V88a8,8,0,0,0,8,8h48V216Zm-32-80a8,8,0,0,1-8,8H96a8,8,0,0,1,0-16h64A8,8,0,0,1,168,136Zm0,32a8,8,0,0,1-8,8H96a8,8,0,0,1,0-16h64A8,8,0,0,1,168,168Z" />
+</vector>

--- a/tauri-app/android-widget/src/main/res/drawable/widget_template_filled_bg.xml
+++ b/tauri-app/android-widget/src/main/res/drawable/widget_template_filled_bg.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 先頭のテンプレボタン。14dp radius の塗りつぶしで、押す先が
+     どれなのかを他の行と分ける。 -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/widget_accent" />
+    <corners android:radius="14dp" />
+</shape>

--- a/tauri-app/android-widget/src/main/res/drawable/widget_template_outline_bg.xml
+++ b/tauri-app/android-widget/src/main/res/drawable/widget_template_outline_bg.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 2 つ目以降のテンプレボタン。塗りは surface のまま、枠だけで押せることを
+     示す。radius は塗りつぶしの行と同じ 14dp。 -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/widget_on_accent" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/widget_border" />
+    <corners android:radius="14dp" />
+</shape>

--- a/tauri-app/android-widget/src/main/res/layout/widget_templates.xml
+++ b/tauri-app/android-widget/src/main/res/layout/widget_templates.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 1e — templates (4x3).
+     Header in the same 9.5sp/0.08 label style as the other widgets, then up to
+     three buttons. The first is filled so the most-used template reads as the
+     primary action; the rest are outlined. Rows the provider has no template
+     for are hidden rather than left blank. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_templates_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_bar_bg"
+    android:orientation="vertical"
+    android:padding="14dp">
+
+    <LinearLayout
+        android:id="@+id/widget_templates_header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingBottom="10dp">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:letterSpacing="0.08"
+            android:maxLines="1"
+            android:text="@string/widget_templates_label"
+            android:textColor="@color/widget_muted"
+            android:textSize="9.5sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:maxLines="1"
+            android:text="@string/widget_templates_app"
+            android:textColor="@color/widget_faint"
+            android:textSize="9.5sp" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/widget_template_row_1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/widget_template_filled_bg"
+        android:gravity="center_vertical"
+        android:minHeight="46dp"
+        android:orientation="horizontal"
+        android:paddingStart="14dp"
+        android:paddingEnd="14dp">
+
+        <ImageView
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:layout_marginEnd="10dp"
+            android:contentDescription="@null"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_file_text"
+            android:tint="@color/widget_on_accent" />
+
+        <TextView
+            android:id="@+id/widget_template_name_1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@color/widget_on_accent"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/widget_template_row_2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@drawable/widget_template_outline_bg"
+        android:gravity="center_vertical"
+        android:minHeight="46dp"
+        android:orientation="horizontal"
+        android:paddingStart="14dp"
+        android:paddingEnd="14dp">
+
+        <ImageView
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:layout_marginEnd="10dp"
+            android:contentDescription="@null"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_file_text"
+            android:tint="@color/widget_faint" />
+
+        <TextView
+            android:id="@+id/widget_template_name_2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@color/widget_text"
+            android:textSize="14sp" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/widget_template_row_3"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@drawable/widget_template_outline_bg"
+        android:gravity="center_vertical"
+        android:minHeight="46dp"
+        android:orientation="horizontal"
+        android:paddingStart="14dp"
+        android:paddingEnd="14dp">
+
+        <ImageView
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:layout_marginEnd="10dp"
+            android:contentDescription="@null"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_file_text"
+            android:tint="@color/widget_faint" />
+
+        <TextView
+            android:id="@+id/widget_template_name_3"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@color/widget_text"
+            android:textSize="14sp" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/widget_templates_empty"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:minHeight="46dp"
+        android:text="@string/widget_templates_empty"
+        android:textColor="@color/widget_muted"
+        android:textSize="13sp"
+        android:visibility="gone" />
+</LinearLayout>

--- a/tauri-app/android-widget/src/main/res/values/widget_strings.xml
+++ b/tauri-app/android-widget/src/main/res/values/widget_strings.xml
@@ -17,4 +17,10 @@
     <string name="widget_notes_list_label">最近のノート</string>
     <string name="widget_notes_list_description">最近のノートを開きます</string>
     <string name="widget_notes_empty">ノートがありません</string>
+
+    <string name="widget_templates_label">TEMPLATES</string>
+    <string name="widget_templates_app">Magical Merchant</string>
+    <string name="widget_templates_widget_label">テンプレート</string>
+    <string name="widget_templates_description">テンプレートからノートを作ります</string>
+    <string name="widget_templates_empty">テンプレートを作る</string>
 </resources>

--- a/tauri-app/android-widget/src/main/res/xml/widget_templates_info.xml
+++ b/tauri-app/android-widget/src/main/res/xml/widget_templates_info.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 30 minutes, the platform minimum: templates are edited in the app, and
+     nothing tells the widget when that happens. -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/widget_templates_description"
+    android:initialLayout="@layout/widget_templates"
+    android:minHeight="180dp"
+    android:minWidth="250dp"
+    android:previewImage="@mipmap/ic_launcher"
+    android:previewLayout="@layout/widget_templates"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellHeight="3"
+    android:targetCellWidth="4"
+    android:updatePeriodMillis="1800000"
+    android:widgetCategory="home_screen" />

--- a/tauri-app/src-tauri/src/widget_bridge.rs
+++ b/tauri-app/src-tauri/src/widget_bridge.rs
@@ -80,6 +80,17 @@ pub extern "system" fn Java_com_magical_1merchant_app_widget_WidgetBridge_readNo
     read_json(env, base_dir, widget_summary::collect_notes)
 }
 
+/// The templates the widget offers, as JSON. Reads only the templates
+/// directory, so the buttons do not wait on the whole notes tree.
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_com_magical_1merchant_app_widget_WidgetBridge_readTemplates<'local>(
+    env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    base_dir: JString<'local>,
+) -> JString<'local> {
+    read_json(env, base_dir, widget_summary::collect_templates)
+}
+
 /// Serializes whatever `collect` gathers under `base_dir`.
 ///
 /// An unreadable path yields `{}`, not an exception: a Java exception crossing

--- a/tauri-app/src-tauri/src/widget_summary.rs
+++ b/tauri-app/src-tauri/src/widget_summary.rs
@@ -18,6 +18,8 @@ use serde::Serialize;
 
 /// 4x2 のノートウィジェットに収まる行数。
 const NOTE_LIMIT: usize = 4;
+/// テンプレウィジェットのボタン数。押せる高さ(46dp)で並べるとこれが上限。
+const TEMPLATE_LIMIT: usize = 3;
 /// シートに出すタグチップ。3 つを超えると 1 行に収まらない。
 const TAG_LIMIT: usize = 3;
 /// バーは 1 行しか出せない。長い記録は先頭だけ見せる。
@@ -40,6 +42,14 @@ pub(crate) struct NotesData {
     notes: Vec<NoteRow>,
 }
 
+/// テンプレウィジェットが要るぶん。テンプレ置き場だけを読む。
+#[derive(Debug, Default, Serialize)]
+pub(crate) struct TemplatesData {
+    /// 名前順のテンプレ。並びが実行ごとに変わると、同じ位置を押しても
+    /// 違うノートが生まれる。
+    templates: Vec<TemplateRow>,
+}
+
 #[derive(Debug, Serialize)]
 struct LastEntry {
     time: String,
@@ -51,6 +61,12 @@ struct NoteRow {
     title: String,
     filename: String,
     date: String,
+}
+
+#[derive(Debug, Serialize)]
+struct TemplateRow {
+    /// ボタンに出す名前であり、ディープリンクに載せる値でもある。
+    name: String,
 }
 
 /// Unreadable trees come back empty rather than as an error: a widget with no
@@ -68,6 +84,21 @@ pub(crate) fn collect_capture(base_dir: &Path) -> CaptureData {
 pub(crate) fn collect_notes(base_dir: &Path) -> NotesData {
     NotesData {
         notes: recent_notes(magical_merchant_core::list_notes(base_dir).unwrap_or_default()),
+    }
+}
+
+/// ノート一覧と分けてあるのは、テンプレ置き場だけ読めば足りるため。
+/// ここで全ノートを読むと、ボタンを 3 つ描くために全ファイルを開くことになる。
+pub(crate) fn collect_templates(base_dir: &Path) -> TemplatesData {
+    TemplatesData {
+        templates: magical_merchant_core::list_templates(base_dir)
+            .unwrap_or_default()
+            .into_iter()
+            .take(TEMPLATE_LIMIT)
+            .map(|template| TemplateRow {
+                name: template.name,
+            })
+            .collect(),
     }
 }
 
@@ -209,5 +240,31 @@ mod tests {
     #[test]
     fn a_blank_note_is_labelled_rather_than_left_empty() {
         assert_eq!(title_of("\n  \n"), UNTITLED);
+    }
+
+    /// 置いた数だけ並べると、ボタンがウィジェットの外まで伸びる。
+    #[test]
+    fn only_the_first_few_templates_fit_on_the_widget() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        for name in ["a", "b", "c", "d"] {
+            let filename =
+                magical_merchant_core::NoteFilename::parse(&format!("{name}.md")).unwrap();
+            magical_merchant_core::save_template(tmp.path(), &filename, "body", &[]).unwrap();
+        }
+
+        let data = collect_templates(tmp.path());
+
+        assert_eq!(data.templates.len(), TEMPLATE_LIMIT);
+        // 名前順。並びが変わると、同じ位置を押しても違うノートが生まれる
+        let names: Vec<&str> = data.templates.iter().map(|t| t.name.as_str()).collect();
+        assert_eq!(names, ["a", "b", "c"]);
+    }
+
+    /// テンプレを 1 つも置いていない端末が普通の状態。空で描かせる。
+    #[test]
+    fn a_tree_without_templates_comes_back_empty() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        assert!(collect_templates(tmp.path()).templates.is_empty());
     }
 }

--- a/tauri-app/src/layouts/AppLayout.tsx
+++ b/tauri-app/src/layouts/AppLayout.tsx
@@ -11,7 +11,7 @@ import FirstRunCard from "../components/FirstRunCard";
 import { ShellProvider, useShell } from "../lib/shell";
 import { createSyncState, syncIconName } from "../lib/sync";
 import { applyTheme, nextTheme, readStoredTheme, THEME_ICONS } from "../lib/theme";
-import { t } from "../lib/i18n";
+import { locale, t } from "../lib/i18n";
 import type { Theme } from "../lib/theme";
 import { MODE_ICONS, MODE_LABELS, ROUTES } from "../lib/routes";
 import type { RoutePath } from "../lib/routes";
@@ -71,9 +71,43 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
     })();
   };
 
+  /**
+   * ウィジェットのテンプレボタン。同じテンプレの今日のぶんが既にあれば
+   * core が作らずにそれを返すので、ここは開くだけでいい。
+   */
+  const openFromTemplate = (name: string): void => {
+    shell.closePalette();
+    void (async () => {
+      try {
+        const created = await typedInvoke("create_from_template", {
+          filename: `${name}.md`,
+          locale: locale(),
+          client: await getDeviceSignals(),
+        });
+        shell.refreshData();
+        const filename = created.path.split("/").at(-1);
+        navigate(filename ? `${ROUTES.NOTES}?file=${encodeURIComponent(filename)}` : ROUTES.NOTES);
+      } catch {
+        // 消したテンプレを指したままのウィジェットが残っていることがある。
+        // 押しても何も起きないより、一覧を開いて理由を出す
+        navigate(ROUTES.NOTES);
+        shell.showToast(t().templates.createFailed);
+      }
+    })();
+  };
+
   const runWidgetAction = (action: WidgetAction): void => {
     if (action.name === "new-note") {
       newNote();
+      return;
+    }
+    if (action.name === "template" && action.template) {
+      openFromTemplate(action.template);
+      return;
+    }
+    // ボタンが 1 つも無いウィジェットと、そのヘッダの行き先
+    if (action.name === "templates") {
+      navigate(ROUTES.TEMPLATES);
       return;
     }
     // ?file= はルーターに預ける。Workspace の選択状態を外から触れるように

--- a/tauri-app/src/lib/widget-actions.test.ts
+++ b/tauri-app/src/lib/widget-actions.test.ts
@@ -6,6 +6,7 @@ describe("parseWidgetAction", () => {
     expect(parseWidgetAction("magical-merchant://widget/new-note")).toEqual({
       name: "new-note",
       file: null,
+      template: null,
     });
   });
 
@@ -13,6 +14,15 @@ describe("parseWidgetAction", () => {
     expect(parseWidgetAction("magical-merchant://widget/note?file=20260809_120000.md")).toEqual({
       name: "note",
       file: "20260809_120000.md",
+      template: null,
+    });
+  });
+
+  it("テンプレのリンクはどのテンプレかを運ぶ", () => {
+    expect(parseWidgetAction("magical-merchant://widget/template?name=daily")).toEqual({
+      name: "template",
+      file: null,
+      template: "daily",
     });
   });
 

--- a/tauri-app/src/lib/widget-actions.ts
+++ b/tauri-app/src/lib/widget-actions.ts
@@ -2,10 +2,13 @@
 export interface WidgetAction {
   name: string;
   file: string | null;
+  /** テンプレ起動(`template`)のときだけ、どのテンプレかが入る。 */
+  template: string | null;
 }
 
 /**
  * `magical-merchant://widget/<name>?file=<filename>` を読む。
+ * テンプレ起動だけは `?name=<テンプレ名>` を伴う。
  * ウィジェット以外の deep link（認証のコールバック）は `null`。
  */
 export function parseWidgetAction(raw: string): WidgetAction | null {
@@ -25,7 +28,11 @@ export function parseWidgetAction(raw: string): WidgetAction | null {
     return null;
   }
 
-  return { name, file: url.searchParams.get("file") };
+  return {
+    name,
+    file: url.searchParams.get("file"),
+    template: url.searchParams.get("name"),
+  };
 }
 
 /** 起動 URL には認証のコールバックも混じる。最初のウィジェットリンクを取る。 */


### PR DESCRIPTION
## なぜやるか

ウィジェットを置く理由は「アプリを開くより速く書き始める」こと。テンプレを
入れた (#139) のに、その入口がアプリの中にしか無いままだと、いちばん摩擦の
少ない場所から届かない。既存の 3 つに 4 つ目として並べる。

base は #139。あちらが入ってからマージしてください。

## やったこと

| 層          | 変更                                                                      |
| ----------- | ------------------------------------------------------------------------- |
| Rust        | `collect_templates` と JNI `readTemplates` — テンプレ置き場だけを読む      |
| TS          | `…/widget/template?name=daily` と `…/widget/templates` を受ける            |
| Kotlin/XML  | `TemplatesWidgetProvider` (4×3)、レイアウト、drawable 3 種、manifest 登録  |

判断が分かれたところ:

- **設定 Activity を作っていない**。ハンドオフは「長押し設定でテンプレを選択」
  だったが、名前順の先頭 3 件に固定した。実機で確かめられない状態で Activity
  1 つぶんの表面積を足したくない。名前順なら並びは動かないので、同じ位置の
  ボタンは同じノートを作り続ける
- **RemoteViewsService を使っていない**。サービスは長い一覧の読みをメイン
  スレッドから外すためのもので、ここが開くのはテンプレ置き場だけ。3 行の
  ために Service と Factory を足す釣り合いではない
- **「今日のぶんがあれば開く」を Kotlin にもフロントにも書いていない**。
  core が既に持っている判断で、両方に書くと片方を直したときにメニューと
  ウィジェットで挙動が食い違う

## やらなかったこと

- **どのテンプレを出すかの設定 (`Activity`)**。上のとおり
- **実機での確認**。下に書いたとおり、ここが未検証の中心

## 未検証（レビューで見てほしいところ）

**Kotlin とレイアウトはコンパイルすら通していない。** Android SDK のビルドを
手元で回せず、CI にも Android ターゲットが無いため。Rust (54 テスト) と TS
(420 テスト、deep link のパースを含む) は通っている。

実機で初めて分かるのは次:

- `R.id.*` / `R.layout.*` / `R.string.*` の解決（レイアウトと Provider の ID 対応）
- `android:tint` が RemoteViews 経由で効くか (API 21+ の想定)
- 4×3 のセル数に 3 ボタンが収まるか (`minHeight="180dp"` は机上の計算)
- `just android-widget-setup` のあと manifest に receiver が入るか

```sh
just android-install
```

## 資料

- `sample/template/design_handoff_note_templates/README.md` の 1e (gitignore 配下)
