### PR TITLE
ci: save caches only on main to stop cache eviction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# キャッシュは main でだけ保存する (save/purge の条件と actions/cache の
+# restore/save 分割はすべてこのため)。PR ごとに保存すると重複分で repo の
+# 10GB 上限を超え、LRU 追い出しで macOS の nix store キャッシュが毎回消えて
+# nix-package-macos が常にフルビルド (10 分) になっていた。PR は main の
+# キャッシュを restore するだけ。purge-created: 0 + purge-primary-key: never
+# は「保存時に同じ prefix の古い世代を消し、main に 1 世代だけ残す」の意
+
 jobs:
   # 変更検出を1ジョブに集約し、各ジョブをジョブ単位で gate する。
   # ステップ単位の if だと、走らないジョブでも runner と checkout の時間を消費する
@@ -90,15 +97,21 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
-      - name: Free disk space
-        run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+      # Free disk space は置かない。store 3G + target で 21GB の空きに収まる。
+      # rm -rf に 87 秒かかっていた
       - uses: nixbuild/nix-quick-install-action@v35
       - uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-${{ runner.os }}-rust-${{ hashFiles('flake.lock', 'flake.nix') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-rust-
           gc-max-store-size-linux: 3G
-      - uses: actions/cache@v6
+          save: ${{ github.ref == 'refs/heads/main' }}
+          purge: ${{ github.ref == 'refs/heads/main' }}
+          purge-prefixes: nix-${{ runner.os }}-rust-
+          purge-created: 0
+          purge-primary-key: never
+      - uses: actions/cache/restore@v6
+        id: cargo-cache
         with:
           path: target
           key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'flake.lock') }}
@@ -108,6 +121,11 @@ jobs:
         run: nix develop .#rust --command just rust::check
       - name: test
         run: nix develop .#rust --command just rust::test
+      - uses: actions/cache/save@v6
+        if: github.ref == 'refs/heads/main' && steps.cargo-cache.outputs.cache-hit != 'true'
+        with:
+          path: target
+          key: ${{ steps.cargo-cache.outputs.cache-primary-key }}
 
   frontend:
     needs: changes
@@ -122,10 +140,16 @@ jobs:
           primary-key: nix-${{ runner.os }}-frontend-${{ hashFiles('flake.lock', 'flake.nix') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-frontend-
           gc-max-store-size-linux: 3G
+          save: ${{ github.ref == 'refs/heads/main' }}
+          purge: ${{ github.ref == 'refs/heads/main' }}
+          purge-prefixes: nix-${{ runner.os }}-frontend-
+          purge-created: 0
+          purge-primary-key: never
       - name: Get pnpm store directory
         id: pnpm-cache
         run: echo "STORE_PATH=$(nix develop .#frontend --command pnpm store path)" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
+        id: pnpm-store
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: pnpm-${{ runner.os }}-${{ hashFiles('tauri-app/pnpm-lock.yaml') }}
@@ -135,6 +159,11 @@ jobs:
         run: nix develop .#frontend --command just tauri_app::check
       - name: test
         run: nix develop .#frontend --command just tauri_app::test
+      - uses: actions/cache/save@v6
+        if: github.ref == 'refs/heads/main' && steps.pnpm-store.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ steps.pnpm-store.outputs.cache-primary-key }}
 
   workers:
     needs: changes
@@ -149,10 +178,16 @@ jobs:
           primary-key: nix-${{ runner.os }}-workers-${{ hashFiles('flake.lock', 'flake.nix') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-workers-
           gc-max-store-size-linux: 2G
+          save: ${{ github.ref == 'refs/heads/main' }}
+          purge: ${{ github.ref == 'refs/heads/main' }}
+          purge-prefixes: nix-${{ runner.os }}-workers-
+          purge-created: 0
+          purge-primary-key: never
       - name: Get pnpm store directory
         id: pnpm-cache
         run: echo "STORE_PATH=$(nix develop .#workers --command pnpm store path)" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
+        id: pnpm-store
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: pnpm-workers-${{ runner.os }}-${{ hashFiles('workers/pnpm-lock.yaml') }}
@@ -162,6 +197,11 @@ jobs:
         run: nix develop .#workers --command just workers::check
       - name: test
         run: nix develop .#workers --command just workers::test
+      - uses: actions/cache/save@v6
+        if: github.ref == 'refs/heads/main' && steps.pnpm-store.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ steps.pnpm-store.outputs.cache-primary-key }}
 
   # ホーム画面ウィジェットの Kotlin とレイアウトは、ここでしか壊れが分からない。
   # `R.id.*` の解決も、apply-widget.go が書き込んだマニフェストが通るかも、
@@ -178,8 +218,10 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
-      - name: Free disk space
-        run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+      # rm -rf に 72 秒かかるので、キャッシュ復元と並行してバックグラウンドで消す。
+      # APK ビルドが始まる頃(2 分後)には終わっている
+      - name: Free disk space (background)
+        run: nohup sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache >/dev/null 2>&1 &
       - uses: nixbuild/nix-quick-install-action@v35
       # キーは release.yml と揃えてある。SDK と NDK は同じものなので、
       # どちらが先に走っても取り直さない
