### PR TITLE
chore(tauri-app): run Vitest headless and ignore its failure screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ profiles/
 /design_handoff_timeline_redesign/
 /plan-*.md
 *.zip
+
+# Vitest browser mode leaves failure screenshots next to the test
+.vitest-attachments/
+__screenshots__/

--- a/tauri-app/vitest.config.ts
+++ b/tauri-app/vitest.config.ts
@@ -21,6 +21,8 @@ export default defineConfig({
     browser: {
       provider: playwright(),
       enabled: true,
+      // 手元でも CI でも Chromium の窓を開かない。並列で回すと窓が前面に出続ける
+      headless: true,
       instances: [{ browser: "chromium" }],
     },
   },


### PR DESCRIPTION
## なぜやるか

ブラウザモードの Vitest が実行のたびに Chromium の窓を開き、複数ブランチを並列で回すと窓が前面に出続けていた。
失敗時に残るスクリーンショットも未追跡ファイルとして毎回現れていた。

## やったこと

- Vitest のブラウザを headless で起動する
- 失敗時のスクリーンショット置き場(`.vitest-attachments/`, `__screenshots__/`)を gitignore に入れた
