### PR TITLE
fix(android): pad the window by the IME inset so the toolbar stops shaking

### DIFF
--- a/tauri-app/android-widget/README.md
+++ b/tauri-app/android-widget/README.md
@@ -108,6 +108,13 @@ elements, the `<activity>` and the list `<service>` in `AndroidManifest.xml`
 behind idempotent marker comments — the same approach as
 [`../android-signing`](../android-signing/README.md).
 
+The copy includes one file that is not a widget:
+[`MainActivity.kt`](src/main/java/com/magical_merchant/app/MainActivity.kt)
+overwrites the Tauri-generated stub to pad the content view by the IME inset
+(#54 — `enableEdgeToEdge()` stops `adjustResize` from working, so without this
+the keyboard-top markdown toolbar falls back to jittery JS positioning). After
+a Tauri upgrade, diff the regenerated stub against ours before re-applying.
+
 ```sh
 just android-widget-setup
 ```

--- a/tauri-app/android-widget/apply-widget.go
+++ b/tauri-app/android-widget/apply-widget.go
@@ -7,6 +7,11 @@
 // <receiver> elements in the generated AndroidManifest.xml. Re-run it (via
 // `just android-widget-setup`) after any regeneration.
 //
+// The copy also carries a MainActivity.kt that overwrites the generated stub:
+// it adds IME-inset padding so the window shrinks with the keyboard (#54).
+// After a Tauri upgrade, diff the freshly generated stub against ours before
+// re-running, in case upstream grew more than enableEdgeToEdge().
+//
 // Both halves are idempotent: copies overwrite, and the manifest region is
 // wrapped in marker comments that are stripped before being re-inserted, so any
 // number of runs yields the same file.

--- a/tauri-app/android-widget/src/main/java/com/magical_merchant/app/MainActivity.kt
+++ b/tauri-app/android-widget/src/main/java/com/magical_merchant/app/MainActivity.kt
@@ -1,0 +1,42 @@
+package com.magical_merchant.app
+
+import android.os.Bundle
+import android.view.View
+import androidx.activity.enableEdgeToEdge
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+
+/**
+ * Replaces the Tauri-generated stub, which only calls [enableEdgeToEdge].
+ *
+ * That call sets `decorFitsSystemWindows = false`, and in that state the
+ * manifest's `adjustResize` no longer shrinks the window when the keyboard
+ * opens (#54). The WebView keeps its full height, the viewport meta
+ * `interactive-widget=resizes-content` has nothing to resize, and the markdown
+ * toolbar falls back to chasing `visualViewport` from JS — which runs a frame
+ * behind the compositor's scrolling, so the toolbar visibly shakes.
+ *
+ * So resize ourselves: pad the content view by the IME inset, the same recipe
+ * [widget.QuickCaptureActivity] uses. The WebView then genuinely ends at the
+ * keyboard, the layout viewport follows, and the CSS `position: fixed; bottom`
+ * path places the toolbar with no JS involved.
+ *
+ * The IME inset is 0 while the keyboard is closed, so edge-to-edge is
+ * untouched; system bars stay the CSS safe-area's job. On WebViews that
+ * report no IME inset the JS fallback in `MarkdownToolbar.tsx` still applies.
+ */
+class MainActivity : TauriActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
+
+        val content = findViewById<View>(android.R.id.content)
+        ViewCompat.setOnApplyWindowInsetsListener(content) { view, insets ->
+            // The IME alone, not plus the navigation bar: the keyboard already
+            // reaches the bottom of the screen, so its inset is the full gap.
+            val ime = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+            view.setPadding(view.paddingLeft, view.paddingTop, view.paddingRight, ime)
+            insets
+        }
+    }
+}


### PR DESCRIPTION
## なぜやるか

closes #54

Android で、キーボード上の Markdown ツールバーがスクロール中に一拍遅れて揺れる。原因は Tauri が生成する `MainActivity` の `enableEdgeToEdge()`。これが `decorFitsSystemWindows = false` にするため、マニフェストの `adjustResize` がキーボードでウィンドウを縮めなくなる。ウィンドウが縮まないので viewport meta の `interactive-widget=resizes-content` にも縮めるものがなく、ツールバーは JS の `visualViewport` 追従にフォールバックする——これはコンポジタのスクロールより1フレーム遅れるので揺れて見える。

Slack や Notion 級のアプリが揺れないのは「ウィンドウを本当に縮める」か「edge-to-edge のままネイティブで IME インセットを padding に当てる」かのどちらかで、Capacitor(Obsidian の基盤)と Joplin(Android 15+)は後者を採っている。本 PR も同じレシピにする。#125 の `QuickCaptureActivity` で実機実証済みの型でもある。

## やったこと

- `android-widget/src/main` に `MainActivity.kt` を追加。既存の `apply-widget.go` の上書きコピーに乗せて生成スタブを置き換え、content view に `WindowInsetsCompat.Type.ime()` の bottom を padding として当てる。IME が閉じていればインセットは 0 なので edge-to-edge はそのまま
- `apply-widget.go` のコメントと README に、ウィジェット外のファイルが 1 つ混ざることと、Tauri 更新時は再生成スタブとの diff を見る注意を記録
- 実機(moto g52j / Android 12, API 31)で、ツールバーがキーボード上端に張り付いたまま揺れないことを確認済み

## やらなかったこと

- `MarkdownToolbar.tsx` の `visualViewport` 追従の削除 — IME インセットを報告しない WebView 向けのフォールバックとして残す(この経路に乗る限り発火しない)
- キーボード表示中の `env(safe-area-inset-bottom)` 調整 — ツールバーが浮く症状が出た場合の追加 CSS を想定していたが、実機で出なかったため見送り

## 資料

- #54(調査経緯)、#125(同型レシピの実機実証)
- 同型実装: Capacitor `SystemBars`(IME 表示中に WebView 親へ ime() padding)、Joplin `MainActivity.kt`(API 35+ で同処理)
