### PR TITLE
feat(mcp-cli): note-writing tools behind --allow-write with restorable history

### DIFF
--- a/.claude/skills/rust-core/SKILL.md
+++ b/.claude/skills/rust-core/SKILL.md
@@ -32,8 +32,16 @@ in `output.rs`): `list_notes`, `read_note`, `backlinks`, `search`,
 values (`parse_timeline_entry` in core), never as raw lines — external
 consumers join on time and location, so keep those fields structured. Place
 names come only from the app's `places.json` cache; the server must stay
-offline. New core read APIs should be considered for MCP exposure; never
-expose writes without discussion. Packaged as `nix run .#mcp` (`nix/mcp.nix`).
+offline. New core read APIs should be considered for MCP exposure.
+
+Write tools (`create_note`, `update_note`, `list_note_history`,
+`read_note_history`, `restore_note`) exist only behind `--allow-write` and
+are removed from the router otherwise — never listed-but-refused. Every
+overwrite goes through `snapshot_note` first (`core/src/note/history.rs`,
+`<base>/history/<stem>/<id>.md`, outside the synced `data/`), and writes
+always use core's note functions so the frontmatter stays compliant. No
+delete tool; do not add one without discussion. Packaged as
+`nix run .#mcp` (`nix/mcp.nix`).
 
 ## Verification
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,16 +16,16 @@ ready to record the moment it opens (widgets exist for exactly this).
 
 ## Tech Stack
 
-| Layer      | Technology                                          |
-| ---------- | --------------------------------------------------- |
-| Core logic | Rust (`core/` crate, framework-independent)         |
-| App        | Tauri 2 + SolidJS (`tauri-app/`)                    |
-| Styling    | Open Props via `--app-*` tokens (`styles/base.css`) |
-| Icons      | Phosphor Icons (SVG files, `components/Icon.tsx`)   |
-| Editor     | Milkdown (headless) + custom plugins                |
-| Markdown   | markdown-it + Shiki; Mermaid / markmap lazy         |
-| Sync       | Cloudflare Workers + R2 (`workers/`)                |
-| AI access  | MCP server (`mcp-cli/`, read-only, `nix run .#mcp`) |
+| Layer      | Technology                                              |
+| ---------- | ------------------------------------------------------- |
+| Core logic | Rust (`core/` crate, framework-independent)             |
+| App        | Tauri 2 + SolidJS (`tauri-app/`)                        |
+| Styling    | Open Props via `--app-*` tokens (`styles/base.css`)     |
+| Icons      | Phosphor Icons (SVG files, `components/Icon.tsx`)       |
+| Editor     | Milkdown (headless) + custom plugins                    |
+| Markdown   | markdown-it + Shiki; Mermaid / markmap lazy             |
+| Sync       | Cloudflare Workers + R2 (`workers/`)                    |
+| AI access  | MCP server (`mcp-cli/`, `nix run .#mcp`; writes opt-in) |
 
 ## UI Architecture (current)
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,8 +14,9 @@ pub mod search;
 pub use error::CoreError;
 pub use note::error::NoteError;
 pub use note::{
-    NoteSummary, create_draft_note, create_note_from_entry, delete_note, list_notes, read_note,
-    read_note_by_filename, read_note_meta, repair_notes, update_note, update_note_meta,
+    NoteSummary, Snapshot, create_draft_note, create_note_from_entry, delete_note,
+    list_note_history, list_notes, read_note, read_note_by_filename, read_note_history,
+    read_note_meta, repair_notes, restore_note, snapshot_note, update_note, update_note_meta,
     update_note_origin, update_note_view,
 };
 pub use search::{HitKind, SearchHit, find_backlinks, search_all};

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -1,8 +1,10 @@
 pub(crate) mod error;
+mod history;
 mod repair;
 pub(crate) mod repository;
 mod summary;
 
+pub use history::{Snapshot, list_note_history, read_note_history, restore_note, snapshot_note};
 pub(crate) use repository::Notes;
 pub use summary::Summary as NoteSummary;
 

