### PR TITLE
perf(tauri-app): slim blocking CSS and defer shiki

### DIFF
--- a/tauri-app/src/components/MarkdownPreview.tsx
+++ b/tauri-app/src/components/MarkdownPreview.tsx
@@ -3,6 +3,7 @@ import { t } from "../lib/i18n";
 import { renderMarkdown } from "../lib/markdown";
 import { resolvedTheme } from "../lib/theme";
 import Icon from "./Icon";
+import "../styles/markdown-preview.css";
 import type { JSX } from "solid-js";
 
 interface MarkdownPreviewProps {

--- a/tauri-app/src/components/MarkdownToolbar.test.tsx
+++ b/tauri-app/src/components/MarkdownToolbar.test.tsx
@@ -25,10 +25,13 @@ describe("MarkdownToolbar", () => {
     const editor = createMockEditor();
     render(() => <MarkdownToolbar editor={editor} />);
 
-    const toolbar = screen.getByRole("toolbar");
+    // markdown-toolbar.css がコンポーネント側で読み込まれるようになり、
+    // デスクトップ環境 (hover あり) では実アプリ同様 display: none になる。
+    // ここで見たいのは構造なので hidden も対象にする
+    const toolbar = screen.getByRole("toolbar", { hidden: true });
     expect(toolbar).toBeDefined();
 
-    const buttons = screen.getAllByRole("button");
+    const buttons = screen.getAllByRole("button", { hidden: true });
     expect(buttons).toHaveLength(6);
 
     expect(screen.getByLabelText("Outdent")).toBeDefined();
@@ -63,9 +66,9 @@ describe("MarkdownToolbar", () => {
     const [editor, setEditor] = createSignal<Editor | undefined>(createMockEditor());
     render(() => <MarkdownToolbar editor={editor()} />);
 
-    expect(screen.getByRole("toolbar")).toBeDefined();
+    expect(screen.getByRole("toolbar", { hidden: true })).toBeDefined();
 
     setEditor(undefined);
-    expect(screen.queryByRole("toolbar")).toBeNull();
+    expect(screen.queryByRole("toolbar", { hidden: true })).toBeNull();
   });
 });

--- a/tauri-app/src/components/MarkdownToolbar.tsx
+++ b/tauri-app/src/components/MarkdownToolbar.tsx
@@ -13,6 +13,7 @@ import { deleteCurrentBlock, exitCodeBlock } from "../lib/block-commands";
 import { t } from "../lib/i18n";
 import { createKeyboardTop, keyboardTopStyle } from "../lib/keyboard";
 import Icon from "./Icon";
+import "../styles/markdown-toolbar.css";
 import type { JSX } from "solid-js";
 
 interface MarkdownToolbarProps {

--- a/tauri-app/src/components/MilkdownEditor.tsx
+++ b/tauri-app/src/components/MilkdownEditor.tsx
@@ -20,6 +20,7 @@ import { createPlaceholderPlugin } from "../lib/placeholder-plugin";
 import { createNoteLinkPlugin } from "../lib/note-link-plugin";
 import type { NoteLinkTarget } from "../lib/note-link-plugin";
 import { getShikiTheme } from "../lib/theme";
+import "../styles/editor.css";
 import type { JSX } from "solid-js";
 
 /** プレビューで押された場所。エディタが立ち上がったらここへカーソルを置く。 */

--- a/tauri-app/src/index.css
+++ b/tauri-app/src/index.css
@@ -1,12 +1,11 @@
+/* ここに置くのは初回描画 (Timeline) と全ビュー共通のぶんだけ。
+   lazy なビュー専用の CSS は、そのチャンクと一緒に読まれるように
+   ビュー/コンポーネント側で import する (settings.css / workspace.css /
+   editor.css / markdown-preview.css / markdown-toolbar.css / templates.css) */
 @import "./styles/base.css";
 @import "./styles/layout.css";
-@import "./styles/workspace.css";
 @import "./styles/timeline.css";
 @import "./styles/popover.css";
 @import "./styles/palette.css";
 @import "./styles/toast.css";
 @import "./styles/tags.css";
-@import "./styles/editor.css";
-@import "./styles/markdown-preview.css";
-@import "./styles/markdown-toolbar.css";
-@import "./styles/settings.css";

--- a/tauri-app/src/lib/markdown.ts
+++ b/tauri-app/src/lib/markdown.ts
@@ -1,6 +1,5 @@
 import MarkdownIt from "markdown-it";
 import type { Env, MarkdownIt as MarkdownItInstance } from "markdown-it";
-import { getHighlighter } from "./highlighter";
 import { renderDiagrams } from "./mermaid";
 import { noteLinkPlugin } from "./note-link-markdown";
 import { isPreservedEmptyLine } from "./preserved-empty-line";
@@ -88,6 +87,9 @@ fenceMd.renderer.rules.fence = (tokens, idx, _options, renderEnv) => {
 async function highlightBlocks(blocks: FenceBlock[]): Promise<string[]> {
   let highlighter;
   try {
+    // 動的 import: shiki (コア + 正規表現エンジン) はコードフェンスを含む
+    // ノートを開くまで読まない。静的に書くと Workspace チャンクに同梱される
+    const { getHighlighter } = await import("./highlighter");
     highlighter = await getHighlighter();
   } catch {
     return blocks.map((block) => plainBlock(block.code));

--- a/tauri-app/src/styles/base.css
+++ b/tauri-app/src/styles/base.css
@@ -1,4 +1,17 @@
-@import "open-props/open-props.min.css";
+/* 全部入り open-props.min.css (30kB) は使わない。アプリと normalize が参照する
+   モジュールだけで 16kB に収まる。新しい var(--...) を使うときは、その
+   モジュールをここに足すこと (欠けると var() が空になり静かに崩れる) */
+@import "open-props/gray.min.css";
+@import "open-props/red.min.css";
+@import "open-props/green.min.css";
+@import "open-props/blue.min.css";
+@import "open-props/indigo.min.css";
+@import "open-props/purple.min.css";
+@import "open-props/easings.min.css";
+@import "open-props/sizes.min.css";
+@import "open-props/shadows.min.css";
+@import "open-props/borders.min.css";
+@import "open-props/fonts.min.css";
 @import "open-props/normalize.min.css";
 
 :root {

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -40,6 +40,7 @@ import type { CaretPoint } from "../components/MilkdownEditor";
 import type { NoteLinkTarget } from "../lib/note-link-plugin";
 import type { SearchHit, Template } from "../lib/commands";
 import { ROUTES } from "../lib/routes";
+import "../styles/workspace.css";
 
 // Milkdown + ProseMirror は編集を始めるまで要らない。一覧とプレビューだけの
 // 表示をこの重さから切り離す


### PR DESCRIPTION
## なぜやるか

設計優先度 2 位「Lightweight」の実測改善。初回ロードを計測したところ、
JS の遅延化(mermaid / milkdown / markmap)は済んでいる一方で CSS と shiki に
無駄が残っていた:

- レンダリングブロッキング CSS 80.3kB のうち **約半分が open-props 全部入り**、
  さらに lazy なビュー専用 CSS(workspace / editor / markdown-preview /
  markdown-toolbar / settings)も同梱。settings.css は二重取り込み
- shiki(コア + 正規表現エンジン、gzip 53kB)が Workspace チャンクに静的に
  同梱され、コードフェンスの無いノートでも必ずロードされていた

## やったこと

計測値(vite build 出力、gzip):

| 対象 | before | after |
| --- | --- | --- |
| ブロッキング CSS | 80.3kB (17.3kB) | **47.7kB (11.0kB)** |
| Workspace チャンク | 297.9kB (109.2kB) | **136.4kB (56.1kB)** |
| shiki | Workspace に同梱 | 別チャンク 161.6kB (53.3kB)、コードフェンス表示時のみ |

- open-props を実使用モジュール 11 個の import に絞る
- lazy ビュー専用 CSS を各コンポーネント側 import に移動(チャンクと一緒に読む)
- `lib/markdown.ts` の highlighter を動的 import に変更(既存の async +
  プレーンテキストフォールバックの中なので挙動は不変)
- ブラウザハーネス(BROWSER_MOCK=1 + agent-browser)で Timeline / Notes /
  コードハイライト / mermaid / エディタ起動 / Settings を目視検証済み

## やらなかったこと

- アイコン 52 個の極小チャンク統合と初期表示分の静的インライン化(Tauri は
  ローカル資産なのでリクエスト増のコストが小さい)
- `prefetchLazyViews()` の見直し(idle での Workspace 先読みは意図された設計)
- `editor.css` が参照する `--app-surface-1` / `--app-surface-3` が**どこにも
  定義されていない既存バグ**の修正(このブランチ以前からの挙動。デザイン意図の
  確認が要るので別途)
- sync `scan_local_files` の mtime+size キャッシュ化(racily-clean 問題の
  検討が必要なため以前の判断どおり見送り)
