### PR TITLE
feat(tauri-app): offer a start-in-fullscreen setting on macOS

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -101,6 +101,9 @@ language each answer came from. Only the interface changes — what you wrote
 stays exactly as you wrote it, and so do your tags and the coordinates behind
 those place names.
 
+On macOS, Settings → WINDOW adds _Start in fullscreen_: the app opens in the
+native fullscreen (its own Space, like the green button) from the next launch.
+
 ## Sync (optional)
 
 A Cloudflare Worker + R2 backend syncs the Markdown files across devices.

--- a/tauri-app/dev/ipc-mock.js
+++ b/tauri-app/dev/ipc-mock.js
@@ -531,6 +531,8 @@
     "plugin:event|listen": () => 1,
     "plugin:event|unlisten": () => null,
     "plugin:deep-link|get_current": () => null,
+    // ブラウザに全画面にする窓は無い。設定を入れても何も起きないのが正しい
+    "plugin:window|set_fullscreen": () => null,
     "plugin:geolocation|check_permissions": () => ({
       location: "denied",
       coarseLocation: "denied",

--- a/tauri-app/src-tauri/capabilities/default.json
+++ b/tauri-app/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-set-fullscreen",
     "opener:default",
     "deep-link:default",
     "geolocation:allow-check-permissions",

--- a/tauri-app/src/layouts/AppLayout.tsx
+++ b/tauri-app/src/layouts/AppLayout.tsx
@@ -19,6 +19,7 @@ import { typedInvoke } from "../lib/commands";
 import { firstWidgetAction } from "../lib/widget-actions";
 import type { WidgetAction } from "../lib/widget-actions";
 import { getDeviceSignals, warmLocation } from "../lib/client-context";
+import { applyStartFullscreen } from "../lib/fullscreen";
 
 const TABS: RoutePath[] = [ROUTES.TIMELINE, ROUTES.NOTES];
 const BOTTOM_TABS: RoutePath[] = [ROUTES.TIMELINE, ROUTES.NOTES, ROUTES.SETTINGS];
@@ -120,6 +121,9 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
   onMount(() => {
     // 最初の記録が測位を待たされないよう、許可済みなら今のうちに測り始める
     warmLocation();
+
+    // 設定画面は遅延読み込みなので、起動時の窓の姿はここで決める
+    void applyStartFullscreen();
 
     // ウィジェットのタップはたいていアプリを冷えた状態から起こす。onOpenUrl は
     // 購読してからのぶんしか来ないので、起動時の URL は getCurrent で拾う。

--- a/tauri-app/src/lib/fullscreen.test.ts
+++ b/tauri-app/src/lib/fullscreen.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mockIPC, mockWindows, clearMocks } from "@tauri-apps/api/mocks";
+import {
+  applyStartFullscreen,
+  enterFullscreen,
+  readStartFullscreen,
+  writeStartFullscreen,
+} from "./fullscreen";
+
+const MAC = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15";
+const ANDROID = "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36";
+
+interface Invoked {
+  cmd: string;
+  args: Record<string, unknown>;
+}
+
+const invoked: Invoked[] = [];
+
+// vi.mock ではなく mockIPC を使う理由は commands.test.ts に書いたとおり
+function mockWindow(fail = false): void {
+  mockWindows("main");
+  mockIPC((cmd, args) => {
+    invoked.push({ cmd, args: (args ?? {}) as Record<string, unknown> });
+    if (fail) {
+      throw new Error("no window");
+    }
+    return null;
+  });
+}
+
+describe("start-fullscreen setting", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    invoked.length = 0;
+  });
+
+  afterEach(() => {
+    clearMocks();
+    localStorage.clear();
+  });
+
+  it("is off until someone turns it on", () => {
+    expect(readStartFullscreen()).toBe(false);
+  });
+
+  it("remembers being turned on", () => {
+    writeStartFullscreen(true);
+    expect(readStartFullscreen()).toBe(true);
+  });
+
+  it("remembers being turned off again", () => {
+    writeStartFullscreen(true);
+    writeStartFullscreen(false);
+    expect(readStartFullscreen()).toBe(false);
+  });
+});
+
+describe("applyStartFullscreen", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    invoked.length = 0;
+    mockWindow();
+  });
+
+  afterEach(() => {
+    clearMocks();
+    localStorage.clear();
+  });
+
+  it("asks the window for fullscreen on a Mac with the setting on", async () => {
+    writeStartFullscreen(true);
+
+    await applyStartFullscreen(MAC);
+
+    expect(invoked).toHaveLength(1);
+    expect(invoked[0].cmd).toBe("plugin:window|set_fullscreen");
+    expect(invoked[0].args.value).toBe(true);
+  });
+
+  it("leaves the window alone when the setting is off", async () => {
+    await applyStartFullscreen(MAC);
+
+    expect(invoked).toHaveLength(0);
+  });
+
+  // Android に全画面の窓は無い。設定が同期されて残っていても触らない
+  it("leaves the window alone off a Mac even with the setting on", async () => {
+    writeStartFullscreen(true);
+
+    await applyStartFullscreen(ANDROID);
+
+    expect(invoked).toHaveLength(0);
+  });
+
+  // ブラウザハーネスやテストでは窓が無い。起動を落とす理由にはならない
+  it("resolves even when the window refuses", async () => {
+    mockWindow(true);
+    writeStartFullscreen(true);
+
+    await expect(applyStartFullscreen(MAC)).resolves.toBeUndefined();
+  });
+});
+
+describe("enterFullscreen", () => {
+  afterEach(() => {
+    clearMocks();
+  });
+
+  it("resolves when there is no Tauri window at all", async () => {
+    clearMocks();
+
+    await expect(enterFullscreen()).resolves.toBeUndefined();
+  });
+});