@@ -188,9 +230,15 @@ jobs:
           primary-key: nix-${{ runner.os }}-android-${{ hashFiles('flake.lock', 'flake.nix') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-android-
           gc-max-store-size-linux: 6G
+          save: ${{ github.ref == 'refs/heads/main' }}
+          purge: ${{ github.ref == 'refs/heads/main' }}
+          purge-prefixes: nix-${{ runner.os }}-android-
+          purge-created: 0
+          purge-primary-key: never
       # rust ジョブとキーを分ける。同じ target/ でもホスト向けと Android 向けで
       # 中身が入れ替わり、共有すると毎回どちらかが作り直しになる
-      - uses: actions/cache@v6
+      - uses: actions/cache/restore@v6
+        id: cargo-cache
         with:
           path: target
           key: cargo-android-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'flake.lock') }}
@@ -201,6 +249,11 @@ jobs:
       # android-widget-setup を含む。ウィジェットのソースを入れた状態で組む
       - name: The debug APK builds
         run: nix develop .#android --command just tauri_app::android-build-debug
+      - uses: actions/cache/save@v6
+        if: github.ref == 'refs/heads/main' && steps.cargo-cache.outputs.cache-hit != 'true'
+        with:
+          path: target
+          key: ${{ steps.cargo-cache.outputs.cache-primary-key }}
 
   # pnpm-lock.yaml を変えると nix/package.nix の pnpmDeps.hash が黙って腐る。
   # 気付くのが macOS 配布 (nix build) の時では遅い
@@ -235,6 +288,11 @@ jobs:
           primary-key: nix-${{ runner.os }}-package-${{ hashFiles('flake.lock', 'flake.nix', 'nix/package.nix', 'Cargo.lock', 'tauri-app/pnpm-lock.yaml') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-package-
           gc-max-store-size-macos: 4G
+          save: ${{ github.ref == 'refs/heads/main' }}
+          purge: ${{ github.ref == 'refs/heads/main' }}
+          purge-prefixes: nix-${{ runner.os }}-package-
+          purge-created: 0
+          purge-primary-key: never
       - name: the .app bundle builds
         run: nix build .#default --no-link
 
@@ -249,4 +307,9 @@ jobs:
           primary-key: nix-${{ runner.os }}-format-${{ hashFiles('flake.lock', 'flake.nix') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-format-
           gc-max-store-size-linux: 2G
+          save: ${{ github.ref == 'refs/heads/main' }}
+          purge: ${{ github.ref == 'refs/heads/main' }}
+          purge-prefixes: nix-${{ runner.os }}-format-
+          purge-created: 0
+          purge-primary-key: never
       - run: nix fmt -- --fail-on-change

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,14 @@ jobs:
         run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
 
       - uses: nixbuild/nix-quick-install-action@v35
+      # restore 専用。タグ ref で保存するとタグごとに約 3GB の重複キャッシュが
+      # 増えて repo の 10GB 上限を圧迫する (保存は ci.yml が main でやる)
       - uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-${{ runner.os }}-android-${{ hashFiles('flake.lock', 'flake.nix') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-android-
           gc-max-store-size-linux: 6G
+          save: false
 
       - name: Generate the Android project
         run: nix develop .#android --command just tauri_app::android-init


### PR DESCRIPTION
## なぜやるか

CI が 1 run 8〜13 分かかっていた。実測したところ原因はキャッシュの追い出し:

- リポジトリの Actions キャッシュ総量が **11.7GB** で上限 10GB を超過
- PR ブランチごとに nix store / pnpm の複製 (~2.9GB) が保存され、LRU で
  **macOS の nix store キャッシュが毎回消えていた**
- その結果 `nix-package-macos` はプレフィックス復元すら「Could not find a
  cache」で、**毎 run フルビルド 10 分**(ジョブ全体 11 分52秒 = 最長)
- ほかに `Free disk space` の `rm -rf` が rust ジョブ 87 秒 / android ジョブ 72 秒

## やったこと

- キャッシュ保存を main のみに変更(PR は restore 専用)
  - `cache-nix-action` は `save:` + `purge:` で同 prefix の古い世代を main 上で削除
  - `actions/cache` は restore/save に分割し、save を main 条件付きに
- `release.yml` の android キャッシュを restore 専用に(タグ ref に ~3GB 複製が残るのを防止)
- rust ジョブの `Free disk space` を削除(store 3G + target は素の空き容量で足りる)
- android ジョブの `Free disk space` をバックグラウンド化(キャッシュ復元と並行、APK ビルド開始までに完了)
- 応急処置として PR スコープの既存キャッシュ 4 件を削除済み(11.7GB → 9.23GB)

期待効果: フル実行時の最長ジョブ `nix-package-macos` が 12 分 → 約 2 分
(Cargo.lock 等が変わらない場合、nix build がキャッシュ済み出力の確認だけになる)。
rust / android ジョブは各 70〜90 秒短縮。

## やらなかったこと

- `nix/package.nix` の derivation 分割(crane 等での Rust 依存の増分キャッシュ)。
  Cargo.lock が変わる run は依然フルビルド 10 分だが、単一 derivation の
  構造変更はリスクが大きいので別途
- main push 時の paths-filter 適用(main では全ジョブ実行が意図された設計のため維持)

## 資料

- https://github.com/nix-community/cache-nix-action (save / purge の仕様)
