### PR TITLE
feat(mcp-cli): return timeline and note records as structured, joinable values

### DIFF
--- a/.claude/skills/rust-core/SKILL.md
+++ b/.claude/skills/rust-core/SKILL.md
@@ -25,9 +25,15 @@ description: Rust core crate conventions, Tauri command plumbing, MCP CLI, and t
 
 ## MCP CLI
 
-`mcp-cli/` exposes core as read-only MCP tools: `list_notes`, `read_note`,
-`search`, `list_timeline_dates`, `read_timeline`. New core read APIs should
-be considered for MCP exposure; never expose writes without discussion.
+`mcp-cli/` exposes core as read-only MCP tools (`server.rs`; output shapes
+in `output.rs`): `list_notes`, `read_note`, `backlinks`, `search`,
+`list_timeline_dates`, `read_timeline`, `read_timeline_range`, `list_places`,
+`list_tags`, `list_templates`, `read_template`. Timeline entries go out as
+values (`parse_timeline_entry` in core), never as raw lines — external
+consumers join on time and location, so keep those fields structured. Place
+names come only from the app's `places.json` cache; the server must stay
+offline. New core read APIs should be considered for MCP exposure; never
+expose writes without discussion. Packaged as `nix run .#mcp` (`nix/mcp.nix`).
 
 ## Verification
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend || 'true' }}
       workers: ${{ steps.filter.outputs.workers || 'true' }}
       nix-package: ${{ steps.filter.outputs.nix-package || 'true' }}
+      nix-mcp: ${{ steps.filter.outputs.nix-mcp || 'true' }}
       android: ${{ steps.filter.outputs.android || 'true' }}
     steps:
       - uses: actions/checkout@v7
@@ -82,6 +83,14 @@ jobs:
             # push / 手動実行では filter を通さないので全ジョブが走る。
             # ci.yml をここに入れると、フロントのジョブを 1 行直しただけで
             # 12 分の APK ビルドが乗る
+            nix-mcp:
+              - 'nix/mcp.nix'
+              - 'mcp-cli/**'
+              - 'core/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'flake.nix'
+              - 'flake.lock'
             android:
               - 'tauri-app/android-widget/**'
               - 'tauri-app/src-tauri/**'
@@ -295,6 +304,29 @@ jobs:
           purge-primary-key: never
       - name: the .app bundle builds
         run: nix build .#default --no-link