--- a/tauri-app/src/lib/fullscreen.ts
+++ b/tauri-app/src/lib/fullscreen.ts
@@ -1,0 +1,41 @@
+/**
+ * 「起動時に全画面」の設定。macOS のデスクトップ版だけの話。
+ *
+ * テーマ(`theme.ts`)や言語(`i18n.ts`)と同じく localStorage に残す。
+ * 窓の状態は Rust 側に持たせるものではない — 次回の起動で読むのは
+ * この WebView 自身で、`getCurrentWindow().setFullscreen` を呼ぶだけで
+ * 緑ボタンと同じネイティブの全画面(専用 Space)に入れる。
+ */
+
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { isMacDesktop } from "./platform";
+
+const STORAGE_KEY = "start-fullscreen";
+
+export function readStartFullscreen(): boolean {
+  return localStorage.getItem(STORAGE_KEY) === "true";
+}
+
+export function writeStartFullscreen(on: boolean): void {
+  localStorage.setItem(STORAGE_KEY, String(on));
+}
+
+/**
+ * 今の窓を全画面にする。ブラウザハーネスやテストには窓が無く、
+ * 呼び出しが落ちる。設定ひとつのために起動を止める理由はないので黙る。
+ */
+export async function enterFullscreen(): Promise<void> {
+  try {
+    await getCurrentWindow().setFullscreen(true);
+  } catch {
+    // 窓が無い(ハーネス・テスト)か、権限が無い。どちらも見た目が変わらないだけ
+  }
+}
+
+/** 起動時に呼ぶ。Mac で設定が入っているときだけ窓に触る。 */
+export async function applyStartFullscreen(userAgent: string = navigator.userAgent): Promise<void> {
+  if (!isMacDesktop(userAgent) || !readStartFullscreen()) {
+    return;
+  }
+  await enterFullscreen();
+}