--- a/core/src/note/history.rs
+++ b/core/src/note/history.rs
@@ -1,0 +1,264 @@
+//! ノートを書き換える前の全文の控え。
+//!
+//! 人が画面で書き直すぶんには要らない — 目の前で消えるのは自分の字だけ。
+//! 外部(MCP)からの書き換えは本人が見ていないところで起きるので、
+//! 「戻れる」ことが書かせる条件になる。
+//!
+//! 置き場は `data/` の外。同期に載せると、書き換えのたびに控えが端末を
+//! 往復し、控えの控えが増える。派生物ではなく退避なので `places.json` とは
+//! 違って壊れていても作り直せないが、失って困るのは戻したいときだけで、
+//! そのときはノート本体が残っている。
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Local, NaiveDateTime};
+use serde::Serialize;
+
+use crate::error::CoreError;
+use crate::utils::fs::{ensure_dir, list_md_files, resolve_existing, write_atomic};
+use crate::utils::paths::{history_dir, notes_dir};
+use crate::utils::validated::NoteFilename;
+
+/// 控え 1 件。`id` がそのまま `restore` の引数。
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Snapshot {
+    /// `YYYYMMDD_HHMMSS`、同じ秒に 2 つ目以降は `-2` `-3` と続く。
+    pub id: String,
+    /// 控えを取った時刻。ノートの `time`(作成)とも `updated`(最後の編集)とも
+    /// 別で、「この中身が最後に有効だった瞬間」。
+    pub time: DateTime<Local>,
+    pub bytes: u64,
+}
+
+fn note_history_dir(base_dir: &Path, filename: &NoteFilename) -> PathBuf {
+    history_dir(base_dir).join(filename.as_str().trim_end_matches(".md"))
+}
+
+/// 控えの名前として通るのは日時とその枝番だけ。`..` や `/` を含む id で
+/// 履歴の外を読み書きさせない。
+fn snapshot_path(dir: &Path, id: &str) -> Result<PathBuf, CoreError> {
+    let (stamp, suffix) = id.split_once('-').unwrap_or((id, "1"));
+    let well_formed = NaiveDateTime::parse_from_str(stamp, "%Y%m%d_%H%M%S").is_ok()
+        && !suffix.is_empty()
+        && suffix.bytes().all(|b| b.is_ascii_digit());
+    if !well_formed {
+        return Err(CoreError::PathTraversal(id.to_string()));
+    }
+    Ok(dir.join(format!("{id}.md")))
+}
+
+/// いまの全文を控えに取る。ノートがまだ無ければ何も取らず `None`。
+///
+/// frontmatter ごと丸写しにする。本文だけ残して戻すと、戻した瞬間の
+/// メタデータが「書き換える前」を名乗ることになる。
+pub fn snapshot_note(
+    base_dir: &Path,
+    filename: &NoteFilename,
+) -> Result<Option<Snapshot>, CoreError> {
+    let path = match resolve_existing(&notes_dir(base_dir), filename.as_str()) {
+        Ok(path) => path,
+        Err(CoreError::NotFound(_)) => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    let content = fs::read_to_string(&path)?;
+    let dir = note_history_dir(base_dir, filename);
+    let now = Local::now();
+    let stamp = now.format("%Y%m%d_%H%M%S").to_string();
+
+    // 同じ秒に 2 回書き換えても前の控えを潰さない。戻したいのは大抵、
+    // 立て続けに間違えた直前の 1 つ。
+    let mut id = stamp.clone();
+    let mut n = 1;
+    while dir.join(format!("{id}.md")).exists() {
+        n += 1;
+        id = format!("{stamp}-{n}");
+    }
+    let target = dir.join(format!("{id}.md"));
+    ensure_dir(&target)?;
+    write_atomic(&target, &content)?;
+    Ok(Some(Snapshot {
+        id,
+        time: now,
+        bytes: content.len() as u64,
+    }))
+}
+
+/// 新しいものから順に。
+pub fn list_note_history(
+    base_dir: &Path,
+    filename: &NoteFilename,
+) -> Result<Vec<Snapshot>, CoreError> {
+    let dir = note_history_dir(base_dir, filename);
+    let mut snapshots: Vec<Snapshot> = list_md_files(&dir)?
+        .into_iter()
+        .filter_map(|entry| {
+            let name = entry.file_name();
+            let id = Path::new(&name).file_stem()?.to_str()?.to_string();
+            let modified = entry.metadata().ok()?.modified().ok()?;
+            Some(Snapshot {
+                id,
+                time: modified.into(),
+                bytes: entry.metadata().ok()?.len(),
+            })
+        })
+        .collect();
+    // id は時刻そのものなので、名前順が時刻順。mtime はコピー先の時刻で、
+    // 同じ秒の枝番を並べ替える力はない。
+    snapshots.sort_by(|a, b| b.id.cmp(&a.id));
+    Ok(snapshots)
+}
+
+/// 控えの全文。読む側が本文だけ欲しければ frontmatter を剥がす。
+pub fn read_note_history(
+    base_dir: &Path,
+    filename: &NoteFilename,
+    id: &str,
+) -> Result<String, CoreError> {
+    let path = snapshot_path(&note_history_dir(base_dir, filename), id)?;
+    if !path.exists() {
+        return Err(CoreError::NotFound(path.to_string_lossy().to_string()));
+    }
+    Ok(fs::read_to_string(path)?)
+}
+
+/// 控えの中身をノートに書き戻す。戻す前にいまの全文も控えに取るので、
+/// 戻したこと自体も戻せる。
+pub fn restore_note(
+    base_dir: &Path,
+    filename: &NoteFilename,
+    id: &str,
+) -> Result<Option<Snapshot>, CoreError> {
+    let content = read_note_history(base_dir, filename, id)?;
+    let before = snapshot_note(base_dir, filename)?;
+    let target = notes_dir(base_dir).join(filename.as_str());
+    ensure_dir(&target)?;
+    write_atomic(&target, content)?;
+    Ok(before)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::device::Context;
+    use crate::utils::frontmatter::{self, NoteFrontmatter};
+    use crate::{create_draft_note, read_note_by_filename, update_note};
+    use tempfile::TempDir;
+
+    fn note(base: &Path, body: &str) -> (PathBuf, NoteFilename) {
+        let path = create_draft_note(base, body, &[], &Context::default()).unwrap();
+        let filename = NoteFilename::parse(path.file_name().unwrap().to_str().unwrap()).unwrap();
+        (path, filename)
+    }
+
+    #[test]
+    fn a_note_that_does_not_exist_leaves_nothing_behind() {
+        let tmp = TempDir::new().unwrap();
+        let filename = NoteFilename::parse("20260101_000000.md").unwrap();
+
+        assert_eq!(snapshot_note(tmp.path(), &filename).unwrap(), None);
+        assert!(list_note_history(tmp.path(), &filename).unwrap().is_empty());
+    }
+
+    /// 控えは本文ではなくファイルそのもの。frontmatter が欠けた控えを戻すと、
+    /// 作成時刻とタグが消える。
+    #[test]
+    fn a_snapshot_is_the_whole_file_frontmatter_included() {
+        let tmp = TempDir::new().unwrap();
+        let (path, filename) = note(tmp.path(), "before");
+
+        let snap = snapshot_note(tmp.path(), &filename).unwrap().unwrap();
+
+        let stored = read_note_history(tmp.path(), &filename, &snap.id).unwrap();
+        assert_eq!(stored, fs::read_to_string(&path).unwrap());
+        assert!(stored.starts_with("---\n"));
+    }
+
+    #[test]
+    fn restoring_brings_the_old_body_back_and_keeps_a_way_back() {
+        let tmp = TempDir::new().unwrap();
+        let (path, filename) = note(tmp.path(), "before");
+        let snap = snapshot_note(tmp.path(), &filename).unwrap().unwrap();
+        update_note(&path, "after", &Context::default()).unwrap();
+
+        let undo = restore_note(tmp.path(), &filename, &snap.id)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            read_note_by_filename(tmp.path(), &filename).unwrap(),
+            "before"
+        );
+        // 戻す直前の「after」も控えに残っている
+        let content = read_note_history(tmp.path(), &filename, &undo.id).unwrap();
+        assert!(content.ends_with("after"));
+    }
+
+    /// 同じ秒に 2 回書き換えたとき、1 回目の控えが 2 回目に潰されない。
+    #[test]
+    fn two_snapshots_in_the_same_second_both_survive() {
+        let tmp = TempDir::new().unwrap();
+        let (path, filename) = note(tmp.path(), "one");
+
+        let first = snapshot_note(tmp.path(), &filename).unwrap().unwrap();
+        update_note(&path, "two", &Context::default()).unwrap();
+        let second = snapshot_note(tmp.path(), &filename).unwrap().unwrap();
+
+        assert_ne!(first.id, second.id);
+        let history = list_note_history(tmp.path(), &filename).unwrap();
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].id, second.id, "newest first");
+        assert!(
+            read_note_history(tmp.path(), &filename, &first.id)
+                .unwrap()
+                .ends_with("one")
+        );
+    }
+
+    /// 控えの置き場は同期の走査範囲の外。載せると端末間で控えが往復する。
+    #[test]
+    fn history_lives_outside_the_synced_data_dir() {
+        let tmp = TempDir::new().unwrap();
+        let (_, filename) = note(tmp.path(), "body");
+
+        snapshot_note(tmp.path(), &filename).unwrap();
+
+        let synced = crate::sync::scan::scan_local_files(tmp.path()).unwrap();
+        assert_eq!(synced.len(), 1, "only the note itself is scanned");
+        assert!(tmp.path().join("history").is_dir());
+    }
+
+    #[test]
+    fn an_id_that_is_not_a_timestamp_is_refused() {
+        let tmp = TempDir::new().unwrap();
+        let (_, filename) = note(tmp.path(), "body");
+
+        for bad in [
+            "../../etc/passwd",
+            "20260101_000000-",
+            "latest",
+            "20260101_000000-x",
+        ] {
+            assert!(
+                read_note_history(tmp.path(), &filename, bad).is_err(),
+                "{bad} should be refused"
+            );
+        }
+    }
+
+    /// 戻したノートの frontmatter は控えの時点のもの。`updated` が戻すたびに
+    /// 進んでいくと、「最後に書き直した時刻」が嘘になる。
+    #[test]
+    fn restoring_does_not_touch_the_frontmatter_it_restores() {
+        let tmp = TempDir::new().unwrap();
+        let (path, filename) = note(tmp.path(), "before");
+        let snap = snapshot_note(tmp.path(), &filename).unwrap().unwrap();
+        update_note(&path, "after", &Context::default()).unwrap();
+
+        restore_note(tmp.path(), &filename, &snap.id).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        let (fm, _) = frontmatter::parse::<NoteFrontmatter>(&content).unwrap();
+        assert_eq!(fm.updated, None);
+    }
+}