+
+  # nix run github:Xantibody/magical-merchant#mcp が AI クライアント側の
+  # 起動方法そのもの。cargo で緑でも fileset にファイルが漏れていれば nix だけ落ちる
+  nix-mcp:
+    needs: changes
+    if: needs.changes.outputs.nix-mcp == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: nixbuild/nix-quick-install-action@v35
+      - uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-mcp-${{ hashFiles('flake.lock', 'flake.nix', 'nix/mcp.nix', 'Cargo.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-mcp-
+          gc-max-store-size-linux: 3G
+          save: ${{ github.ref == 'refs/heads/main' }}
+          purge: ${{ github.ref == 'refs/heads/main' }}
+          purge-prefixes: nix-${{ runner.os }}-mcp-
+          purge-created: 0
+          purge-primary-key: never
+      - name: the MCP server builds and its tests pass
+        run: nix build .#mcp --no-link
 
   format:
     runs-on: ubuntu-latest

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,11 @@
     "deepwiki": {
       "type": "http",
       "url": "https://mcp.deepwiki.com/mcp"
+    },
+    "magical-merchant": {
+      "type": "stdio",
+      "command": "cargo",
+      "args": ["run", "--quiet", "-p", "magical-merchant-mcp-cli"]
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ ready to record the moment it opens (widgets exist for exactly this).
 | Editor     | Milkdown (headless) + custom plugins                |
 | Markdown   | markdown-it + Shiki; Mermaid / markmap lazy         |
 | Sync       | Cloudflare Workers + R2 (`workers/`)                |
-| AI access  | MCP server (`mcp-cli/`, read-only tools)            |
+| AI access  | MCP server (`mcp-cli/`, read-only, `nix run .#mcp`) |
 
 ## UI Architecture (current)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,10 +2729,12 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "dirs",
  "magical-merchant-core",
  "rmcp",
  "schemars 1.2.1",
  "serde",
+ "tempfile",
  "tokio",
 ]
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -32,4 +32,5 @@ pub use utils::device::Context as DeviceContext;
 pub use utils::frontmatter;
 /// 1 件ぶんのノートメタデータ。中身は frontmatter そのもの。
 pub use utils::frontmatter::NoteFrontmatter as NoteMeta;
+pub use utils::markdown::{TimelineEntry, parse_timeline_entry};
 pub use utils::validated::NoteFilename;

--- a/core/src/note/summary.rs
+++ b/core/src/note/summary.rs
@@ -26,7 +26,7 @@ pub struct Summary {
 impl Summary {
     #[must_use]
     pub fn from_file(path: PathBuf, filename: String, content: &str) -> Self {
-        let (time, mut tags, body, origin, template) =
+        let (time, tags, body, origin, template) =
             if let Ok((fm, body)) = frontmatter::parse::<NoteFrontmatter>(content) {
                 (Some(fm.time), fm.tags, body, fm.origin, fm.template)
             } else {
@@ -35,18 +35,7 @@ impl Summary {
                 (None, Vec::new(), frontmatter::strip(content), None, None)
             };
 
-        // 本文に書かれた `#タグ` が今の入力方法。frontmatter に残っているのは
-        // タグ欄で付けていた頃のもので、消すと過去のノートから分類が消える。
-        // 見せる形は本文側の規則に合わせる — ファイルの中身には手を付けない。
-        for tag in &mut tags {
-            tag.make_ascii_lowercase();
-        }
-        for tag in tags::parse(body) {
-            if !tags.contains(&tag) {
-                tags.push(tag);
-            }
-        }
-
+        let tags = tags::merge(tags, body);
         let preview: String = body.chars().take(100).collect();
 
         Self {

--- a/core/src/utils/markdown.rs
+++ b/core/src/utils/markdown.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, FixedOffset, Local};
+use chrono::{DateTime, FixedOffset, Local, NaiveTime};
 use serde::Serialize;
 use serde::de::IgnoredAny;
 
@@ -60,6 +60,39 @@ pub fn timeline_entry_time(entry: &str) -> Option<&str> {
         .and_then(|t| t.strip_suffix("] "))
 }
 
+/// 1 行を分解したもの。行の形(時刻の括弧、行末 JSON)を読む側に見せない。
+///
+/// 画面は行のまま扱えるが、外部(MCP)に渡すときは書式ではなく値が要る。
+/// 突き合わせたいのは「いつ・どこで」であって、`- [` の位置ではない。
+#[derive(Debug, Clone, PartialEq)]
+pub struct TimelineEntry {
+    /// 端末のローカル時刻。旧い行では `None`。
+    pub time: Option<NaiveTime>,
+    /// 書き手が打った本文だけ。
+    pub text: String,
+    /// 記録時の端末の状態。何も残っていなければ既定値。
+    pub context: Context,
+}
+
+/// 保存された行を [`TimelineEntry`] に戻す。
+///
+/// 読めない部分は本文に倒す。行末が JSON として壊れていても、時刻の括弧が
+/// 無くても、書かれた文字は失わない。
+#[must_use]
+pub fn parse_timeline_entry(entry: &str) -> TimelineEntry {
+    let time =
+        timeline_entry_time(entry).and_then(|t| NaiveTime::parse_from_str(t, "%H:%M:%S").ok());
+    let rest = split_time_prefix(entry).map_or(entry, |(_, rest)| rest);
+    let context = split_context_json(rest)
+        .and_then(|json| serde_json::from_str::<Context>(json).ok())
+        .unwrap_or_default();
+    TimelineEntry {
+        time,
+        text: strip_timeline_prefix(entry).to_string(),
+        context,
+    }
+}
+
 pub fn format_note_markdown(
     body: &str,
     tags: &[String],
@@ -81,6 +114,7 @@ pub fn format_note_markdown(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::device::Location;
     use crate::utils::frontmatter::NoteFrontmatter;
     use chrono::TimeZone;
 
@@ -178,5 +212,53 @@ mod tests {
         let context = fm.context.unwrap();
         assert_eq!(context.battery, Some(100));
         assert_eq!(context.is_charging, Some(true));
+    }
+    #[test]
+    fn a_line_parses_back_into_time_text_and_context() {
+        let ctx = Context {
+            battery: Some(82),
+            location: Some(Location {
+                latitude: 35.6762,
+                longitude: 139.6503,
+            }),
+            os: "macos".to_string(),
+            ..Context::default()
+        };
+        let line = format_timeline_line("hello world", fixed_timestamp(), &ctx);
+
+        let entry = parse_timeline_entry(&line);
+
+        assert_eq!(entry.time, NaiveTime::from_hms_opt(14, 30, 45));
+        assert_eq!(entry.text, "hello world");
+        assert_eq!(entry.context, ctx);
+    }
+
+    /// 時刻もコンテキストも持たない旧い行。本文だけは落とさない。
+    #[test]
+    fn a_bare_line_is_all_text() {
+        let entry = parse_timeline_entry("- plain bullet");
+
+        assert_eq!(entry.time, None);
+        assert_eq!(entry.text, "- plain bullet");
+        assert_eq!(entry.context, Context::default());
+    }
+
+    #[test]
+    fn a_multiline_entry_keeps_its_newlines() {
+        let line = format_timeline_line("line1\nline2", fixed_timestamp(), &Context::default());
+
+        let entry = parse_timeline_entry(&line);
+
+        assert_eq!(entry.text, "line1\nline2");
+    }
+
+    /// 本文が `{` で終わる JSON 風の文だと、末尾がコンテキストと紛れる。
+    /// 読めない JSON は本文のまま残す。
+    #[test]
+    fn a_trailing_brace_in_the_text_is_not_a_context() {
+        let entry = parse_timeline_entry("- [09:00:00] fn main() {");
+
+        assert_eq!(entry.text, "fn main() {");
+        assert_eq!(entry.context, Context::default());
     }
 }

--- a/core/src/utils/place.rs
+++ b/core/src/utils/place.rs
@@ -67,6 +67,36 @@ impl PlaceCache {
     pub fn is_empty(&self) -> bool {
         self.places.is_empty()
     }
+
+    /// 言語の希望つきで引く。希望の言語に無ければ他の言語、それも無ければ
+    /// 言語を付けて書く前の控えを見る。
+    ///
+    /// 画面(`resolve`)はこれを使わない。あちらは希望の言語に無ければ
+    /// ジオコーダに聞き直せるが、MCP のように聞き直す手段のない読み手には、
+    /// 別の言語の名前でも座標だけよりは役に立つ。
+    #[must_use]
+    pub fn lookup(&self, locale: &str, key: &str) -> Option<&str> {
+        let suffix = format!(":{key}");
+        self.get(&cache_key(locale, key))
+            .or_else(|| {
+                self.places
+                    .iter()
+                    .find(|(k, _)| k.ends_with(&suffix))
+                    .map(|(_, v)| v.as_str())
+            })
+            .or_else(|| self.get(key))
+    }
+}
+
+/// 控えの中でのキー。言語を変えると同じ座標に別の名前が付くので、
+/// 座標だけで引くと前の言語の名前をそのまま出してしまう。
+///
+/// この変更より前に書かれた控え(言語の付かないキー)はもう一致しない。
+/// 派生ファイルなので消しには行かず、次に同じ場所を通ったときに
+/// 言語付きで書き直されるに任せる。
+#[must_use]
+pub fn cache_key(locale: &str, place_key: &str) -> String {
+    format!("{locale}:{place_key}")
 }
 
 #[cfg(test)]
@@ -135,5 +165,36 @@ mod tests {
         let tmp = TempDir::new().unwrap();
 
         assert!(PlaceCache::load(&tmp.path().join("places.json")).is_empty());
+    }
+    /// 画面の言語で聞いた名前があればそれ。無ければ別の言語のものでも、
+    /// 座標だけ見せられるより読める。
+    #[test]
+    fn lookup_prefers_the_asked_language_and_falls_back_to_any() {
+        let mut cache = PlaceCache::default();
+        cache.insert(cache_key("ja", "35.68,139.55"), "渋谷区".to_string());
+        cache.insert(cache_key("en", "35.68,139.55"), "Shibuya".to_string());
+        cache.insert(cache_key("ja", "43.06,141.35"), "札幌市".to_string());
+
+        assert_eq!(cache.lookup("en", "35.68,139.55"), Some("Shibuya"));
+        assert_eq!(cache.lookup("en", "43.06,141.35"), Some("札幌市"));
+        assert_eq!(cache.lookup("en", "0.00,0.00"), None);
+    }
+
+    /// 言語を付けて書く前の控え。消しには行かないので、読めるうちは読む。
+    #[test]
+    fn lookup_reads_a_legacy_key_without_a_language() {
+        let mut cache = PlaceCache::default();
+        cache.insert("35.68,139.55".to_string(), "渋谷区".to_string());
+
+        assert_eq!(cache.lookup("ja", "35.68,139.55"), Some("渋谷区"));
+    }
+
+    #[test]
+    fn the_cache_remembers_which_language_it_asked_in() {
+        assert_eq!(cache_key("en", "35.68,139.55"), "en:35.68,139.55");
+        assert_ne!(
+            cache_key("en", "35.68,139.55"),
+            cache_key("ja", "35.68,139.55")
+        );
     }
 }

--- a/core/src/utils/tags.rs
+++ b/core/src/utils/tags.rs
@@ -51,6 +51,24 @@ pub fn parse(text: &str) -> Vec<String> {
     tags
 }
 
+/// frontmatter のタグと本文の `#タグ` を、ノートが名乗る 1 つの一覧にする。
+///
+/// 本文に書かれた `#タグ` が今の入力方法。frontmatter に残っているのは
+/// タグ欄で付けていた頃のもので、消すと過去のノートから分類が消える。
+/// 見せる形は本文側の規則に合わせる — ファイルの中身には手を付けない。
+#[must_use]
+pub fn merge(mut tags: Vec<String>, body: &str) -> Vec<String> {
+    for tag in &mut tags {
+        tag.make_ascii_lowercase();
+    }
+    for tag in parse(body) {
+        if !tags.contains(&tag) {
+            tags.push(tag);
+        }
+    }
+    tags
+}
+
 /// 行がコードフェンスの区切りなら、その記号と本数を返す。
 fn fence_marker(line: &str) -> Option<(char, usize)> {
     let trimmed = line.trim_start();

--- a/docs/development.md
+++ b/docs/development.md
@@ -127,7 +127,8 @@ unified formatting for all languages. CI runs `nix fmt -- --fail-on-change`.
 
 | Variable                           | Description                            | Set by       |
 | ---------------------------------- | -------------------------------------- | ------------ |
-| `MAGICAL_MERCHANT_DATA_DIR`        | Data directory path for MCP CLI        | User         |
+| `MAGICAL_MERCHANT_DATA_DIR`        | Data directory for the MCP server      | User         |
+| `MAGICAL_MERCHANT_LOCALE`          | Place-name language for the MCP server | User         |
 | `ANDROID_HOME`                     | Android SDK path                       | Nix devShell |
 | `NDK_HOME`                         | Android NDK path                       | Nix devShell |
 | `PLAYWRIGHT_BROWSERS_PATH`         | Playwright browser path                | Nix devShell |

--- a/docs/features.md
+++ b/docs/features.md
@@ -118,20 +118,45 @@ list that deep-links into the app.
 
 `mcp-cli` exposes the same core as read-only
 [Model Context Protocol](https://modelcontextprotocol.io/) tools for AI
-assistants:
+assistants. It finds the app's data directory on its own, so the usual
+client configuration is just the launch command:
 
-```sh
-magical_merchant_mcp_cli --data-dir /path/to/data
+```json
+{
+  "mcpServers": {
+    "magical-merchant": {
+      "type": "stdio",
+      "command": "nix",
+      "args": ["run", "github:Xantibody/magical-merchant#mcp"]
+    }
+  }
+}
 ```
 
-| Tool                  | Description                                  |
-| --------------------- | -------------------------------------------- |
-| `list_notes`          | List all notes with tags and a short preview |
-| `read_note`           | Read a note's full Markdown source           |
-| `search`              | Search notes and timeline entries            |
-| `list_timeline_dates` | List the dates that have timeline entries    |
-| `read_timeline`       | Read all timeline entries for a single day   |
+Every record comes back with the device state captured when it was
+written — local time, GPS coordinates (and the place name the app resolved
+for them), battery, network type, and which device wrote it — so an agent
+can line the journal up with other time- or location-based data.
 
-> [!NOTE]
-> The data directory can also be set with the `MAGICAL_MERCHANT_DATA_DIR`
-> environment variable.
+| Tool                  | Description                                                         |
+| --------------------- | ------------------------------------------------------------------- |
+| `list_notes`          | List all notes with tags, a short preview, and their origin         |
+| `read_note`           | Read a note's metadata (time, tags, context) and Markdown body      |
+| `backlinks`           | List the records that link to a note with `[[…]]`                   |
+| `search`              | Search notes and timeline entries                                   |
+| `list_timeline_dates` | List the dates that have timeline entries                           |
+| `read_timeline`       | Read one day's entries with time, text, tags, location, and device  |
+| `read_timeline_range` | Read entries between two days, optionally filtered by tag           |
+| `list_places`         | Places (~1 km cells) records were written at, with names and counts |
+| `list_tags`           | Every `#tag` with note and entry counts                             |
+| `list_templates`      | List note templates                                                 |
+| `read_template`       | Read a template's body and tags                                     |
+
+| Flag / variable                            | Description                                                         |
+| ------------------------------------------ | ------------------------------------------------------------------- |
+| `--data-dir` / `MAGICAL_MERCHANT_DATA_DIR` | Override the data directory (default: the app's own data directory) |
+| `--locale` / `MAGICAL_MERCHANT_LOCALE`     | Preferred language for place names, `ja` or `en` (default `en`)     |
+
+Timeline times are the recording device's local wall-clock time without a
+UTC offset; note times are RFC 3339 with the offset. Place names come from
+the app's own geocoding cache — the server never calls a network service.

--- a/flake.nix
+++ b/flake.nix
@@ -150,6 +150,9 @@
           # pnpm-lock.yaml を変えると package.nix の hash が黙って腐り、
           # nix build (= macOS の配布経路) だけが後から壊れる。CI で単体で検証できるよう出す
           pnpm-deps = default.pnpmDeps;
+          # AI クライアントから `nix run github:Xantibody/magical-merchant#mcp` で
+          # 起動する読み取り専用 MCP サーバー。アプリ本体のツールチェーンは要らない
+          mcp = pkgs.callPackage ./nix/mcp.nix { };
         };
         formatter = treefmtEval.config.build.wrapper;
         checks.formatting = treefmtEval.config.build.check self;

--- a/mcp-cli/Cargo.toml
+++ b/mcp-cli/Cargo.toml
@@ -23,6 +23,10 @@ chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
+dirs = "6"
+
+[dev-dependencies]
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/mcp-cli/src/main.rs
+++ b/mcp-cli/src/main.rs
@@ -2,246 +2,65 @@
 // prove it handles the error case.
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
+mod output;
+mod server;
+
 use std::path::PathBuf;
 
-use chrono::NaiveDate;
 use clap::Parser;
-use rmcp::handler::server::tool::ToolRouter;
-use rmcp::handler::server::wrapper::{Json, Parameters};
-use rmcp::model::{
-    CallToolRequestParams, CallToolResponse, ListToolsResult, PaginatedRequestParams,
-    ServerCapabilities, ServerInfo,
-};
-use rmcp::service::RequestContext;
-use rmcp::{ErrorData, RoleServer, ServerHandler, ServiceExt, schemars, tool, tool_router};
-use serde::{Deserialize, Serialize};
+use rmcp::ServiceExt;
+
+/// Tauri の `app_data_dir` と同じ場所。アプリの識別子を変えたらここも変わる。
+const APP_IDENTIFIER: &str = "com.magical-merchant.app";
 
 #[derive(Parser)]
 #[command(
     name = "magical-merchant-mcp",
-    about = "MCP server for magical-merchant"
+    version,
+    about = "Read-only MCP server for a Magical Merchant journal"
 )]
 struct Cli {
+    /// Where the app keeps its data. Defaults to the app's own data
+    /// directory on this machine.
     #[arg(long, env = "MAGICAL_MERCHANT_DATA_DIR")]
-    data_dir: PathBuf,
+    data_dir: Option<PathBuf>,
+
+    /// Preferred language for place names (`ja` or `en`). Falls back to
+    /// whatever language the app has resolved a place in.
+    #[arg(long, env = "MAGICAL_MERCHANT_LOCALE", default_value = "en")]
+    locale: String,
 }
 
-struct McpServer {
-    data_dir: PathBuf,
-    tool_router: ToolRouter<Self>,
-}
-
-impl McpServer {
-    fn new(data_dir: PathBuf) -> Self {
-        Self {
-            data_dir,
-            tool_router: Self::tool_router(),
-        }
-    }
-}
-
-// --- Parameter types ---
-
-#[derive(Deserialize, schemars::JsonSchema)]
-struct FilenameParam {
-    /// The note filename, e.g. `20260320_143045.md`
-    filename: String,
-}
-
-#[derive(Deserialize, schemars::JsonSchema)]
-struct QueryParam {
-    /// Substring to look for; matching ignores case
-    query: String,
-}
-
-#[derive(Deserialize, schemars::JsonSchema)]
-struct DateParam {
-    /// The day to read, in YYYY-MM-DD format
-    date: String,
-}
-
-// --- Output types ---
-
-#[derive(Serialize, schemars::JsonSchema)]
-struct NoteListOutput {
-    notes: Vec<NoteInfo>,
-}
-
-#[derive(Serialize, schemars::JsonSchema)]
-struct NoteInfo {
-    filename: String,
-    time: Option<String>,
-    tags: Vec<String>,
-    preview: String,
-}
-
-#[derive(Serialize, schemars::JsonSchema)]
-struct NoteOutput {
-    content: String,
-}
-
-#[derive(Serialize, schemars::JsonSchema)]
-struct SearchOutput {
-    hits: Vec<SearchHitInfo>,
-}
-
-#[derive(Serialize, schemars::JsonSchema)]
-struct SearchHitInfo {
-    /// Which store the hit came from: `timeline` or `note`.
-    kind: String,
-    title: String,
-    snippet: String,
-    date: String,
-    /// Set for note hits; the argument to pass to `read_note`.
-    filename: Option<String>,
-    /// Set for timeline hits; the entry's position within its day.
-    index: Option<usize>,
-    tags: Vec<String>,
-}
-
-#[derive(Serialize, schemars::JsonSchema)]
-struct TimelineDatesOutput {
-    dates: Vec<String>,
-}
-
-#[derive(Serialize, schemars::JsonSchema)]
-struct TimelineOutput {
-    entries: Vec<String>,
-}
-
-fn note_to_info(n: magical_merchant_core::NoteSummary) -> NoteInfo {
-    NoteInfo {
-        filename: n.filename,
-        time: n.time.map(|t| t.to_rfc3339()),
-        tags: n.tags,
-        preview: n.preview,
-    }
-}
-
-fn hit_to_info(h: magical_merchant_core::SearchHit) -> SearchHitInfo {
-    let kind = match h.kind {
-        magical_merchant_core::HitKind::Timeline => "timeline",
-        magical_merchant_core::HitKind::Note => "note",
-    };
-    SearchHitInfo {
-        kind: kind.to_string(),
-        title: h.title,
-        snippet: h.snippet,
-        date: h.date,
-        filename: h.filename,
-        index: h.index,
-        tags: h.tags,
-    }
-}
-
-#[tool_router]
-impl McpServer {
-    #[tool(
-        name = "list_notes",
-        description = "List all notes, newest first, with their tags and a short preview"
-    )]
-    fn list_notes(&self) -> Result<Json<NoteListOutput>, String> {
-        let notes = magical_merchant_core::list_notes(&self.data_dir).map_err(|e| e.to_string())?;
-        Ok(Json(NoteListOutput {
-            notes: notes.into_iter().map(note_to_info).collect(),
-        }))
-    }
-
-    #[tool(
-        name = "read_note",
-        description = "Read the full Markdown source of a note by its filename"
-    )]
-    fn read_note(
-        &self,
-        Parameters(param): Parameters<FilenameParam>,
-    ) -> Result<Json<NoteOutput>, String> {
-        let filename = magical_merchant_core::NoteFilename::parse(&param.filename)
-            .map_err(|e| e.to_string())?;
-        let content = magical_merchant_core::read_note_by_filename(&self.data_dir, &filename)
-            .map_err(|e| e.to_string())?;
-        Ok(Json(NoteOutput { content }))
-    }
-
-    #[tool(
-        name = "search",
-        description = "Search notes and timeline entries for a substring, ignoring case"
-    )]
-    fn search(
-        &self,
-        Parameters(param): Parameters<QueryParam>,
-    ) -> Result<Json<SearchOutput>, String> {
-        let hits = magical_merchant_core::search_all(&self.data_dir, &param.query)
-            .map_err(|e| e.to_string())?;
-        Ok(Json(SearchOutput {
-            hits: hits.into_iter().map(hit_to_info).collect(),
-        }))
-    }
-
-    #[tool(
-        name = "list_timeline_dates",
-        description = "List the dates (YYYY-MM-DD) that have timeline entries, newest first"
-    )]
-    fn list_timeline_dates(&self) -> Result<Json<TimelineDatesOutput>, String> {
-        let dates = magical_merchant_core::list_timeline_dates(&self.data_dir)
-            .map_err(|e| e.to_string())?;
-        Ok(Json(TimelineDatesOutput {
-            dates: dates
-                .iter()
-                .map(|d| d.format("%Y-%m-%d").to_string())
-                .collect(),
-        }))
-    }
-
-    #[tool(
-        name = "read_timeline",
-        description = "Read all timeline entries for a single day (YYYY-MM-DD)"
-    )]
-    fn read_timeline(
-        &self,
-        Parameters(param): Parameters<DateParam>,
-    ) -> Result<Json<TimelineOutput>, String> {
-        let date = NaiveDate::parse_from_str(&param.date, "%Y-%m-%d")
-            .map_err(|e| format!("Invalid date '{}': {e}", param.date))?;
-        let entries = magical_merchant_core::read_timeline(&self.data_dir, date)
-            .map_err(|e| e.to_string())?;
-        Ok(Json(TimelineOutput { entries }))
-    }
-}
-
-impl ServerHandler for McpServer {
-    fn get_info(&self) -> ServerInfo {
-        let mut info = ServerInfo::new(ServerCapabilities::default());
-        info.server_info.name = "magical-merchant".into();
-        info.server_info.version = "0.1.0".into();
-        info.instructions = Some("Magical Merchant note and timeline server".into());
-        info
-    }
-
-    async fn list_tools(
-        &self,
-        _request: Option<PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
-    ) -> Result<ListToolsResult, ErrorData> {
-        let items = self.tool_router.list_all();
-        Ok(ListToolsResult::with_all_items(items))
-    }
-
-    async fn call_tool(
-        &self,
-        request: CallToolRequestParams,
-        context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResponse, ErrorData> {
-        let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
-        self.tool_router.call(tcc).await
-    }
+/// アプリが書いている場所を、引数なしでも見つける。公開アプリの MCP に
+/// パスを手で書かせると、最初の設定でつまずく。
+fn default_data_dir() -> Option<PathBuf> {
+    dirs::data_dir().map(|d| d.join(APP_IDENTIFIER))
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
-    let server = McpServer::new(cli.data_dir);
+    let data_dir = cli
+        .data_dir
+        .or_else(default_data_dir)
+        .ok_or_else(|| anyhow::anyhow!("no data directory: pass --data-dir"))?;
+    server::exists_or_hint(&data_dir).map_err(|e| anyhow::anyhow!(e))?;
+
+    let server = server::McpServer::new(data_dir, cli.locale);
     let transport = rmcp::transport::io::stdio();
     let running = server.serve(transport).await?;
     running.waiting().await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_default_data_dir_is_the_apps_own() {
+        let dir = default_data_dir().unwrap();
+
+        assert!(dir.ends_with(APP_IDENTIFIER));
+    }
 }

--- a/mcp-cli/src/output.rs
+++ b/mcp-cli/src/output.rs
@@ -1,0 +1,304 @@
+//! MCP に返す形。core の型をそのまま出さないのは、core が schemars を
+//! 知らないのと、外に見せる名前と中の名前を別々に変えられるようにするため。
+
+use magical_merchant_core::utils::device::{Context, NetworkType};
+use magical_merchant_core::{NoteSummary, SearchHit, TemplateSummary, TimelineEntry};
+use rmcp::schemars;
+use serde::Serialize;
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct NoteListOutput {
+    pub(crate) notes: Vec<NoteInfo>,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct NoteInfo {
+    /// The argument to pass to `read_note`.
+    pub(crate) filename: String,
+    /// Creation time, RFC 3339 with the device's UTC offset.
+    pub(crate) time: Option<String>,
+    pub(crate) tags: Vec<String>,
+    /// First 100 characters of the body.
+    pub(crate) preview: String,
+    /// Local datetime (`YYYY-MM-DDTHH:MM:SS`) of the timeline entry this note
+    /// was promoted from, if any.
+    pub(crate) origin: Option<String>,
+    /// Name of the template this note was created from, if any.
+    pub(crate) template: Option<String>,
+}
+
+impl From<NoteSummary> for NoteInfo {
+    fn from(n: NoteSummary) -> Self {
+        Self {
+            filename: n.filename,
+            time: n.time.map(|t| t.to_rfc3339()),
+            tags: n.tags,
+            preview: n.preview,
+            origin: n.origin,
+            template: n.template,
+        }
+    }
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct NoteOutput {
+    pub(crate) filename: String,
+    /// Creation time, RFC 3339 with the device's UTC offset.
+    pub(crate) time: Option<String>,
+    /// Last body edit, RFC 3339. Absent when the note was never edited.
+    pub(crate) updated: Option<String>,
+    /// Tags from the frontmatter and from `#tag` in the body, merged.
+    pub(crate) tags: Vec<String>,
+    pub(crate) origin: Option<String>,
+    pub(crate) template: Option<String>,
+    /// Per-note view preference (e.g. `mindmap`).
+    pub(crate) view: Option<String>,
+    /// Device state at creation time.
+    pub(crate) context: Option<ContextInfo>,
+    /// Markdown body without the frontmatter.
+    pub(crate) body: String,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct SearchOutput {
+    pub(crate) hits: Vec<SearchHitInfo>,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct SearchHitInfo {
+    /// Which store the hit came from: `timeline` or `note`.
+    pub(crate) kind: String,
+    pub(crate) title: String,
+    pub(crate) snippet: String,
+    /// `YYYY-MM-DD`.
+    pub(crate) date: String,
+    /// Set for note hits; the argument to pass to `read_note`.
+    pub(crate) filename: Option<String>,
+    /// Set for timeline hits; the entry's position within its day.
+    pub(crate) index: Option<usize>,
+    pub(crate) tags: Vec<String>,
+}
+
+impl From<SearchHit> for SearchHitInfo {
+    fn from(h: SearchHit) -> Self {
+        let kind = match h.kind {
+            magical_merchant_core::HitKind::Timeline => "timeline",
+            magical_merchant_core::HitKind::Note => "note",
+        };
+        Self {
+            kind: kind.to_string(),
+            title: h.title,
+            snippet: h.snippet,
+            date: h.date,
+            filename: h.filename,
+            index: h.index,
+            tags: h.tags,
+        }
+    }
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct TimelineDatesOutput {
+    /// `YYYY-MM-DD`, newest first.
+    pub(crate) dates: Vec<String>,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct TimelineOutput {
+    /// Chronological order.
+    pub(crate) entries: Vec<EntryInfo>,
+    /// True when more entries matched than were returned.
+    pub(crate) truncated: bool,
+}
+
+/// One timeline entry with its recorded context flattened into fields an
+/// agent can filter and join on.
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct EntryInfo {
+    /// `YYYY-MM-DD`.
+    pub(crate) date: String,
+    /// Position within the day; pass to `read_timeline` results to refer back.
+    pub(crate) index: usize,
+    /// Local wall-clock time on the recording device, `HH:MM:SS`. Entries
+    /// carry no UTC offset; treat as the device's local time.
+    pub(crate) time: Option<String>,
+    /// `date` and `time` joined: `YYYY-MM-DDTHH:MM:SS` (local, no offset).
+    pub(crate) datetime: Option<String>,
+    /// What the user wrote.
+    pub(crate) text: String,
+    /// `#tags` found in the text.
+    pub(crate) tags: Vec<String>,
+    /// Device state at recording time. Empty object when nothing was recorded.
+    pub(crate) context: ContextInfo,
+}
+
+/// Device state at recording time. Every field is optional: older entries
+/// and desktops without sensors leave most of it out.
+#[derive(Serialize, schemars::JsonSchema, Default)]
+pub(crate) struct ContextInfo {
+    /// Battery percentage, 0–100.
+    pub(crate) battery: Option<u8>,
+    pub(crate) is_charging: Option<bool>,
+    /// `WiFi`, `Ethernet`, `Mobile`, or `Offline`.
+    pub(crate) network_type: Option<String>,
+    pub(crate) location: Option<LocationInfo>,
+    pub(crate) device: Option<DeviceInfo>,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct LocationInfo {
+    pub(crate) latitude: f64,
+    pub(crate) longitude: f64,
+    /// Coordinates rounded to ~1 km; the argument shared with `list_places`.
+    pub(crate) place_key: String,
+    /// Municipality-level name, when the app has resolved it before.
+    pub(crate) place: Option<String>,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct DeviceInfo {
+    /// `macos`, `android`, `linux`, `windows`, ...
+    pub(crate) os: String,
+    pub(crate) os_version: Option<String>,
+    pub(crate) arch: String,
+    pub(crate) hostname: Option<String>,
+    /// e.g. `ja_JP`.
+    pub(crate) locale: Option<String>,
+}
+
+impl ContextInfo {
+    /// `place` は呼ぶ側が控えから引く。ここは値の並べ替えだけ。
+    pub(crate) fn from_context(ctx: &Context, place: Option<String>) -> Self {
+        let network_type = ctx.network_type.as_ref().map(|n| {
+            match n {
+                NetworkType::WiFi => "WiFi",
+                NetworkType::Ethernet => "Ethernet",
+                NetworkType::Mobile => "Mobile",
+                NetworkType::Offline => "Offline",
+            }
+            .to_string()
+        });
+        let location = ctx.location.as_ref().map(|l| LocationInfo {
+            latitude: l.latitude,
+            longitude: l.longitude,
+            place_key: magical_merchant_core::utils::place::place_key(l.latitude, l.longitude),
+            place,
+        });
+        // 端末情報が 1 つも無いエントリで `device: {}` を出さない。旧い行は
+        // そもそも端末を記録していないので、空の箱は「不明」を偽って見せる。
+        let has_device = !ctx.os.is_empty()
+            || !ctx.arch.is_empty()
+            || ctx.os_version.is_some()
+            || ctx.hostname.is_some()
+            || ctx.locale.is_some();
+        let device = has_device.then(|| DeviceInfo {
+            os: ctx.os.clone(),
+            os_version: ctx.os_version.clone(),
+            arch: ctx.arch.clone(),
+            hostname: ctx.hostname.clone(),
+            locale: ctx.locale.clone(),
+        });
+        Self {
+            battery: ctx.battery,
+            is_charging: ctx.is_charging,
+            network_type,
+            location,
+            device,
+        }
+    }
+}
+
+impl EntryInfo {
+    pub(crate) fn new(
+        date: &str,
+        index: usize,
+        entry: TimelineEntry,
+        place: Option<String>,
+    ) -> Self {
+        let time = entry.time.map(|t| t.format("%H:%M:%S").to_string());
+        let datetime = time.as_ref().map(|t| format!("{date}T{t}"));
+        Self {
+            date: date.to_string(),
+            index,
+            time,
+            datetime,
+            tags: magical_merchant_core::utils::tags::parse(&entry.text),
+            text: entry.text,
+            context: ContextInfo::from_context(&entry.context, place),
+        }
+    }
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct PlacesOutput {
+    /// Most-visited first.
+    pub(crate) places: Vec<PlaceInfo>,
+}
+
+/// A ~1 km grid cell that at least one record was written in.
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct PlaceInfo {
+    /// Rounded `lat,lon`; matches `context.location.place_key` on entries.
+    pub(crate) place_key: String,
+    /// Centre of the cell (the rounded coordinates).
+    pub(crate) latitude: f64,
+    pub(crate) longitude: f64,
+    /// Municipality-level name, when the app has resolved it before.
+    pub(crate) place: Option<String>,
+    /// Timeline entries written here.
+    pub(crate) entries: usize,
+    /// Notes created here.
+    pub(crate) notes: usize,
+    /// Earliest and latest `YYYY-MM-DD` seen here.
+    pub(crate) first: String,
+    pub(crate) last: String,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct TagsOutput {
+    /// Most-used first.
+    pub(crate) tags: Vec<TagInfo>,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct TagInfo {
+    pub(crate) tag: String,
+    /// Notes carrying the tag.
+    pub(crate) notes: usize,
+    /// Timeline entries carrying the tag.
+    pub(crate) entries: usize,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct TemplateListOutput {
+    pub(crate) templates: Vec<TemplateInfo>,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct TemplateInfo {
+    /// The argument to pass to `read_template`.
+    pub(crate) filename: String,
+    /// Display name; also the value notes record in `template`.
+    pub(crate) name: String,
+    pub(crate) tags: Vec<String>,
+    /// First line, with `{{variables}}` left unresolved.
+    pub(crate) preview: String,
+}
+
+impl From<TemplateSummary> for TemplateInfo {
+    fn from(t: TemplateSummary) -> Self {
+        Self {
+            filename: t.filename,
+            name: t.name,
+            tags: t.tags,
+            preview: t.preview,
+        }
+    }
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct TemplateOutput {
+    /// Body with `{{variables}}` left unresolved.
+    pub(crate) body: String,
+    pub(crate) tags: Vec<String>,
+}

--- a/mcp-cli/src/server.rs
+++ b/mcp-cli/src/server.rs
@@ -1,0 +1,754 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use chrono::NaiveDate;
+use magical_merchant_core::utils::paths::place_cache_path;
+use magical_merchant_core::utils::place::{PlaceCache, place_key};
+use magical_merchant_core::{NoteFilename, parse_timeline_entry};
+use rmcp::handler::server::tool::ToolRouter;
+use rmcp::handler::server::wrapper::{Json, Parameters};
+use rmcp::model::{
+    CallToolRequestParams, CallToolResponse, ListToolsResult, PaginatedRequestParams,
+    ServerCapabilities, ServerInfo,
+};
+use rmcp::service::RequestContext;
+use rmcp::{ErrorData, RoleServer, ServerHandler, schemars, tool, tool_router};
+use serde::Deserialize;
+
+use crate::output::{
+    ContextInfo, EntryInfo, NoteListOutput, NoteOutput, PlaceInfo, PlacesOutput, SearchOutput,
+    TagInfo, TagsOutput, TemplateListOutput, TemplateOutput, TimelineDatesOutput, TimelineOutput,
+};
+
+/// 範囲読みの 1 回あたりの上限。日記は年単位で溜まるので、青天井にすると
+/// 1 回の呼び出しがモデルの文脈を使い切る。
+const DEFAULT_LIMIT: usize = 500;
+
+const INSTRUCTIONS: &str = "Read-only access to a Magical Merchant journal: \
+a Timeline of timestamped entries (one file per day) and Notes (Markdown \
+files). Every record carries the device state at the moment it was written: \
+local time, GPS coordinates when available, battery, network, and which \
+device wrote it. Use `read_timeline_range` to pull entries for a period, \
+`list_places` to see where records were written, and `search` to find text. \
+Timeline times are the device's local wall-clock time without a UTC offset; \
+note times are RFC 3339 with the offset.";
+
+pub(crate) struct McpServer {
+    data_dir: PathBuf,
+    locale: String,
+    tool_router: ToolRouter<Self>,
+}
+
+impl McpServer {
+    pub(crate) fn new(data_dir: PathBuf, locale: String) -> Self {
+        Self {
+            data_dir,
+            locale,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    fn places(&self) -> PlaceCache {
+        PlaceCache::load(&place_cache_path(&self.data_dir))
+    }
+
+    fn place_name(&self, cache: &PlaceCache, latitude: f64, longitude: f64) -> Option<String> {
+        cache
+            .lookup(&self.locale, &place_key(latitude, longitude))
+            .map(str::to_string)
+    }
+
+    fn day_entries(&self, cache: &PlaceCache, date: NaiveDate) -> Result<Vec<EntryInfo>, String> {
+        let formatted = date.format("%Y-%m-%d").to_string();
+        let lines = magical_merchant_core::read_timeline(&self.data_dir, date)
+            .map_err(|e| e.to_string())?;
+        Ok(lines
+            .iter()
+            .enumerate()
+            .map(|(index, line)| {
+                let entry = parse_timeline_entry(line);
+                let place = entry
+                    .context
+                    .location
+                    .as_ref()
+                    .and_then(|l| self.place_name(cache, l.latitude, l.longitude));
+                EntryInfo::new(&formatted, index, entry, place)
+            })
+            .collect())
+    }
+}
+
+// --- Parameter types ---
+
+#[derive(Deserialize, schemars::JsonSchema)]
+pub(crate) struct FilenameParam {
+    /// The note filename, e.g. `20260320_143045.md`
+    filename: String,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+pub(crate) struct QueryParam {
+    /// Substring to look for; matching ignores case
+    query: String,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+pub(crate) struct DateParam {
+    /// The day to read, in YYYY-MM-DD format
+    date: String,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+pub(crate) struct RangeParam {
+    /// First day to read, inclusive, YYYY-MM-DD
+    from: String,
+    /// Last day to read, inclusive, YYYY-MM-DD
+    to: String,
+    /// Only entries whose text carries this `#tag` (without the `#`)
+    tag: Option<String>,
+    /// Maximum number of entries to return (default 500)
+    limit: Option<usize>,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+pub(crate) struct TemplateParam {
+    /// The template filename, e.g. `daily.md`
+    filename: String,
+}
+
+fn parse_date(text: &str) -> Result<NaiveDate, String> {
+    NaiveDate::parse_from_str(text, "%Y-%m-%d").map_err(|e| format!("Invalid date '{text}': {e}"))
+}
+
+fn parse_filename(text: &str) -> Result<NoteFilename, String> {
+    NoteFilename::parse(text).map_err(|e| e.to_string())
+}
+
+fn err<E: std::fmt::Display>(e: E) -> String {
+    e.to_string()
+}
+
+#[tool_router]
+impl McpServer {
+    #[tool(
+        name = "list_notes",
+        description = "List all notes, newest first, with their tags, a short preview, and where they came from"
+    )]
+    fn list_notes(&self) -> Result<Json<NoteListOutput>, String> {
+        let notes = magical_merchant_core::list_notes(&self.data_dir).map_err(err)?;
+        Ok(Json(NoteListOutput {
+            notes: notes.into_iter().map(Into::into).collect(),
+        }))
+    }
+
+    #[tool(
+        name = "read_note",
+        description = "Read a note by filename: its metadata (time, tags, device context) and the Markdown body"
+    )]
+    fn read_note(
+        &self,
+        Parameters(param): Parameters<FilenameParam>,
+    ) -> Result<Json<NoteOutput>, String> {
+        let filename = parse_filename(&param.filename)?;
+        let body =
+            magical_merchant_core::read_note_by_filename(&self.data_dir, &filename).map_err(err)?;
+        // 壊れた frontmatter は本文だけ返す。一覧がそうしているのと同じで、
+        // メタデータが読めないことを理由に本文まで隠す理由がない。
+        let meta = magical_merchant_core::read_note_meta(&self.data_dir, &filename).ok();
+        let cache = self.places();
+        let context = meta.as_ref().and_then(|m| m.context.as_ref()).map(|ctx| {
+            let place = ctx
+                .location
+                .as_ref()
+                .and_then(|l| self.place_name(&cache, l.latitude, l.longitude));
+            ContextInfo::from_context(ctx, place)
+        });
+        let (time, updated, tags, origin, template, view) = meta.map_or_else(
+            || (None, None, Vec::new(), None, None, None),
+            |m| {
+                (
+                    Some(m.time.to_rfc3339()),
+                    m.updated.map(|t| t.to_rfc3339()),
+                    m.tags,
+                    m.origin,
+                    m.template,
+                    m.view,
+                )
+            },
+        );
+        Ok(Json(NoteOutput {
+            filename: filename.as_str().to_string(),
+            time,
+            updated,
+            // 一覧と同じ規則で合流させる。frontmatter だけ・本文だけの片方を
+            // 見せると、同じノートが一覧と単票で違うタグを名乗る。
+            tags: magical_merchant_core::utils::tags::merge(tags, &body),
+            origin,
+            template,
+            view,
+            context,
+            body,
+        }))
+    }
+
+    #[tool(
+        name = "backlinks",
+        description = "List the notes and timeline entries that link to a note with [[filename-stem]]"
+    )]
+    fn backlinks(
+        &self,
+        Parameters(param): Parameters<FilenameParam>,
+    ) -> Result<Json<SearchOutput>, String> {
+        let filename = parse_filename(&param.filename)?;
+        let hits = magical_merchant_core::find_backlinks(&self.data_dir, &filename).map_err(err)?;
+        Ok(Json(SearchOutput {
+            hits: hits.into_iter().map(Into::into).collect(),
+        }))
+    }
+
+    #[tool(
+        name = "search",
+        description = "Search notes and timeline entries for a substring, ignoring case; newest first"
+    )]
+    fn search(
+        &self,
+        Parameters(param): Parameters<QueryParam>,
+    ) -> Result<Json<SearchOutput>, String> {
+        let hits = magical_merchant_core::search_all(&self.data_dir, &param.query).map_err(err)?;
+        Ok(Json(SearchOutput {
+            hits: hits.into_iter().map(Into::into).collect(),
+        }))
+    }
+
+    #[tool(
+        name = "list_timeline_dates",
+        description = "List the dates (YYYY-MM-DD) that have timeline entries, newest first"
+    )]
+    fn list_timeline_dates(&self) -> Result<Json<TimelineDatesOutput>, String> {
+        let dates = magical_merchant_core::list_timeline_dates(&self.data_dir).map_err(err)?;
+        Ok(Json(TimelineDatesOutput {
+            dates: dates
+                .iter()
+                .map(|d| d.format("%Y-%m-%d").to_string())
+                .collect(),
+        }))
+    }
+
+    #[tool(
+        name = "read_timeline",
+        description = "Read every timeline entry of one day (YYYY-MM-DD) with its time, text, tags, location, and device context"
+    )]
+    fn read_timeline(
+        &self,
+        Parameters(param): Parameters<DateParam>,
+    ) -> Result<Json<TimelineOutput>, String> {
+        let date = parse_date(&param.date)?;
+        let entries = self.day_entries(&self.places(), date)?;
+        Ok(Json(TimelineOutput {
+            entries,
+            truncated: false,
+        }))
+    }
+
+    #[tool(
+        name = "read_timeline_range",
+        description = "Read timeline entries between two days (inclusive), oldest first, optionally filtered by tag; use this to line records up with other time-based data"
+    )]
+    fn read_timeline_range(
+        &self,
+        Parameters(param): Parameters<RangeParam>,
+    ) -> Result<Json<TimelineOutput>, String> {
+        let from = parse_date(&param.from)?;
+        let to = parse_date(&param.to)?;
+        if from > to {
+            return Err(format!("'from' ({from}) is after 'to' ({to})"));
+        }
+        let limit = param.limit.unwrap_or(DEFAULT_LIMIT);
+        let tag = param.tag.map(|t| t.trim_start_matches('#').to_lowercase());
+        let cache = self.places();
+
+        let mut entries = Vec::new();
+        let mut truncated = false;
+        // 日付一覧から絞る。範囲の全日を開きに行くと、書いていない日の
+        // ぶんだけ無駄に stat が積み上がる。
+        let mut dates: Vec<NaiveDate> = magical_merchant_core::list_timeline_dates(&self.data_dir)
+            .map_err(err)?
+            .into_iter()
+            .filter(|d| (from..=to).contains(d))
+            .collect();
+        dates.sort_unstable();
+        'days: for date in dates {
+            for entry in self.day_entries(&cache, date)? {
+                if tag.as_ref().is_some_and(|t| !entry.tags.contains(t)) {
+                    continue;
+                }
+                if entries.len() >= limit {
+                    truncated = true;
+                    break 'days;
+                }
+                entries.push(entry);
+            }
+        }
+        Ok(Json(TimelineOutput { entries, truncated }))
+    }
+
+    #[tool(
+        name = "list_places",
+        description = "List the places (~1 km grid cells) records were written at, with names when known, most-visited first"
+    )]
+    fn list_places(&self) -> Result<Json<PlacesOutput>, String> {
+        let cache = self.places();
+        let mut cells: BTreeMap<String, PlaceInfo> = BTreeMap::new();
+        let mut visit = |latitude: f64, longitude: f64, date: &str, is_note: bool| {
+            let key = place_key(latitude, longitude);
+            let cell = cells.entry(key.clone()).or_insert_with(|| PlaceInfo {
+                latitude: round_to_key(latitude),
+                longitude: round_to_key(longitude),
+                place: self.place_name(&cache, latitude, longitude),
+                place_key: key,
+                entries: 0,
+                notes: 0,
+                first: date.to_string(),
+                last: date.to_string(),
+            });
+            if is_note {
+                cell.notes += 1;
+            } else {
+                cell.entries += 1;
+            }
+            if date < cell.first.as_str() {
+                cell.first = date.to_string();
+            }
+            if date > cell.last.as_str() {
+                cell.last = date.to_string();
+            }
+        };
+
+        for date in magical_merchant_core::list_timeline_dates(&self.data_dir).map_err(err)? {
+            let formatted = date.format("%Y-%m-%d").to_string();
+            for line in magical_merchant_core::read_timeline(&self.data_dir, date).map_err(err)? {
+                if let Some(l) = parse_timeline_entry(&line).context.location {
+                    visit(l.latitude, l.longitude, &formatted, false);
+                }
+            }
+        }
+        for note in magical_merchant_core::list_notes(&self.data_dir).map_err(err)? {
+            // 読めないノートは地図に載らないだけ。一覧を止める理由にはならない
+            let Ok(filename) = NoteFilename::parse(&note.filename) else {
+                continue;
+            };
+            let Ok(meta) = magical_merchant_core::read_note_meta(&self.data_dir, &filename) else {
+                continue;
+            };
+            if let Some(l) = meta.context.and_then(|c| c.location) {
+                let date = meta.time.format("%Y-%m-%d").to_string();
+                visit(l.latitude, l.longitude, &date, true);
+            }
+        }
+
+        let mut places: Vec<PlaceInfo> = cells.into_values().collect();
+        places.sort_by(|a, b| (b.entries + b.notes).cmp(&(a.entries + a.notes)));
+        Ok(Json(PlacesOutput { places }))
+    }
+
+    #[tool(
+        name = "list_tags",
+        description = "List every #tag used across notes and timeline entries with usage counts, most-used first"
+    )]
+    fn list_tags(&self) -> Result<Json<TagsOutput>, String> {
+        let mut counts: BTreeMap<String, (usize, usize)> = BTreeMap::new();
+        for note in magical_merchant_core::list_notes(&self.data_dir).map_err(err)? {
+            for tag in note.tags {
+                counts.entry(tag).or_default().0 += 1;
+            }
+        }
+        for date in magical_merchant_core::list_timeline_dates(&self.data_dir).map_err(err)? {
+            for line in magical_merchant_core::read_timeline(&self.data_dir, date).map_err(err)? {
+                let entry = parse_timeline_entry(&line);
+                for tag in magical_merchant_core::utils::tags::parse(&entry.text) {
+                    counts.entry(tag).or_default().1 += 1;
+                }
+            }
+        }
+        let mut tags: Vec<TagInfo> = counts
+            .into_iter()
+            .map(|(tag, (notes, entries))| TagInfo {
+                tag,
+                notes,
+                entries,
+            })
+            .collect();
+        tags.sort_by(|a, b| (b.notes + b.entries).cmp(&(a.notes + a.entries)));
+        Ok(Json(TagsOutput { tags }))
+    }
+
+    #[tool(
+        name = "list_templates",
+        description = "List the note templates with their tags and first line"
+    )]
+    fn list_templates(&self) -> Result<Json<TemplateListOutput>, String> {
+        let templates = magical_merchant_core::list_templates(&self.data_dir).map_err(err)?;
+        Ok(Json(TemplateListOutput {
+            templates: templates.into_iter().map(Into::into).collect(),
+        }))
+    }
+
+    #[tool(
+        name = "read_template",
+        description = "Read a note template's body and tags, with {{variables}} left unresolved"
+    )]
+    fn read_template(
+        &self,
+        Parameters(param): Parameters<TemplateParam>,
+    ) -> Result<Json<TemplateOutput>, String> {
+        let filename = parse_filename(&param.filename)?;
+        let detail =
+            magical_merchant_core::read_template(&self.data_dir, &filename).map_err(err)?;
+        Ok(Json(TemplateOutput {
+            body: detail.body,
+            tags: detail.tags,
+        }))
+    }
+}
+
+/// `place_key` と同じ丸め。キーは文字列なので、数値で返すにはもう一度丸める。
+fn round_to_key(value: f64) -> f64 {
+    (value * 100.0).round() / 100.0
+}
+
+impl ServerHandler for McpServer {
+    fn get_info(&self) -> ServerInfo {
+        let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build());
+        info.server_info.name = "magical-merchant".into();
+        info.server_info.version = env!("CARGO_PKG_VERSION").into();
+        info.instructions = Some(INSTRUCTIONS.into());
+        info
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        let items = self.tool_router.list_all();
+        Ok(ListToolsResult::with_all_items(items))
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
+        self.tool_router.call(tcc).await
+    }
+}
+
+/// テストと `main` が同じ既定を見るよう、ここに置く。
+pub(crate) fn exists_or_hint(data_dir: &Path) -> Result<(), String> {
+    if data_dir.is_dir() {
+        return Ok(());
+    }
+    Err(format!(
+        "data directory not found: {}\nRun the app once, or pass --data-dir / MAGICAL_MERCHANT_DATA_DIR",
+        data_dir.display()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Local, TimeZone};
+    use magical_merchant_core::utils::device::{Context, Location};
+    use magical_merchant_core::utils::markdown::format_timeline_line;
+    use magical_merchant_core::utils::place::cache_key;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn shibuya() -> Location {
+        Location {
+            latitude: 35.6762,
+            longitude: 139.6503,
+        }
+    }
+
+    fn mac_at_shibuya() -> Context {
+        Context {
+            battery: Some(56),
+            location: Some(shibuya()),
+            os: "macos".to_string(),
+            arch: "aarch64".to_string(),
+            hostname: Some("MacBook".to_string()),
+            ..Context::default()
+        }
+    }
+
+    /// 日付を固定して書く。`save_timeline_entry` は今日にしか書けない。
+    fn write_day(base: &Path, date: &str, entries: &[(u32, &str, &Context)]) {
+        let dir = base.join("data/timeline");
+        fs::create_dir_all(&dir).unwrap();
+        let day = NaiveDate::parse_from_str(date, "%Y-%m-%d").unwrap();
+        let lines: Vec<String> = entries
+            .iter()
+            .map(|(hour, text, ctx)| {
+                let at = Local
+                    .from_local_datetime(&day.and_hms_opt(*hour, 0, 0).unwrap())
+                    .unwrap();
+                format_timeline_line(text, at, ctx)
+            })
+            .collect();
+        fs::write(dir.join(format!("{date}.md")), lines.join("\n") + "\n").unwrap();
+    }
+
+    fn name_shibuya(base: &Path, locale: &str) {
+        let mut cache = PlaceCache::default();
+        cache.insert(
+            cache_key(locale, &place_key(35.6762, 139.6503)),
+            "渋谷区".to_string(),
+        );
+        cache.save(&place_cache_path(base)).unwrap();
+    }
+
+    fn server(base: &Path) -> McpServer {
+        McpServer::new(base.to_path_buf(), "ja".to_string())
+    }
+
+    fn range(server: &McpServer, from: &str, to: &str, tag: Option<&str>) -> TimelineOutput {
+        server
+            .read_timeline_range(Parameters(RangeParam {
+                from: from.to_string(),
+                to: to.to_string(),
+                tag: tag.map(str::to_string),
+                limit: None,
+            }))
+            .unwrap()
+            .0
+    }
+
+    #[test]
+    fn an_entry_comes_back_as_values_not_a_line() {
+        let tmp = TempDir::new().unwrap();
+        write_day(
+            tmp.path(),
+            "2026-04-30",
+            &[(9, "朝 #run", &mac_at_shibuya())],
+        );
+        name_shibuya(tmp.path(), "ja");
+
+        let out = server(tmp.path())
+            .read_timeline(Parameters(DateParam {
+                date: "2026-04-30".to_string(),
+            }))
+            .unwrap()
+            .0;
+
+        let entry = &out.entries[0];
+        assert_eq!(entry.datetime.as_deref(), Some("2026-04-30T09:00:00"));
+        assert_eq!(entry.text, "朝 #run");
+        assert_eq!(entry.tags, vec!["run"]);
+        assert_eq!(entry.context.battery, Some(56));
+        let location = entry.context.location.as_ref().unwrap();
+        assert_eq!(location.place.as_deref(), Some("渋谷区"));
+        assert_eq!(location.place_key, "35.68,139.65");
+        assert_eq!(
+            entry.context.device.as_ref().unwrap().hostname.as_deref(),
+            Some("MacBook")
+        );
+    }
+
+    /// 旧い行は端末も座標も持たない。無いものを空の箱で見せない。
+    #[test]
+    fn a_bare_entry_has_no_device_or_location() {
+        let tmp = TempDir::new().unwrap();
+        write_day(
+            tmp.path(),
+            "2026-04-30",
+            &[(9, "bare", &Context::default())],
+        );
+
+        let out = server(tmp.path())
+            .read_timeline(Parameters(DateParam {
+                date: "2026-04-30".to_string(),
+            }))
+            .unwrap()
+            .0;
+
+        assert!(out.entries[0].context.device.is_none());
+        assert!(out.entries[0].context.location.is_none());
+    }
+
+    #[test]
+    fn a_range_spans_days_oldest_first_and_skips_days_outside() {
+        let tmp = TempDir::new().unwrap();
+        let ctx = Context::default();
+        write_day(tmp.path(), "2026-01-15", &[(9, "jan", &ctx)]);
+        write_day(tmp.path(), "2026-02-10", &[(9, "feb", &ctx)]);
+        write_day(tmp.path(), "2026-03-01", &[(9, "mar", &ctx)]);
+
+        let out = range(&server(tmp.path()), "2026-01-15", "2026-02-28", None);
+
+        let texts: Vec<&str> = out.entries.iter().map(|e| e.text.as_str()).collect();
+        assert_eq!(texts, vec!["jan", "feb"]);
+        assert!(!out.truncated);
+    }
+
+    #[test]
+    fn a_range_filters_by_tag_with_or_without_the_hash() {
+        let tmp = TempDir::new().unwrap();
+        let ctx = Context::default();
+        write_day(
+            tmp.path(),
+            "2026-01-15",
+            &[(9, "走った #run", &ctx), (10, "休憩", &ctx)],
+        );
+
+        let server = server(tmp.path());
+        assert_eq!(
+            range(&server, "2026-01-01", "2026-12-31", Some("run"))
+                .entries
+                .len(),
+            1
+        );
+        assert_eq!(
+            range(&server, "2026-01-01", "2026-12-31", Some("#run"))
+                .entries
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn a_range_stops_at_the_limit_and_says_so() {
+        let tmp = TempDir::new().unwrap();
+        let ctx = Context::default();
+        write_day(
+            tmp.path(),
+            "2026-01-15",
+            &[(9, "a", &ctx), (10, "b", &ctx), (11, "c", &ctx)],
+        );
+
+        let out = server(tmp.path())
+            .read_timeline_range(Parameters(RangeParam {
+                from: "2026-01-01".to_string(),
+                to: "2026-12-31".to_string(),
+                tag: None,
+                limit: Some(2),
+            }))
+            .unwrap()
+            .0;
+
+        assert_eq!(out.entries.len(), 2);
+        assert!(out.truncated);
+    }
+
+    #[test]
+    fn a_backwards_range_is_refused() {
+        let tmp = TempDir::new().unwrap();
+
+        let result = server(tmp.path()).read_timeline_range(Parameters(RangeParam {
+            from: "2026-02-01".to_string(),
+            to: "2026-01-01".to_string(),
+            tag: None,
+            limit: None,
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn places_are_counted_per_grid_cell_across_entries_and_notes() {
+        let tmp = TempDir::new().unwrap();
+        let here = mac_at_shibuya();
+        let nearby = Context {
+            location: Some(Location {
+                latitude: 35.6769,
+                longitude: 139.6509,
+            }),
+            ..Context::default()
+        };
+        let far = Context {
+            location: Some(Location {
+                latitude: 43.06,
+                longitude: 141.35,
+            }),
+            ..Context::default()
+        };
+        write_day(
+            tmp.path(),
+            "2026-01-15",
+            &[(9, "a", &here), (10, "b", &nearby)],
+        );
+        write_day(tmp.path(), "2026-03-01", &[(9, "c", &far)]);
+        magical_merchant_core::create_draft_note(tmp.path(), "note", &[], &here).unwrap();
+        name_shibuya(tmp.path(), "en");
+
+        let out = server(tmp.path()).list_places().unwrap().0;
+
+        assert_eq!(out.places.len(), 2);
+        let shibuya = &out.places[0];
+        assert_eq!(shibuya.place_key, "35.68,139.65");
+        assert_eq!(shibuya.entries, 2);
+        assert_eq!(shibuya.notes, 1);
+        assert_eq!(shibuya.first, "2026-01-15");
+        // 控えは en で書かれているが、ja で聞いても名前は出る
+        assert_eq!(shibuya.place.as_deref(), Some("渋谷区"));
+        assert_eq!(out.places[1].place, None);
+        assert_eq!(out.places[1].entries, 1);
+    }
+
+    #[test]
+    fn tags_are_counted_across_notes_and_entries() {
+        let tmp = TempDir::new().unwrap();
+        let ctx = Context::default();
+        write_day(
+            tmp.path(),
+            "2026-01-15",
+            &[(9, "#run 朝", &ctx), (10, "#run 夜 #rest", &ctx)],
+        );
+        magical_merchant_core::create_draft_note(tmp.path(), "設計 #rust", &[], &ctx).unwrap();
+
+        let out = server(tmp.path()).list_tags().unwrap().0;
+
+        let run = out.tags.iter().find(|t| t.tag == "run").unwrap();
+        assert_eq!((run.notes, run.entries), (0, 2));
+        let rust = out.tags.iter().find(|t| t.tag == "rust").unwrap();
+        assert_eq!((rust.notes, rust.entries), (1, 0));
+        assert_eq!(out.tags[0].tag, "run");
+    }
+
+    #[test]
+    fn a_note_comes_back_as_metadata_plus_body() {
+        let tmp = TempDir::new().unwrap();
+        let path = magical_merchant_core::create_draft_note(
+            tmp.path(),
+            "# 題\n本文 #rust",
+            &["Memo".to_string()],
+            &mac_at_shibuya(),
+        )
+        .unwrap();
+        name_shibuya(tmp.path(), "ja");
+        let filename = path.file_name().unwrap().to_str().unwrap().to_string();
+
+        let out = server(tmp.path())
+            .read_note(Parameters(FilenameParam { filename }))
+            .unwrap()
+            .0;
+
+        assert_eq!(out.body, "# 題\n本文 #rust");
+        assert!(!out.body.contains("---"));
+        assert_eq!(out.tags, vec!["memo", "rust"]);
+        assert!(out.time.is_some());
+        assert_eq!(out.updated, None);
+        let context = out.context.unwrap();
+        assert_eq!(context.battery, Some(56));
+        assert_eq!(context.location.unwrap().place.as_deref(), Some("渋谷区"));
+    }
+
+    #[test]
+    fn a_missing_data_dir_names_the_path_and_the_flag() {
+        let message = exists_or_hint(Path::new("/nonexistent/magical-merchant")).unwrap_err();
+
+        assert!(message.contains("/nonexistent/magical-merchant"));
+        assert!(message.contains("--data-dir"));
+    }
+}

--- a/nix/mcp.nix
+++ b/nix/mcp.nix
@@ -1,0 +1,60 @@
+# MCP サーバーだけのパッケージ。default(Tauri アプリ)から切り出すのは、
+# AI クライアントの設定に `nix run github:Xantibody/magical-merchant#mcp` と
+# 書けるようにするため。アプリ本体を建てる pnpm と Tauri のツールチェーンを、
+# stdio で JSON を返すだけのバイナリのために取り寄せたくない。
+{
+  lib,
+  rustPlatform,
+  fetchurl,
+}:
+let
+  crateApiUrl = "https://crates.io/api/v1/crates";
+  crateMirrorUrl = "https://static.crates.io/crates";
+  cargoToml = lib.importTOML ../mcp-cli/Cargo.toml;
+  cargoFlags = [
+    "-p"
+    "magical-merchant-mcp-cli"
+  ];
+in
+rustPlatform.buildRustPackage {
+  pname = "magical-merchant-mcp";
+  inherit (cargoToml.package) version;
+
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../Cargo.toml
+      ../Cargo.lock
+      ../core
+      ../mcp-cli
+      # ワークスペースの解決にだけ要る。ビルドはしない
+      ../tauri-app/src-tauri/Cargo.toml
+      ../tauri-app/src-tauri/src
+      ../tauri-app/src-tauri/build.rs
+    ];
+  };
+
+  # package.nix と同じ理由(crates.io の api/v1 が curl 系 UA を 403 で返す)
+  cargoDeps =
+    (rustPlatform.importCargoLock.override {
+      fetchurl =
+        args:
+        fetchurl (
+          args
+          // {
+            url = lib.replaceStrings [ crateApiUrl ] [ crateMirrorUrl ] args.url;
+          }
+        );
+    })
+      {
+        lockFile = ../Cargo.lock;
+      };
+
+  cargoBuildFlags = cargoFlags;
+  cargoTestFlags = cargoFlags;
+
+  meta = {
+    description = "Read-only MCP server for a Magical Merchant journal";
+    mainProgram = "magical-merchant-mcp-cli";
+  };
+}

--- a/tauri-app/src-tauri/src/place.rs
+++ b/tauri-app/src-tauri/src/place.rs
@@ -7,7 +7,7 @@
 //! ものの劣化版にしかならず、住所の言い方は国ごとに違う。
 
 use magical_merchant_core::utils::paths::place_cache_path;
-use magical_merchant_core::utils::place::{PlaceCache, place_key};
+use magical_merchant_core::utils::place::{PlaceCache, cache_key, place_key};
 use std::path::Path;
 
 /// 地名の分かった座標だけを、[`place_key`] 付きで返す。
@@ -52,16 +52,6 @@ pub(crate) fn resolve(
         let _ = cache.save(&path);
     }
     resolved
-}
-
-/// 控えの中でのキー。言語を変えると同じ座標に別の名前が付くので、
-/// 座標だけで引くと前の言語の名前をそのまま出してしまう。
-///
-/// この変更より前に書かれた控え(言語の付かないキー)はもう一致しない。
-/// 派生ファイルなので消しには行かず、次に同じ場所を通ったときに
-/// 言語付きで書き直されるに任せる。
-fn cache_key(locale: &str, place_key: &str) -> String {
-    format!("{locale}:{place_key}")
 }
 
 /// 住所の各段から、地図で指させるいちばん細かいものを選ぶ。
@@ -301,16 +291,6 @@ mod tests {
 
     /// 住所の 4 段を、無い段は `""` で。ジオコーダが空文字で返す段と
     /// そもそも返さない段は、どちらも「名乗れなかった」で区別しない。
-    /// 控えは言語ごとに分ける。座標だけで引くと、言語を変えても前の名前が出る。
-    #[test]
-    fn the_cache_remembers_which_language_it_asked_in() {
-        assert_eq!(cache_key("en", "35.68,139.55"), "en:35.68,139.55");
-        assert_ne!(
-            cache_key("en", "35.68,139.55"),
-            cache_key("ja", "35.68,139.55")
-        );
-    }
-
     fn named(areas: [&str; 4]) -> Option<String> {
         let [locality, sub, admin, country] =
             areas.map(|area| (!area.is_empty()).then(|| area.to_string()));


### PR DESCRIPTION
## なぜやるか

MCP はタイムラインを保存形式の生の行(`- [HH:MM:SS] 本文 {json}`)のまま返していた。行末 JSON に埋まっている時刻・座標・電池・端末を使うには、読む側がアプリのファイル形式を再パースするしかない。
他の MCP やエージェントがこれをラップし、別のデータと「いつ・どこで」で突き合わせられるよう、値として返す形に作り直す。
公開アプリなので、個人的な結合ロジックは持たず、パスを手書きしなくても動き、ネットワークに出ない読み取り専用の口に徹する。

## やったこと

時刻と座標を値で返し、地名はアプリの控えから引く。緑が新しく足した部分。

```mermaid
flowchart LR
  client["AI クライアント / 上位の MCP"] -->|"nix run …#mcp"| mcp["MCP サーバー"]
  mcp -->|"行を値に分解"| parse["core: parse_timeline_entry"]
  parse --> files["data/ のノートとタイムライン"]
  mcp -->|"座標 → 地名"| places["places.json (アプリの地名控え)"]

  classDef added stroke:#3fb950,stroke-width:3px
  class parse,places added
```

- **記録が値で返る**: エントリごとに `datetime`、本文、タグ、座標と地名(`place_key` 付き)、電池、回線、端末が並ぶ。外部が突き合わせに使うキーは `datetime` と `place_key`
- **問い方が増えた**: 期間指定(タグ絞り込み・上限付き)、場所ごとの集計、タグ集計、バックリンク、テンプレの読み出し
- **設定なしで動く**: データディレクトリはアプリと同じ場所を自動検出し、`nix run github:Xantibody/magical-merchant#mcp` で起動できる(CI でもビルド)
- 先に構造を直した: タグ合流と地名控えのキー生成を core に寄せ、Tauri 側と MCP 側が同じ規則を使う

## やらなかったこと

- **書き込み**: 別 PR(#158)。読み取りの形を先に固める
- **タイムライン時刻の UTC オフセット**: 保存形式が端末ローカル時刻のみで持たないため、`datetime` はオフセット無しで返し、その旨をツール説明に書いた