--- a/tauri-app/src/lib/i18n.ts
+++ b/tauri-app/src/lib/i18n.ts
@@ -190,6 +190,8 @@ const ja = {
     languageSystem: "システム",
     languageJa: "日本語",
     languageEn: "English",
+    startFullscreen: "起動時に全画面",
+    startFullscreenHint: "次回の起動から反映されます",
   },
   palette: {
     dialogLabel: "検索・コマンド",
@@ -430,6 +432,8 @@ const en: Messages = {
     languageSystem: "System",
     languageJa: "日本語",
     languageEn: "English",
+    startFullscreen: "Start in fullscreen",
+    startFullscreenHint: "Applies from the next launch",
   },
   palette: {
     dialogLabel: "Search and commands",

--- a/tauri-app/src/lib/platform.test.ts
+++ b/tauri-app/src/lib/platform.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { isMacDesktop } from "./platform";
+
+const MAC_WKWEBVIEW =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)";
+const ANDROID_WEBVIEW =
+  "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/120.0.0.0 Mobile Safari/537.36";
+const IPAD_SAFARI =
+  "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+const WINDOWS_WEBVIEW2 =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0";
+
+describe("isMacDesktop", () => {
+  it("recognises the macOS WKWebView", () => {
+    expect(isMacDesktop(MAC_WKWEBVIEW)).toBe(true);
+  });
+
+  it("is false on Android", () => {
+    expect(isMacDesktop(ANDROID_WEBVIEW)).toBe(false);
+  });
+
+  // iPad の UA にも "Mac OS X" が出る。ネイティブの全画面は Mac だけの話
+  it("is false on an iPad even though its user agent mentions Mac OS X", () => {
+    expect(isMacDesktop(IPAD_SAFARI)).toBe(false);
+  });
+
+  it("is false on Windows", () => {
+    expect(isMacDesktop(WINDOWS_WEBVIEW2)).toBe(false);
+  });
+
+  it("is false for an empty user agent", () => {
+    expect(isMacDesktop("")).toBe(false);
+  });
+});

--- a/tauri-app/src/lib/platform.ts
+++ b/tauri-app/src/lib/platform.ts
@@ -1,0 +1,17 @@
+/**
+ * 実行している OS の見分け。Rust 側に聞けば確実だが、設定画面の出し分けの
+ * ために IPC を往復させるほどのことではない。WebView の UA で足りる。
+ */
+
+/**
+ * macOS のデスクトップ版か。iPad の Safari も "Mac OS X" を名乗るので、
+ * "Macintosh" を見たうえでモバイルの印を除く。
+ */
+export function isMacDesktop(userAgent: string = navigator.userAgent): boolean {
+  return (
+    userAgent.includes("Macintosh") &&
+    !userAgent.includes("Android") &&
+    !userAgent.includes("iPhone") &&
+    !userAgent.includes("iPad")
+  );
+}

--- a/tauri-app/src/styles/base.css
+++ b/tauri-app/src/styles/base.css
@@ -153,6 +153,42 @@ body {
   cursor: default;
 }
 
+/* ---------------- スイッチ ---------------- */
+
+/* `<label><span>文言</span><input type="checkbox"><span class="switch"></label>`
+   の形で使う。入力を隠すのは置く側(sync-popover-toggle / settings-toggle)の
+   仕事で、ここは見た目だけ */
+.switch {
+  width: 34px;
+  height: 20px;
+  border-radius: 10px;
+  background: var(--app-border);
+  position: relative;
+  display: inline-block;
+  flex-shrink: 0;
+  transition: background 0.15s;
+}
+
+.switch::after {
+  content: "";
+  position: absolute;
+  left: 2px;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: white;
+  transition: left 0.15s;
+}
+
+input:checked ~ .switch {
+  background: var(--app-accent);
+}
+
+input:checked ~ .switch::after {
+  left: 16px;
+}
+
 /* ---------------- 初回起動 ---------------- */
 
 .first-run-overlay {

--- a/tauri-app/src/styles/popover.css
+++ b/tauri-app/src/styles/popover.css
@@ -77,41 +77,11 @@
   cursor: pointer;
 }
 
-/* チェックボックスは隠し、右のスイッチが状態を映す */
+/* チェックボックスは隠し、右のスイッチ(base.css の .switch)が状態を映す */
 .sync-popover-toggle input {
   position: absolute;
   opacity: 0;
   pointer-events: none;
-}
-
-.switch {
-  width: 34px;
-  height: 20px;
-  border-radius: 10px;
-  background: var(--app-border);
-  position: relative;
-  display: inline-block;
-  transition: background 0.15s;
-}
-
-.switch::after {
-  content: "";
-  position: absolute;
-  left: 2px;
-  top: 2px;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  background: white;
-  transition: left 0.15s;
-}
-
-.sync-popover-toggle input:checked ~ .switch {
-  background: var(--app-accent);
-}
-
-.sync-popover-toggle input:checked ~ .switch::after {
-  left: 16px;
 }
 
 .link-button {

--- a/tauri-app/src/styles/settings.css
+++ b/tauri-app/src/styles/settings.css
@@ -124,6 +124,34 @@
   color: var(--app-text-faint);
 }
 
+/* 文言と右端のスイッチ。枠は settings-link と揃え、行ごと押せる */
+.settings-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 44px;
+  padding: 10px 14px;
+  border: 1px solid var(--app-border);
+  border-radius: 9px;
+  background: var(--app-input-bg);
+  color: var(--app-text);
+  font-size: 14px;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgb(20 20 25 / 4%);
+}
+
+.settings-toggle:hover {
+  background: var(--app-surface-2);
+}
+
+/* チェックボックスは隠し、右のスイッチ(base.css の .switch)が状態を映す */
+.settings-toggle input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
 /* 設定ファイルで固定されている環境では読むだけ */
 .settings-readonly {
   display: flex;

--- a/tauri-app/src/views/Settings.test.tsx
+++ b/tauri-app/src/views/Settings.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@solidjs/testing-library";
+import { mockIPC, mockWindows, clearMocks } from "@tauri-apps/api/mocks";
+import { MemoryRouter, Route } from "@solidjs/router";
+import { readStartFullscreen } from "../lib/fullscreen";
+import Settings from "./Settings";
+
+const MAC = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15";
+const ANDROID = "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36";
+
+const fullscreenCalls: unknown[] = [];
+let listens = 0;
+
+/** Tauri の内部 API に公開の型は無い。テストが触るぶんだけ形を書く */
+interface TauriInternals {
+  __TAURI_INTERNALS__: { transformCallback: () => number };
+  __TAURI_EVENT_PLUGIN_INTERNALS__: { unregisterListener: () => void };
+}
+const tauri = globalThis as unknown as TauriInternals;
+
+// vi.mock ではなく mockIPC を使う理由は commands.test.ts に書いたとおり
+function mockCommands(): void {
+  mockWindows("main");
+  mockIPC((cmd, args) => {
+    switch (cmd) {
+      case "list_templates": {
+        return [];
+      }
+      case "get_sync_config": {
+        return { workers_url: "", auto_sync: false };
+      }
+      case "is_sync_config_editable": {
+        return false;
+      }
+      case "auth_status": {
+        return false;
+      }
+      case "plugin:event|listen": {
+        listens += 1;
+        return 1;
+      }
+      case "plugin:event|unlisten": {
+        return null;
+      }
+      case "plugin:window|set_fullscreen": {
+        fullscreenCalls.push(args);
+        return null;
+      }
+      default: {
+        throw new Error(`unexpected command ${cmd}`);
+      }
+    }
+  });
+  // 認証イベントの listen / unlisten が要る。mockIPC は invoke しか差し替えない
+  tauri.__TAURI_INTERNALS__.transformCallback = () => 1;
+  tauri.__TAURI_EVENT_PLUGIN_INTERNALS__ = { unregisterListener: () => {} };
+}
+
+/** テストは Chromium で走るので、実行した Mac の UA が漏れないよう固定する。 */
+function pretendUserAgent(userAgent: string): void {
+  Object.defineProperty(navigator, "userAgent", { value: userAgent, configurable: true });
+}
+
+/**
+ * onMount が認証イベントを 2 つ listen し終えるまで待つ。途中でテストが
+ * 終わると clearMocks に transformCallback を消され、後続の listen が落ちる
+ */
+async function renderSettings(): Promise<void> {
+  render(() => (
+    <MemoryRouter>
+      <Route path="/" component={Settings} />
+    </MemoryRouter>
+  ));
+  await waitFor(() => expect(listens).toBe(2));
+}
+
+describe("Settings › start in fullscreen", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    fullscreenCalls.length = 0;
+    listens = 0;
+    mockCommands();
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(navigator, "userAgent");
+    // 破棄時の unlisten がモックを使うので、消すのはその後
+    cleanup();
+    clearMocks();
+    localStorage.clear();
+  });
+
+  it("offers the switch on a Mac", async () => {
+    pretendUserAgent(MAC);
+
+    await renderSettings();
+
+    expect(screen.getByLabelText<HTMLInputElement>("起動時に全画面").checked).toBe(false);
+  });
+
+  // 全画面にできる窓は Mac にしかない。Android に出すと押しても何も起きない
+  it("hides the switch off a Mac", async () => {
+    pretendUserAgent(ANDROID);
+
+    await renderSettings();
+
+    expect(screen.queryByLabelText("起動時に全画面")).toBeNull();
+  });
+
+  it("remembers the switch and goes fullscreen right away", async () => {
+    pretendUserAgent(MAC);
+    await renderSettings();
+
+    fireEvent.click(screen.getByLabelText("起動時に全画面"));
+
+    expect(readStartFullscreen()).toBe(true);
+    await waitFor(() => expect(fullscreenCalls).toHaveLength(1));
+  });
+
+  // 切るときは窓に触らない。いま全画面で使っているのを設定の操作で解かない
+  it("leaves the window alone when switched off", async () => {
+    pretendUserAgent(MAC);
+    await renderSettings();
+    const toggle = screen.getByLabelText("起動時に全画面");
+    fireEvent.click(toggle);
+    await waitFor(() => expect(fullscreenCalls).toHaveLength(1));
+
+    fireEvent.click(toggle);
+
+    expect(readStartFullscreen()).toBe(false);
+    expect(fullscreenCalls).toHaveLength(1);
+  });
+});