--- a/core/src/utils/paths.rs
+++ b/core/src/utils/paths.rs
@@ -38,6 +38,15 @@ pub fn templates_dir(base_dir: &Path) -> PathBuf {
     data_dir(base_dir).join(TEMPLATES_DIR)
 }
 
+/// 書き換え前のノートの控えの置き場。
+///
+/// `data/` の外に置く。同期に載せると、書き換えのたびに控えが端末間を
+/// 往復する。控えは戻すためのもので、共有するものではない。
+#[must_use]
+pub fn history_dir(base_dir: &Path) -> PathBuf {
+    base_dir.join("history")
+}
+
 /// 地名キャッシュの置き場。
 ///
 /// `data/` の外に置く。中身は座標から引き直せる派生物でしかなく、同期に

--- a/docs/development.md
+++ b/docs/development.md
@@ -129,6 +129,7 @@ unified formatting for all languages. CI runs `nix fmt -- --fail-on-change`.
 | ---------------------------------- | -------------------------------------- | ------------ |
 | `MAGICAL_MERCHANT_DATA_DIR`        | Data directory for the MCP server      | User         |
 | `MAGICAL_MERCHANT_LOCALE`          | Place-name language for the MCP server | User         |
+| `MAGICAL_MERCHANT_ALLOW_WRITE`     | Enable the MCP server's write tools    | User         |
 | `ANDROID_HOME`                     | Android SDK path                       | Nix devShell |
 | `NDK_HOME`                         | Android NDK path                       | Nix devShell |
 | `PLAYWRIGHT_BROWSERS_PATH`         | Playwright browser path                | Nix devShell |

