### PR TITLE
fix(tauri-app): keep double-clicks on the mindmap from zooming

### DIFF
--- a/tauri-app/src/components/MindmapView.test.tsx
+++ b/tauri-app/src/components/MindmapView.test.tsx
@@ -5,6 +5,21 @@ import MindmapView from "./MindmapView";
 
 const OUTLINE = ["# 計画", "- 買い出し", "- 仕込み", "## 当日", "- 集合"].join("\n");
 
+function query<T extends Element>(root: ParentNode, selector: string): T {
+  const el = root.querySelector<T>(selector);
+  if (!el) {
+    throw new Error(`見つからない: ${selector}`);
+  }
+  return el;
+}
+
+function sleep(ms: number): Promise<void> {
+  // oxlint-disable-next-line promise/avoid-new
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
 describe("MindmapView", () => {
   afterEach(() => cleanup());
 
@@ -29,5 +44,48 @@ describe("MindmapView", () => {
     setSource("# 後の本文");
 
     await expect.element(screen.locator(".mindmap-view svg")).toHaveTextContent("後の本文");
+  });
+
+  describe("ダブルクリックで拡大しない", () => {
+    // markmap の描画ルート (<svg> 直下の無名 <g>) の transform。d3-zoom は
+    // ここに拡大・移動を書き込むので、これが動かなければズームしていない
+    async function renderAndSettle(baseElement: HTMLElement) {
+      const screen = page.elementLocator(baseElement);
+      await expect
+        .element(screen.locator(".mindmap-view svg g.markmap-node").first())
+        .toBeInTheDocument();
+      const svg = query<SVGSVGElement>(baseElement, ".mindmap-view svg");
+      const rootGroup = query<SVGGElement>(svg, ":scope > g:not([class])");
+      // fit() は duration 0 でも d3 の transition 経由なので、初期 transform が
+      // 書かれるまで待たないと「前」の値が取れない
+      await expect.poll(() => rootGroup.getAttribute("transform")).toBeTruthy();
+      return { svg, rootGroup, before: rootGroup.getAttribute("transform") };
+    }
+
+    // d3-zoom のダブルクリック拡大は 250ms の transition で動くので、
+    // 「変わらなかった」と言うにはその時間ぶん待って見届ける必要がある
+    async function expectTransformUnchanged(rootGroup: SVGGElement, before: string | null) {
+      await sleep(400);
+      expect(rootGroup.getAttribute("transform")).toBe(before);
+    }
+
+    it("折りたたみの丸をダブルクリックしても拡大しない", async () => {
+      const { baseElement } = render(() => <MindmapView source={OUTLINE} />);
+      const { svg, rootGroup, before } = await renderAndSettle(baseElement);
+      const circle = query<SVGCircleElement>(svg, "g.markmap-node > circle");
+
+      circle.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, clientX: 10, clientY: 10 }));
+
+      await expectTransformUnchanged(rootGroup, before);
+    });
+
+    it("余白をダブルクリックしても拡大しない", async () => {
+      const { baseElement } = render(() => <MindmapView source={OUTLINE} />);
+      const { svg, rootGroup, before } = await renderAndSettle(baseElement);
+
+      svg.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, clientX: 10, clientY: 10 }));
+
+      await expectTransformUnchanged(rootGroup, before);
+    });
   });
 });

--- a/tauri-app/src/components/MindmapView.tsx
+++ b/tauri-app/src/components/MindmapView.tsx
@@ -8,6 +8,17 @@ interface MindmapViewProps {
 }
 
 /**
+ * d3-zoom が既定で付けるダブルクリック 2 倍拡大だけを外す。
+ * markmap はラベル (foreignObject) では dblclick を止めているが、折りたたみの
+ * 丸と余白では止めていないので、そこをダブルタップすると意図せず拡大していた。
+ * `zoom: false` にするとホイール・ピンチの拡大まで消えてしまうので、
+ * リスナーを名前空間 "dblclick.zoom" で狙い撃ちにする。
+ */
+function disableDoubleClickZoom(mm: Markmap): void {
+  mm.svg.on("dblclick.zoom", null);
+}
+
+/**
  * 本文の見出し・リスト構造をマインドマップとして描く読み取り専用ビュー。
  * このコンポーネントは Workspace から lazy import される。markmap-view は
  * d3 を連れてくる重い依存なので、mermaid と同じく使うノートだけに払わせる。
@@ -28,9 +39,13 @@ export default function MindmapView(props: MindmapViewProps): JSX.Element {
     // つながり、破棄後でも fit が走って取り外された SVG の寸法を読もうとする
     markmap ??= Markmap.create(svgRef, { duration: 0 });
     const current = markmap;
+    disableDoubleClickZoom(current);
     void (async () => {
       // 全消し + 作り直しではなく差分更新。ユーザーが畳んだ枝はここで保たれる
       await current.setData(root);
+      // setData にオプションを渡すと markmap が zoom を付け直すので、その後で
+      // 改めて外す。今は渡していないが、一行で済む保険なので毎回やっておく
+      disableDoubleClickZoom(current);
       if (markmap === current) {
         await current.fit();
       }


### PR DESCRIPTION
## なぜやるか

マインドマップの折りたたみの丸や余白をダブルタップすると、地図全体が 2 倍に拡大していた。
markmap が入れる d3-zoom には既定でダブルクリック拡大が付いていて、markmap はラベル上でしかそれを止めていない。

## やったこと

- `dblclick.zoom` のリスナーだけを外し、ホイールとピンチの拡大は残した
- 実 DOM でダブルクリックを起こし、ルートの transform が変わらないことを見る回帰テストを足した

## やらなかったこと

- `zoom: false` にはしなかった。ホイール・ピンチの拡大まで消えるため