--- a/tauri-app/src/views/Settings.tsx
+++ b/tauri-app/src/views/Settings.tsx
@@ -3,8 +3,10 @@ import { A } from "@solidjs/router";
 import Icon from "../components/Icon";
 import { typedInvoke } from "../lib/commands";
 import { EVENTS } from "../lib/events";
+import { enterFullscreen, readStartFullscreen, writeStartFullscreen } from "../lib/fullscreen";
 import { applyLocale, readStoredLocale, t } from "../lib/i18n";
 import type { LocalePreference } from "../lib/i18n";
+import { isMacDesktop } from "../lib/platform";
 import { ROUTES } from "../lib/routes";
 import { listen } from "@tauri-apps/api/event";
 import type { UnlistenFn } from "@tauri-apps/api/event";
@@ -24,6 +26,18 @@ export default function Settings(): JSX.Element {
   const chooseLocale = (preference: LocalePreference): void => {
     setLocalePreference(preference);
     applyLocale(preference);
+  };
+
+  const [startFullscreen, setStartFullscreen] = createSignal(readStartFullscreen());
+
+  const chooseStartFullscreen = (on: boolean): void => {
+    setStartFullscreen(on);
+    writeStartFullscreen(on);
+    // 入れた側は次回を待たせずその場で全画面にする。切った側は触らない —
+    // いま全画面で使っているのを設定の操作で解く理由はない
+    if (on) {
+      void enterFullscreen();
+    }
   };
 
   const unlisteners: UnlistenFn[] = [];
@@ -150,6 +164,23 @@ export default function Settings(): JSX.Element {
             </For>
           </div>
         </section>
+
+        {/* 全画面の窓があるのは macOS だけ。Android に出しても何も起きない */}
+        <Show when={isMacDesktop()}>
+          <section class="settings-section">
+            <h2 class="settings-section-label">WINDOW</h2>
+            <label class="settings-toggle">
+              <span>{t().settings.startFullscreen}</span>
+              <input
+                type="checkbox"
+                checked={startFullscreen()}
+                onChange={(e) => chooseStartFullscreen(e.currentTarget.checked)}
+              />
+              <span class="switch" aria-hidden="true" />
+            </label>
+            <p class="settings-hint">{t().settings.startFullscreenHint}</p>
+          </section>
+        </Show>
 
         <section class="settings-section">
           <h2 class="settings-section-label">TEMPLATES</h2>

--- a/tauri-app/vitest.config.ts
+++ b/tauri-app/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       "mermaid",
       "@solidjs/testing-library",
       "@tauri-apps/api/mocks",
+      "@tauri-apps/api/window",
     ],
   },
   test: {


### PR DESCRIPTION
## なぜやるか

Mac では起動のたびに全画面にし直していた。設定で「起動時に全画面」を選べるようにする。

## やったこと

- Settings に WINDOW セクションを足した(macOS のデスクトップ版でだけ出る)
  - 入れると次回の起動から、緑ボタンと同じネイティブの全画面(専用 Space)で開く
  - 入れた瞬間もその場で全画面にする。切ったときは窓に触らない
- 設定はテーマや言語と同じく localStorage に持ち、起動時に AppLayout で窓に適用する
- 窓の操作に必要な `core:window:allow-set-fullscreen` を capability に足し、ブラウザハーネスの IPC モックにも同じコマンドを足した
- 先に構造を直した: スイッチの見た目(`.switch`)を同期ポップオーバー専用から base.css の共通部品に移した

## やらなかったこと

- Rust 側での窓状態の保存はしない。読むのは次回起動時のこの WebView 自身で、localStorage で足りる
- 設定を切った瞬間に全画面を解除しない。いま全画面で使っているのを設定の操作で解く理由がないため