--- a/docs/features.md
+++ b/docs/features.md
@@ -152,10 +152,29 @@ can line the journal up with other time- or location-based data.
 | `list_templates`      | List note templates                                                 |
 | `read_template`       | Read a template's body and tags                                     |
 
-| Flag / variable                            | Description                                                         |
-| ------------------------------------------ | ------------------------------------------------------------------- |
-| `--data-dir` / `MAGICAL_MERCHANT_DATA_DIR` | Override the data directory (default: the app's own data directory) |
-| `--locale` / `MAGICAL_MERCHANT_LOCALE`     | Preferred language for place names, `ja` or `en` (default `en`)     |
+With `--allow-write` the server also offers note-writing tools. Notes are
+plain Markdown, so a body can hold anything the app renders — Mermaid
+diagrams in a fenced `mermaid` block, `[[YYYYMMDD_HHMMSS]]` links to other
+notes, `#tags`. The server writes the frontmatter itself and keeps it
+intact on updates; the body is all a client sends.
+
+Every overwrite first saves a full copy of the previous version under
+`<data-dir>/history/` (outside the synced `data/`), so any change an
+assistant makes can be brought back:
+
+| Tool                | Description                                                          |
+| ------------------- | -------------------------------------------------------------------- |
+| `create_note`       | Create a note from a Markdown body (first line `# Title`)            |
+| `update_note`       | Replace a note's body; returns the id of the copy saved beforehand   |
+| `list_note_history` | List the saved copies of a note, newest first                        |
+| `read_note_history` | Read the body of one saved copy                                      |
+| `restore_note`      | Bring a note back to a saved copy (the current version is saved too) |
+
+| Flag / variable                                  | Description                                                         |
+| ------------------------------------------------ | ------------------------------------------------------------------- |
+| `--data-dir` / `MAGICAL_MERCHANT_DATA_DIR`       | Override the data directory (default: the app's own data directory) |
+| `--locale` / `MAGICAL_MERCHANT_LOCALE`           | Preferred language for place names, `ja` or `en` (default `en`)     |
+| `--allow-write` / `MAGICAL_MERCHANT_ALLOW_WRITE` | Offer the note-writing tools (off by default)                       |
 
 Timeline times are the recording device's local wall-clock time without a
 UTC offset; note times are RFC 3339 with the offset. Place names come from

--- a/mcp-cli/src/main.rs
+++ b/mcp-cli/src/main.rs
@@ -29,6 +29,11 @@ struct Cli {
     /// whatever language the app has resolved a place in.
     #[arg(long, env = "MAGICAL_MERCHANT_LOCALE", default_value = "en")]
     locale: String,
+
+    /// Also offer the write tools (`create_note`, `update_note`, `restore_note`,
+    /// ...). Every overwrite saves a copy first under `<data-dir>/history`.
+    #[arg(long, env = "MAGICAL_MERCHANT_ALLOW_WRITE")]
+    allow_write: bool,
 }
 
 /// アプリが書いている場所を、引数なしでも見つける。公開アプリの MCP に
@@ -46,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
         .ok_or_else(|| anyhow::anyhow!("no data directory: pass --data-dir"))?;
     server::exists_or_hint(&data_dir).map_err(|e| anyhow::anyhow!(e))?;
 
-    let server = server::McpServer::new(data_dir, cli.locale);
+    let server = server::McpServer::new(data_dir, cli.locale, cli.allow_write);
     let transport = rmcp::transport::io::stdio();
     let running = server.serve(transport).await?;
     running.waiting().await?;

--- a/mcp-cli/src/output.rs
+++ b/mcp-cli/src/output.rs
@@ -2,7 +2,7 @@
 //! 知らないのと、外に見せる名前と中の名前を別々に変えられるようにするため。
 
 use magical_merchant_core::utils::device::{Context, NetworkType};
-use magical_merchant_core::{NoteSummary, SearchHit, TemplateSummary, TimelineEntry};
+use magical_merchant_core::{NoteSummary, SearchHit, Snapshot, TemplateSummary, TimelineEntry};
 use rmcp::schemars;
 use serde::Serialize;
 
@@ -301,4 +301,53 @@ pub(crate) struct TemplateOutput {
     /// Body with `{{variables}}` left unresolved.
     pub(crate) body: String,
     pub(crate) tags: Vec<String>,
+}
+
+// --- Write tools ---
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct CreatedNoteOutput {
+    /// The new note's filename; also its permanent id.
+    pub(crate) filename: String,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct UpdatedNoteOutput {
+    pub(crate) filename: String,
+    /// The copy of the note taken before this write. Pass its `id` to
+    /// `restore_note` to undo.
+    pub(crate) snapshot: Option<SnapshotInfo>,
+}
+
+/// One saved copy of a note, taken before a write replaced it.
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct SnapshotInfo {
+    /// The argument to pass to `read_note_history` / `restore_note`.
+    pub(crate) id: String,
+    /// When the copy was taken, RFC 3339.
+    pub(crate) time: String,
+    pub(crate) bytes: u64,
+}
+
+impl From<Snapshot> for SnapshotInfo {
+    fn from(s: Snapshot) -> Self {
+        Self {
+            id: s.id,
+            time: s.time.to_rfc3339(),
+            bytes: s.bytes,
+        }
+    }
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct HistoryOutput {
+    /// Newest first.
+    pub(crate) snapshots: Vec<SnapshotInfo>,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub(crate) struct HistoryVersionOutput {
+    pub(crate) id: String,
+    /// Markdown body of that version, without the frontmatter.
+    pub(crate) body: String,
 }

--- a/mcp-cli/src/server.rs
+++ b/mcp-cli/src/server.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use chrono::NaiveDate;
+use magical_merchant_core::utils::device::Context;
+use magical_merchant_core::utils::frontmatter;
 use magical_merchant_core::utils::paths::place_cache_path;
 use magical_merchant_core::utils::place::{PlaceCache, place_key};
 use magical_merchant_core::{NoteFilename, parse_timeline_entry};
@@ -16,8 +18,9 @@ use rmcp::{ErrorData, RoleServer, ServerHandler, schemars, tool, tool_router};
 use serde::Deserialize;
 
 use crate::output::{
-    ContextInfo, EntryInfo, NoteListOutput, NoteOutput, PlaceInfo, PlacesOutput, SearchOutput,
-    TagInfo, TagsOutput, TemplateListOutput, TemplateOutput, TimelineDatesOutput, TimelineOutput,
+    ContextInfo, CreatedNoteOutput, EntryInfo, HistoryOutput, HistoryVersionOutput, NoteListOutput,
+    NoteOutput, PlaceInfo, PlacesOutput, SearchOutput, TagInfo, TagsOutput, TemplateListOutput,
+    TemplateOutput, TimelineDatesOutput, TimelineOutput, UpdatedNoteOutput,
 };
 
 /// 範囲読みの 1 回あたりの上限。日記は年単位で溜まるので、青天井にすると
@@ -31,7 +34,18 @@ local time, GPS coordinates when available, battery, network, and which \
 device wrote it. Use `read_timeline_range` to pull entries for a period, \
 `list_places` to see where records were written, and `search` to find text. \
 Timeline times are the device's local wall-clock time without a UTC offset; \
-note times are RFC 3339 with the offset.";
+note times are RFC 3339 with the offset. When write tools are present, \
+every overwrite first saves a copy that `restore_note` can bring back.";
+
+/// 書き込みは頼まれたときだけ出す。公開アプリの MCP が既定で書けると、
+/// 「読ませたつもり」の設定で日記が書き換わる。
+const WRITE_TOOLS: [&str; 5] = [
+    "create_note",
+    "update_note",
+    "list_note_history",
+    "read_note_history",
+    "restore_note",
+];
 
 pub(crate) struct McpServer {
     data_dir: PathBuf,
@@ -40,11 +54,29 @@ pub(crate) struct McpServer {
 }
 
 impl McpServer {
-    pub(crate) fn new(data_dir: PathBuf, locale: String) -> Self {
+    pub(crate) fn new(data_dir: PathBuf, locale: String, allow_write: bool) -> Self {
+        let mut tool_router = Self::tool_router();
+        if !allow_write {
+            // 断るのではなく見せない。並んでいるのに毎回断られる道具は、
+            // モデルに「もう一度試す」以外の使い道がない
+            for name in WRITE_TOOLS {
+                tool_router.remove_route(name);
+            }
+        }
         Self {
             data_dir,
             locale,
-            tool_router: Self::tool_router(),
+            tool_router,
+        }
+    }
+
+    /// 書き込み時に記録する端末。座標や電池は MCP から読めないので、
+    /// 分かる範囲(OS と CPU)だけを正直に書く。
+    fn context() -> Context {
+        Context {
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            ..Context::default()
         }
     }
 
@@ -108,6 +140,34 @@ pub(crate) struct RangeParam {
     tag: Option<String>,
     /// Maximum number of entries to return (default 500)
     limit: Option<usize>,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+pub(crate) struct CreateNoteParam {
+    /// Markdown body. The first line should be a `# Title` heading — that is
+    /// the note's title. Fenced `mermaid` code blocks render as diagrams;
+    /// `[[YYYYMMDD_HHMMSS]]` links another note by filename stem.
+    body: String,
+    /// Tags to record in the frontmatter (without the `#`). Tags written as
+    /// `#tag` in the body are picked up automatically.
+    tags: Option<Vec<String>>,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+pub(crate) struct UpdateNoteParam {
+    /// The note filename, e.g. `20260320_143045.md`
+    filename: String,
+    /// The complete new Markdown body; replaces the old one. The frontmatter
+    /// (creation time, tags, device context) is preserved by the server.
+    body: String,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+pub(crate) struct HistoryParam {
+    /// The note filename, e.g. `20260320_143045.md`
+    filename: String,
+    /// A snapshot id from `list_note_history` or `update_note`
+    id: String,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -383,6 +443,113 @@ impl McpServer {
     }
 
     #[tool(
+        name = "create_note",
+        description = "Create a new note from a Markdown body (first line `# Title`); returns its filename"
+    )]
+    fn create_note(
+        &self,
+        Parameters(param): Parameters<CreateNoteParam>,
+    ) -> Result<Json<CreatedNoteOutput>, String> {
+        if param.body.trim().is_empty() {
+            return Err("body is empty".to_string());
+        }
+        let tags = param.tags.unwrap_or_default();
+        let path = magical_merchant_core::create_draft_note(
+            &self.data_dir,
+            &param.body,
+            &tags,
+            &Self::context(),
+        )
+        .map_err(err)?;
+        let filename = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| "created note has no filename".to_string())?;
+        Ok(Json(CreatedNoteOutput {
+            filename: filename.to_string(),
+        }))
+    }
+
+    #[tool(
+        name = "update_note",
+        description = "Replace a note's Markdown body, keeping its frontmatter; a copy of the previous version is saved first and can be brought back with restore_note"
+    )]
+    fn update_note(
+        &self,
+        Parameters(param): Parameters<UpdateNoteParam>,
+    ) -> Result<Json<UpdatedNoteOutput>, String> {
+        let filename = parse_filename(&param.filename)?;
+        if param.body.trim().is_empty() {
+            return Err("body is empty; delete is not offered here".to_string());
+        }
+        let snapshot =
+            magical_merchant_core::snapshot_note(&self.data_dir, &filename).map_err(err)?;
+        // 控えが取れなかった(存在しない)ノートには書かない。update は
+        // 無いファイルを frontmatter ごとでっち上げてしまう
+        let Some(snapshot) = snapshot else {
+            return Err(format!("note not found: {filename}"));
+        };
+        let path =
+            magical_merchant_core::utils::paths::notes_dir(&self.data_dir).join(filename.as_str());
+        magical_merchant_core::update_note(&path, &param.body, &Self::context()).map_err(err)?;
+        Ok(Json(UpdatedNoteOutput {
+            filename: filename.as_str().to_string(),
+            snapshot: Some(snapshot.into()),
+        }))
+    }
+
+    #[tool(
+        name = "list_note_history",
+        description = "List the saved copies of a note taken before each write, newest first"
+    )]
+    fn list_note_history(
+        &self,
+        Parameters(param): Parameters<FilenameParam>,
+    ) -> Result<Json<HistoryOutput>, String> {
+        let filename = parse_filename(&param.filename)?;
+        let snapshots =
+            magical_merchant_core::list_note_history(&self.data_dir, &filename).map_err(err)?;
+        Ok(Json(HistoryOutput {
+            snapshots: snapshots.into_iter().map(Into::into).collect(),
+        }))
+    }
+
+    #[tool(
+        name = "read_note_history",
+        description = "Read the body of one saved copy of a note"
+    )]
+    fn read_note_history(
+        &self,
+        Parameters(param): Parameters<HistoryParam>,
+    ) -> Result<Json<HistoryVersionOutput>, String> {
+        let filename = parse_filename(&param.filename)?;
+        let content =
+            magical_merchant_core::read_note_history(&self.data_dir, &filename, &param.id)
+                .map_err(err)?;
+        Ok(Json(HistoryVersionOutput {
+            id: param.id,
+            body: frontmatter::strip(&content).to_string(),
+        }))
+    }
+
+    #[tool(
+        name = "restore_note",
+        description = "Bring a note back to a saved copy; the current version is saved first so the restore itself can be undone"
+    )]
+    fn restore_note(
+        &self,
+        Parameters(param): Parameters<HistoryParam>,
+    ) -> Result<Json<UpdatedNoteOutput>, String> {
+        let filename = parse_filename(&param.filename)?;
+        let snapshot = magical_merchant_core::restore_note(&self.data_dir, &filename, &param.id)
+            .map_err(err)?;
+        Ok(Json(UpdatedNoteOutput {
+            filename: filename.as_str().to_string(),
+            snapshot: snapshot.map(Into::into),
+        }))
+    }
+
+    #[tool(
         name = "list_templates",
         description = "List the note templates with their tags and first line"
     )]
