### PR TITLE
fix(android): migrate readTemplates to jni 0.22 entry-point pattern

### DIFF
--- a/tauri-app/src-tauri/src/widget_bridge.rs
+++ b/tauri-app/src-tauri/src/widget_bridge.rs
@@ -100,11 +100,15 @@ pub extern "system" fn Java_com_magical_1merchant_app_widget_WidgetBridge_readNo
 /// directory, so the buttons do not wait on the whole notes tree.
 #[unsafe(no_mangle)]
 pub extern "system" fn Java_com_magical_1merchant_app_widget_WidgetBridge_readTemplates<'local>(
-    env: JNIEnv<'local>,
+    mut unowned_env: EnvUnowned<'local>,
     _class: JClass<'local>,
     base_dir: JString<'local>,
 ) -> JString<'local> {
-    read_json(env, base_dir, widget_summary::collect_templates)
+    unowned_env
+        .with_env(|env| -> jni::errors::Result<JString<'local>> {
+            Ok(read_json(env, base_dir, widget_summary::collect_templates))
+        })
+        .resolve::<LogErrorAndDefault>()
 }
 
 /// Serializes whatever `collect` gathers under `base_dir`.


### PR DESCRIPTION
## なぜやるか

`just tauri_app::android-build-release` が `E0425: cannot find type JNIEnv` で失敗し、Android にインストールできなくなっていた。jni 0.22 への更新(#143)と note-template-widget(#140)がすれ違ってマージされたため、`readTemplates` だけが 0.21 時代の `JNIEnv` シグネチャのまま残っていた。

## やったこと

- `widget_bridge.rs` の `readTemplates` を、同ファイルの他の3エントリポイントと同じ jni 0.22 パターン(`EnvUnowned` + `with_env` + `resolve::<LogErrorAndDefault>()`)に揃えた

## 資料

- #140 (note-template-widget)
- #143 (jni を含む cargo dependencies 更新)
