### PR TITLE
fix(tauri-app): select the neighbouring note after deleting one

### DIFF
--- a/tauri-app/src/lib/items.test.ts
+++ b/tauri-app/src/lib/items.test.ts
@@ -11,6 +11,7 @@ import {
   originKeyOf,
   replaceDayItems,
   planBulkDelete,
+  neighborOf,
 } from "./items";
 import type { Note } from "./commands";
 
@@ -272,5 +273,29 @@ describe("planBulkDelete", () => {
 
   it("returns nothing for an empty selection", () => {
     expect(planBulkDelete([])).toStrictEqual([]);
+  });
+});
+
+const list = (...ids: string[]) => ids.map((id) => ({ id }));
+
+describe("neighborOf", () => {
+  it("has no neighbour when the deleted note was the only one", () => {
+    expect(neighborOf(list("a"), "a")).toBeNull();
+  });
+
+  it("falls to the note below when the first note is deleted", () => {
+    expect(neighborOf(list("a", "b", "c"), "a")).toBe("b");
+  });
+
+  it("moves to the note above when a middle note is deleted", () => {
+    expect(neighborOf(list("a", "b", "c"), "b")).toBe("a");
+  });
+
+  it("moves to the note above when the last note is deleted", () => {
+    expect(neighborOf(list("a", "b", "c"), "c")).toBe("b");
+  });
+
+  it("has no neighbour for an id that is not in the list", () => {
+    expect(neighborOf(list("a", "b"), "zzz")).toBeNull();
   });
 });

--- a/tauri-app/src/lib/items.ts
+++ b/tauri-app/src/lib/items.ts
@@ -194,6 +194,19 @@ export function planBulkDelete(targets: DeleteTarget[]): DeleteTarget[] {
   );
 }
 
+/**
+ * 消したあとに選び直す隣の id。一覧で真上にあったものを優先し、先頭を
+ * 消したときだけ真下へ落ちる。ノートは新しい順に並ぶので「上」は直近の
+ * 記録 — 消した直後に目が向く先と同じ。残りがなければ null。
+ */
+export function neighborOf(items: readonly { id: string }[], id: string): string | null {
+  const at = items.findIndex((item) => item.id === id);
+  if (at === -1) {
+    return null;
+  }
+  return items[at - 1]?.id ?? items[at + 1]?.id ?? null;
+}
+
 export interface TimelineDay {
   /** `YYYY-MM-DD`。見出しの文字は表示側で作る。 */
   date: string;

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -20,7 +20,7 @@ import TemplatePicker from "../components/TemplatePicker";
 import { typedInvoke } from "../lib/commands";
 import { getDeviceSignals } from "../lib/client-context";
 import { useShell } from "../lib/shell";
-import { groupNotes, itemTitle, noteCreatedLabel, toNoteItems } from "../lib/items";
+import { groupNotes, itemTitle, neighborOf, noteCreatedLabel, toNoteItems } from "../lib/items";
 import type { ItemGroup, NoteItem } from "../lib/items";
 import { readNoteContent, toggledView, viewToFrontmatter } from "../lib/note-view";
 import type { NoteView } from "../lib/note-view";
@@ -509,8 +509,15 @@ export default function Workspace(): JSX.Element {
 
   // ---- 削除 + Undo（5秒は tombstone、経過後に本削除）----
   const remove = (item: NoteItem): void => {
-    setHidden((ids) => [...ids, item.id]);
-    setEditing(false);
+    // 隠す前に隣を決める。selected は一覧から消えた id を先頭へ倒すので、
+    // 何もしないと削除のたびに最上段へ飛ばされる。隣なら目線は動かない。
+    // detailOpen は触らない — 今まで通り、端末が狭ければ隣を開いたままにする
+    const neighbor = neighborOf(visibleItems(), item.id);
+    batch(() => {
+      setHidden((ids) => [...ids, item.id]);
+      setSelectedId(neighbor);
+      setEditing(false);
+    });
 
     const commit = setTimeout(() => {
       void (async () => {
@@ -526,7 +533,12 @@ export default function Workspace(): JSX.Element {
 
     shell.showToast(t().notes.deleted, () => {
       clearTimeout(commit);
-      setHidden((ids) => ids.filter((id) => id !== item.id));
+      batch(() => {
+        setHidden((ids) => ids.filter((id) => id !== item.id));
+        // 取り消しは「消す前」へ戻す操作。隣に残したままだと、戻ったのに
+        // 別のノートを見せられる
+        setSelectedId(item.id);
+      });
     });
   };
 


### PR DESCRIPTION
## なぜやるか

ノートを削除すると選択が一覧の先頭に飛んでいた。
選択中の id が一覧から消えると先頭へ倒す fallback があり、削除の tombstone でも同じ道を通っていたため。

## やったこと

- 削除後は一覧で真上にあったノートを選ぶ(先頭を消したときだけ真下)
- Undo で戻したときは、消す前に見ていたノートに選択を戻す
- 隣を決める規則は純粋関数に切り出してテストした

## やらなかったこと

- モバイルで詳細ペインを閉じる動きは変えていない。今までも削除で閉じてはいなかったので、隣を開いたままにする