@@ -510,7 +677,20 @@ mod tests {
     }
 
     fn server(base: &Path) -> McpServer {
-        McpServer::new(base.to_path_buf(), "ja".to_string())
+        McpServer::new(base.to_path_buf(), "ja".to_string(), false)
+    }
+
+    fn writable(base: &Path) -> McpServer {
+        McpServer::new(base.to_path_buf(), "ja".to_string(), true)
+    }
+
+    fn tool_names(server: &McpServer) -> Vec<String> {
+        server
+            .tool_router
+            .list_all()
+            .into_iter()
+            .map(|t| t.name.to_string())
+            .collect()
     }
 
     fn range(server: &McpServer, from: &str, to: &str, tag: Option<&str>) -> TimelineOutput {
@@ -750,5 +930,128 @@ mod tests {
 
         assert!(message.contains("/nonexistent/magical-merchant"));
         assert!(message.contains("--data-dir"));
+    }
+
+    /// 読み取り専用の起動では書く道具が並ばない。断る道具は並べない。
+    #[test]
+    fn write_tools_are_absent_unless_asked_for() {
+        let tmp = TempDir::new().unwrap();
+
+        let read_only = tool_names(&server(tmp.path()));
+        let with_writes = tool_names(&writable(tmp.path()));
+
+        for name in WRITE_TOOLS {
+            assert!(!read_only.contains(&name.to_string()), "{name} leaked");
+            assert!(with_writes.contains(&name.to_string()), "{name} missing");
+        }
+    }
+
+    #[test]
+    fn a_created_note_has_compliant_frontmatter_and_the_given_body() {
+        let tmp = TempDir::new().unwrap();
+
+        let out = writable(tmp.path())
+            .create_note(Parameters(CreateNoteParam {
+                body: "# 図\n```mermaid\ngraph TD; A-->B;\n```".to_string(),
+                tags: Some(vec!["Diagram".to_string()]),
+            }))
+            .unwrap()
+            .0;
+
+        let filename = NoteFilename::parse(&out.filename).unwrap();
+        let meta = magical_merchant_core::read_note_meta(tmp.path(), &filename).unwrap();
+        assert_eq!(meta.tags, vec!["Diagram"]);
+        assert_eq!(meta.context.unwrap().os, std::env::consts::OS);
+        let body = magical_merchant_core::read_note_by_filename(tmp.path(), &filename).unwrap();
+        assert!(body.starts_with("# 図\n```mermaid"));
+    }
+
+    #[test]
+    fn an_empty_body_is_not_a_note() {
+        let tmp = TempDir::new().unwrap();
+
+        let result = writable(tmp.path()).create_note(Parameters(CreateNoteParam {
+            body: "  \n".to_string(),
+            tags: None,
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn updating_keeps_the_frontmatter_and_leaves_a_way_back() {
+        let tmp = TempDir::new().unwrap();
+        let server = writable(tmp.path());
+        let created = server
+            .create_note(Parameters(CreateNoteParam {
+                body: "before".to_string(),
+                tags: Some(vec!["keep".to_string()]),
+            }))
+            .unwrap()
+            .0;
+        let filename = NoteFilename::parse(&created.filename).unwrap();
+        let time_before = magical_merchant_core::read_note_meta(tmp.path(), &filename)
+            .unwrap()
+            .time;
+
+        let updated = server
+            .update_note(Parameters(UpdateNoteParam {
+                filename: created.filename.clone(),
+                body: "after".to_string(),
+            }))
+            .unwrap()
+            .0;
+
+        let meta = magical_merchant_core::read_note_meta(tmp.path(), &filename).unwrap();
+        assert_eq!(meta.time, time_before);
+        assert_eq!(meta.tags, vec!["keep"]);
+        assert!(meta.updated.is_some());
+        assert_eq!(
+            magical_merchant_core::read_note_by_filename(tmp.path(), &filename).unwrap(),
+            "after"
+        );
+
+        let snapshot = updated.snapshot.unwrap();
+        let old = server
+            .read_note_history(Parameters(HistoryParam {
+                filename: created.filename.clone(),
+                id: snapshot.id.clone(),
+            }))
+            .unwrap()
+            .0;
+        assert_eq!(old.body, "before");
+
+        server
+            .restore_note(Parameters(HistoryParam {
+                filename: created.filename.clone(),
+                id: snapshot.id,
+            }))
+            .unwrap();
+        assert_eq!(
+            magical_merchant_core::read_note_by_filename(tmp.path(), &filename).unwrap(),
+            "before"
+        );
+        let history = server
+            .list_note_history(Parameters(FilenameParam {
+                filename: created.filename,
+            }))
+            .unwrap()
+            .0;
+        assert_eq!(history.snapshots.len(), 2, "the restore also left a copy");
+    }
+
+    /// 無いノートを update で作らせない。frontmatter を今の時刻ででっち上げた
+    /// ファイルが、要求したのと違う名前で生まれる。
+    #[test]
+    fn updating_a_missing_note_is_refused() {
+        let tmp = TempDir::new().unwrap();
+
+        let result = writable(tmp.path()).update_note(Parameters(UpdateNoteParam {
+            filename: "20260101_000000.md".to_string(),
+            body: "ghost".to_string(),
+        }));
+
+        assert!(result.is_err());
+        assert!(!tmp.path().join("data/notes/20260101_000000.md").exists());
     }
 }


### PR DESCRIPTION
## なぜやるか

AI からノートを書きたい(Mermaid を含む Markdown の作成・書き直し)。
ただし外部からの書き換えは本人が見ていないところで起きるので、frontmatter がアプリの形式のまま保たれることと、どの変更も戻せることが書かせる条件になる。
公開アプリの MCP が既定で書けるのは危ないので、明示的に有効にしたときだけ。

## やったこと

上書きの前に全文を退避し、退避先は同期に乗せない。緑が新しく足した部分。

```mermaid
flowchart LR
  client["AI クライアント"] -->|"--allow-write のときだけ見える"| write["MCP: create / update / restore"]
  write -->|"本文だけ渡す"| core["core: ノート作成・更新 (frontmatter はここが書く)"]
  core --> notes["data/notes (同期対象)"]
  write -->|"上書き前に全文を退避"| history["history/ (同期の外)"]
  history -->|"restore_note"| notes

  classDef added stroke:#3fb950,stroke-width:3px
  class write,history added
```

- **本文だけで書ける**: クライアントは Markdown 本文を送るだけで、`time`/`tags`/`context`/`updated` はアプリと同じ core の関数が書く。Mermaid フェンス、`[[リンク]]`、`#タグ` は本文の中で普通に使える
- **必ず戻れる**: 更新は退避 id を返し、`restore_note` で戻せる。戻す前にも退避するので、戻したこと自体も戻せる
- **既定は読み取り専用**: `--allow-write` 無しでは書き込みツールが一覧に出ない(断るのではなく見せない)

## やらなかったこと

- **削除ツール**: 戻せない操作なので付けない。要るなら別途相談
- **AI が書いた印**: frontmatter に新キーを足すのは形式の変更なので見送った。`context.os` に MCP を動かした端末の OS が入るだけ
- **退避の掃除**: 上書きのたびに増えるが、消す基準を決めていない(#159)

## 資料

- 読み取り側の PR: #157
