### PR TITLE
feat: search inside the active tag filter from the palette

### DIFF
--- a/core/benches/core_paths.rs
+++ b/core/benches/core_paths.rs
@@ -28,7 +28,7 @@ fn search(c: &mut Criterion) {
         ("common", fixture::COMMON_NEEDLE),
     ] {
         group.bench_with_input(BenchmarkId::from_parameter(label), needle, |b, needle| {
-            b.iter(|| search_all(black_box(base), black_box(needle)).unwrap());
+            b.iter(|| search_all(black_box(base), black_box(needle), &[]).unwrap());
         });
     }
     group.finish();

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -41,13 +41,25 @@ pub struct SearchHit {
 const SNIPPET_CONTEXT: usize = 40;
 const MAX_HITS: usize = 100;
 
-/// タイムライン全日を走査して needle(小文字化済み)に一致するエントリを集める。
-fn timeline_hits(base_dir: &Path, needle: &str) -> Result<Vec<SearchHit>, CoreError> {
+/// 検索の範囲を切るタグ(`tags::normalize` 済み)。空なら切らない。
+/// 複数あれば全部を持つ記録だけが残る。
+fn in_scope(scope: &[String], tags: &[String]) -> bool {
+    scope.iter().all(|wanted| tags.contains(wanted))
+}
+
+/// タイムライン全日を走査して needle(小文字化済み)に一致し、`scope` の
+/// タグを全て持つエントリを集める。needle が空なら本文は見ない。
+fn timeline_hits(
+    base_dir: &Path,
+    needle: &str,
+    scope: &[String],
+) -> Result<Vec<SearchHit>, CoreError> {
     let mut hits = Vec::new();
     let timeline = Timeline::new(base_dir.to_path_buf());
     // 改行をまたぐ needle だけは日単位の足切りが使えない。CRLF のファイルでは
     // エントリ内の改行が "\n" に正規化され、ファイル本文の部分文字列にならない。
-    let day_filter_applies = !needle.contains('\n');
+    // needle が空なら足切りは常に通るので、小文字化のぶんだけ無駄になる。
+    let day_filter_applies = !needle.is_empty() && !needle.contains('\n');
 
     for date in list_timeline_dates(base_dir)? {
         let Some(content) = timeline.read_raw(date)? else {
@@ -72,6 +84,10 @@ fn timeline_hits(base_dir: &Path, needle: &str) -> Result<Vec<SearchHit>, CoreEr
             if !lowered.contains(needle) {
                 continue;
             }
+            let entry_tags = tags::parse(text);
+            if !in_scope(scope, &entry_tags) {
+                continue;
+            }
             let excerpt = snippet(text, &lowered, needle);
             hits.push(SearchHit {
                 kind: HitKind::Timeline,
@@ -80,7 +96,7 @@ fn timeline_hits(base_dir: &Path, needle: &str) -> Result<Vec<SearchHit>, CoreEr
                 date: formatted.clone(),
                 filename: None,
                 index: Some(index),
-                tags: tags::parse(text),
+                tags: entry_tags,
                 match_start: excerpt.match_start,
                 match_len: excerpt.match_start.map(|_| needle.chars().count()),
             });
@@ -91,16 +107,33 @@ fn timeline_hits(base_dir: &Path, needle: &str) -> Result<Vec<SearchHit>, CoreEr
 
 /// Timeline と Notes を横断して大文字小文字を無視した部分一致で検索する。
 /// 新しいものから順に返す。
-pub fn search_all(base_dir: &Path, query: &str) -> Result<Vec<SearchHit>, CoreError> {
+///
+/// `tags` は範囲。渡された全てのタグを持つ記録だけが対象になる(`#` の有無と
+/// ASCII の大小は見ない)。query が空でも tags があれば、そのタグの付いた記録を
+/// 全部返す — 画面でタグを選んで絞った状態を、そのまま検索の入り口にするため。
+/// どちらも空なら何も返さない。
+pub fn search_all(
+    base_dir: &Path,
+    query: &str,
+    tags: &[String],
+) -> Result<Vec<SearchHit>, CoreError> {
     let needle = query.trim().to_lowercase();
-    if needle.is_empty() {
+    let scope: Vec<String> = tags
+        .iter()
+        .map(|t| tags::normalize(t))
+        .filter(|t| !t.is_empty())
+        .collect();
+    if needle.is_empty() && scope.is_empty() {
         return Ok(Vec::new());
     }
 
-    let mut hits = timeline_hits(base_dir, &needle)?;
+    let mut hits = timeline_hits(base_dir, &needle, &scope)?;
 
     let mut haystack = String::new();
     for note in list_notes(base_dir)? {
+        if !in_scope(&scope, &note.tags) {
+            continue;
+        }
         // format! + join だとノート 1 件につき 2 回余分に確保する。
         haystack.clear();
         haystack.push_str(&note.preview);
@@ -148,7 +181,7 @@ pub fn find_backlinks(
     // 書き方の違いでバックリンクが消えてはいけない
     let needle = format!("[[{stem}");
 
-    let mut hits = timeline_hits(base_dir, &needle)?;
+    let mut hits = timeline_hits(base_dir, &needle, &[])?;
 
     for note in list_notes(base_dir)? {
         if note.filename == target.as_str() {
@@ -235,10 +268,15 @@ struct Excerpt {
 /// `lowered` は照合に使った `text` の小文字版。作り直さず受け取るのは、
 /// ここが 1 ヒットごとに走るため。
 fn snippet(text: &str, lowered: &str, needle: &str) -> Excerpt {
-    // ヒットしたのが本文以外（ノートのタグなど）なら先頭から切り出す。
-    let found = lowered
-        .find(needle)
-        .map(|byte| lowered[..byte].chars().count());
+    // ヒットしたのが本文以外(ノートのタグなど)なら先頭から切り出す。
+    // needle が空(タグだけで絞った一覧)のときも同じ — 光らせる場所はない。
+    let found = if needle.is_empty() {
+        None
+    } else {
+        lowered
+            .find(needle)
+            .map(|byte| lowered[..byte].chars().count())
+    };
     let at = found.unwrap_or(0);
     let end = at + needle.chars().count() + SNIPPET_CONTEXT;
     let start = at.saturating_sub(SNIPPET_CONTEXT);
@@ -302,7 +340,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         save_timeline_entry(tmp.path(), "anything", &context()).unwrap();
 
-        assert!(search_all(tmp.path(), "   ").unwrap().is_empty());
+        assert!(search_all(tmp.path(), "   ", &[]).unwrap().is_empty());
     }
 
     #[test]
@@ -311,7 +349,7 @@ mod tests {
         save_timeline_entry(tmp.path(), "R2 同期のリトライ戦略", &context()).unwrap();
         save_timeline_entry(tmp.path(), "牛乳を買う", &context()).unwrap();
 
-        let hits = search_all(tmp.path(), "リトライ").unwrap();
+        let hits = search_all(tmp.path(), "リトライ", &[]).unwrap();
 
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].kind, HitKind::Timeline);
@@ -326,7 +364,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         save_timeline_entry(tmp.path(), "R2 を直す #Sync #設計", &context()).unwrap();
 
-        let hits = search_all(tmp.path(), "直す").unwrap();
+        let hits = search_all(tmp.path(), "直す", &[]).unwrap();
 
         assert_eq!(hits[0].tags, vec!["sync", "設計"]);
     }
@@ -336,7 +374,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         save_timeline_entry(tmp.path(), "Local-First Sync", &context()).unwrap();
 
-        assert_eq!(search_all(tmp.path(), "local-first").unwrap().len(), 1);
+        assert_eq!(search_all(tmp.path(), "local-first", &[]).unwrap().len(), 1);
     }
 
     /// 日ファイルの先頭に端末情報が載っている日でも、返す index は
@@ -354,7 +392,7 @@ mod tests {
         save_timeline_entry(tmp.path(), "first", &ctx).unwrap();
         save_timeline_entry(tmp.path(), "second", &ctx).unwrap();
 
-        let hits = search_all(tmp.path(), "second").unwrap();
+        let hits = search_all(tmp.path(), "second", &[]).unwrap();
 
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].title, "second");
@@ -371,7 +409,7 @@ mod tests {
         };
         save_timeline_entry(tmp.path(), "plain text", &ctx).unwrap();
 
-        assert!(search_all(tmp.path(), "MacBook").unwrap().is_empty());
+        assert!(search_all(tmp.path(), "MacBook", &[]).unwrap().is_empty());
     }
 
     #[test]
@@ -383,7 +421,7 @@ mod tests {
         };
         save_timeline_entry(tmp.path(), "plain text", &ctx).unwrap();
 
-        assert!(search_all(tmp.path(), "battery").unwrap().is_empty());
+        assert!(search_all(tmp.path(), "battery", &[]).unwrap().is_empty());
     }
 
     #[test]
@@ -391,7 +429,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         create_draft_note(tmp.path(), "R2 のリトライ設計", &[], &context()).unwrap();
 
-        let hits = search_all(tmp.path(), "リトライ").unwrap();
+        let hits = search_all(tmp.path(), "リトライ", &[]).unwrap();
 
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].kind, HitKind::Note);
@@ -403,7 +441,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         create_draft_note(tmp.path(), "body", &["sync".to_string()], &context()).unwrap();
 
-        let hits = search_all(tmp.path(), "sync").unwrap();
+        let hits = search_all(tmp.path(), "sync", &[]).unwrap();
 
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].tags, vec!["sync"]);
@@ -415,7 +453,7 @@ mod tests {
         let long = format!("{}NEEDLE{}", "a".repeat(80), "b".repeat(80));
         save_timeline_entry(tmp.path(), &long, &context()).unwrap();
 
-        let hits = search_all(tmp.path(), "needle").unwrap();
+        let hits = search_all(tmp.path(), "needle", &[]).unwrap();
 
         assert!(hits[0].snippet.starts_with('…'));
         assert!(hits[0].snippet.ends_with('…'));
@@ -427,7 +465,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         save_timeline_entry(tmp.path(), "一行目\n二行目にリトライ", &context()).unwrap();
 
-        let hits = search_all(tmp.path(), "リトライ").unwrap();
+        let hits = search_all(tmp.path(), "リトライ", &[]).unwrap();
 
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].title, "一行目");
@@ -440,7 +478,7 @@ mod tests {
         let body = "本文はタグと無関係で長い".repeat(10);
         create_draft_note(tmp.path(), &body, &["sync".to_string()], &context()).unwrap();
 
-        let hits = search_all(tmp.path(), "sync").unwrap();
+        let hits = search_all(tmp.path(), "sync", &[]).unwrap();
 
         assert_eq!(hits.len(), 1);
         assert!(hits[0].snippet.starts_with("本文はタグと無関係で長い"));
@@ -452,7 +490,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         save_timeline_entry(tmp.path(), "needle のあと\n改行", &context()).unwrap();
 
-        let hits = search_all(tmp.path(), "needle").unwrap();
+        let hits = search_all(tmp.path(), "needle", &[]).unwrap();
 
         assert_eq!(hits[0].snippet, "needle のあと 改行");
     }
@@ -462,7 +500,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         save_timeline_entry(tmp.path(), "short needle here", &context()).unwrap();
 
-        let hits = search_all(tmp.path(), "needle").unwrap();
+        let hits = search_all(tmp.path(), "needle", &[]).unwrap();
 
         assert_eq!(hits[0].snippet, "short needle here");
     }
@@ -474,7 +512,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         save_timeline_entry(tmp.path(), "short needle here", &context()).unwrap();
 
-        let hits = search_all(tmp.path(), "needle").unwrap();
+        let hits = search_all(tmp.path(), "needle", &[]).unwrap();
 
         assert_eq!(hits[0].match_start, Some(6));
         assert_eq!(hits[0].match_len, Some(6));
@@ -488,7 +526,7 @@ mod tests {
         let long = format!("{}NEEDLE{}", "a".repeat(80), "b".repeat(80));
         save_timeline_entry(tmp.path(), &long, &context()).unwrap();
 
-        let hits = search_all(tmp.path(), "needle").unwrap();
+        let hits = search_all(tmp.path(), "needle", &[]).unwrap();
 
         let start = hits[0].match_start.unwrap();
         let len = hits[0].match_len.unwrap();
@@ -503,7 +541,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         save_timeline_entry(tmp.path(), "日本語の本文にリトライ", &context()).unwrap();
 
-        let hits = search_all(tmp.path(), "リトライ").unwrap();
+        let hits = search_all(tmp.path(), "リトライ", &[]).unwrap();
 
         assert_eq!(hits[0].match_start, Some(7));
         assert_eq!(hits[0].match_len, Some(4));
@@ -515,10 +553,124 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         create_draft_note(tmp.path(), "本文", &["sync".to_string()], &context()).unwrap();
 
-        let hits = search_all(tmp.path(), "sync").unwrap();
+        let hits = search_all(tmp.path(), "sync", &[]).unwrap();
 
         assert_eq!(hits[0].match_start, None);
         assert_eq!(hits[0].match_len, None);
+    }
+
+    fn scope(tags: &[&str]) -> Vec<String> {
+        tags.iter().map(|t| (*t).to_string()).collect()
+    }
+
+    /// 画面でタグを選んで絞り込んだまま検索できるように、範囲はタグで切る。
+    #[test]
+    fn a_tag_scope_keeps_only_entries_carrying_the_tag() {
+        let tmp = TempDir::new().unwrap();
+        save_timeline_entry(tmp.path(), "リトライを直す #sync", &context()).unwrap();
+        save_timeline_entry(tmp.path(), "リトライを試す #run", &context()).unwrap();
+
+        let hits = search_all(tmp.path(), "リトライ", &scope(&["sync"])).unwrap();
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "リトライを直す #sync");
+    }
+
+    #[test]
+    fn a_tag_scope_keeps_only_notes_carrying_the_tag() {
+        let tmp = TempDir::new().unwrap();
+        create_draft_note(
+            tmp.path(),
+            "リトライ設計",
+            &["sync".to_string()],
+            &context(),
+        )
+        .unwrap();
+        write_second_note(tmp.path(), "20200101_000000.md", "リトライの雑記 #misc");
+
+        let hits = search_all(tmp.path(), "リトライ", &scope(&["sync"])).unwrap();
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].kind, HitKind::Note);
+        assert_eq!(hits[0].tags, vec!["sync"]);
+    }
+
+    /// 何も打たずにタグだけ渡すと、そのタグの付いた記録が一覧になる。
+    /// パレットで「タグで絞った状態」をそのまま眺められるようにするため。
+    #[test]
+    fn an_empty_query_with_a_tag_lists_everything_carrying_it() {
+        let tmp = TempDir::new().unwrap();
+        save_timeline_entry(tmp.path(), "走った #run", &context()).unwrap();
+        save_timeline_entry(tmp.path(), "読んだ #book", &context()).unwrap();
+        create_draft_note(tmp.path(), "走る計画", &["run".to_string()], &context()).unwrap();
+
+        let hits = search_all(tmp.path(), "", &scope(&["run"])).unwrap();
+
+        assert_eq!(hits.len(), 2);
+        assert!(hits.iter().any(|h| h.kind == HitKind::Timeline));
+        assert!(hits.iter().any(|h| h.kind == HitKind::Note));
+        // 本文には光らせる場所がない
+        assert!(hits.iter().all(|h| h.match_start.is_none()));
+    }
+
+    #[test]
+    fn an_unknown_tag_matches_nothing() {
+        let tmp = TempDir::new().unwrap();
+        save_timeline_entry(tmp.path(), "走った #run", &context()).unwrap();
+
+        assert!(
+            search_all(tmp.path(), "", &scope(&["nope"]))
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    /// 選んだチップは `#Sync` でも、書かれているのは `#sync` かもしれない。
+    /// 先頭の `#` も書き手が付けがちなので、付いていても同じタグとして読む。
+    #[test]
+    fn tag_scope_matching_ignores_case_and_a_leading_hash() {
+        let tmp = TempDir::new().unwrap();
+        save_timeline_entry(tmp.path(), "直す #sync", &context()).unwrap();
+
+        assert_eq!(
+            search_all(tmp.path(), "", &scope(&["#SYNC"]))
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    /// 複数渡したら AND。どれか 1 つで良いなら、1 つずつ引けばいい。
+    #[test]
+    fn every_tag_in_the_scope_must_be_present() {
+        let tmp = TempDir::new().unwrap();
+        save_timeline_entry(tmp.path(), "両方 #a #b", &context()).unwrap();
+        save_timeline_entry(tmp.path(), "片方 #a", &context()).unwrap();
+
+        let hits = search_all(tmp.path(), "", &scope(&["a", "b"])).unwrap();
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "両方 #a #b");
+    }
+
+    /// 空のタグは範囲を狭めない。`""` を渡されて全件が消えると、呼び出し側は
+    /// 何が起きたか分からない。
+    #[test]
+    fn blank_tags_do_not_narrow_the_scope() {
+        let tmp = TempDir::new().unwrap();
+        save_timeline_entry(tmp.path(), "走った #run", &context()).unwrap();
+
+        assert_eq!(
+            search_all(tmp.path(), "走った", &scope(&["", "#"]))
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(
+            search_all(tmp.path(), "", &scope(&[""]))
+                .unwrap()
+                .is_empty()
+        );
     }
 
     fn filename_of(path: &Path) -> crate::utils::validated::NoteFilename {

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -6,6 +6,7 @@ use crate::error::CoreError;
 use crate::timeline::Timeline;
 use crate::timeline::day::DayLog;
 use crate::utils::markdown::strip_timeline_prefix;
+use crate::utils::tags;
 use crate::{list_notes, list_timeline_dates};
 
 /// 検索結果がどちらの保管場所から来たか。
@@ -79,7 +80,7 @@ fn timeline_hits(base_dir: &Path, needle: &str) -> Result<Vec<SearchHit>, CoreEr
                 date: formatted.clone(),
                 filename: None,
                 index: Some(index),
-                tags: Vec::new(),
+                tags: tags::parse(text),
                 match_start: excerpt.match_start,
                 match_len: excerpt.match_start.map(|_| needle.chars().count()),
             });
@@ -316,6 +317,18 @@ mod tests {
         assert_eq!(hits[0].kind, HitKind::Timeline);
         assert_eq!(hits[0].title, "R2 同期のリトライ戦略");
         assert_eq!(hits[0].index, Some(0));
+    }
+
+    /// ノートのヒットはタグを名乗るのに、エントリのヒットだけ空だった。
+    /// 呼び出し側が「同じ形」と信じて読むので、片方だけ黙っていてはいけない。
+    #[test]
+    fn a_timeline_hit_reports_the_tags_in_its_text() {
+        let tmp = TempDir::new().unwrap();
+        save_timeline_entry(tmp.path(), "R2 を直す #Sync #設計", &context()).unwrap();
+
+        let hits = search_all(tmp.path(), "直す").unwrap();
+
+        assert_eq!(hits[0].tags, vec!["sync", "設計"]);
     }
 
     #[test]

--- a/core/src/utils/tags.rs
+++ b/core/src/utils/tags.rs
@@ -69,6 +69,16 @@ pub fn merge(mut tags: Vec<String>, body: &str) -> Vec<String> {
     tags
 }
 
+/// 外から渡されたタグを、`parse` が返す形に揃える。
+///
+/// 画面のチップや MCP の引数は `#Sync` のように `#` 付き・大文字混じりで
+/// 来ることがある。本文から拾った `sync` と突き合わせる前にここを通す。
+/// 空になったら「タグではない」ので、呼び出し側は捨てること。
+#[must_use]
+pub fn normalize(tag: &str) -> String {
+    tag.trim().trim_start_matches('#').to_ascii_lowercase()
+}
+
 /// 行がコードフェンスの区切りなら、その記号と本数を返す。
 fn fence_marker(line: &str) -> Option<(char, usize)> {
     let trimmed = line.trim_start();
@@ -233,6 +243,14 @@ mod tests {
     #[test]
     fn finds_nothing_in_text_without_tags() {
         assert_eq!(parse("ただの本文"), Vec::<String>::new());
+    }
+
+    /// チップや引数で渡される形と、本文から拾った形を同じにする。
+    #[test]
+    fn normalizes_an_external_tag_to_the_parsed_form() {
+        assert_eq!(normalize("#Sync"), "sync");
+        assert_eq!(normalize(" 設計 "), "設計");
+        assert_eq!(normalize("#"), "");
     }
 
     #[test]

--- a/docs/features.md
+++ b/docs/features.md
@@ -89,6 +89,16 @@ used tags. Search results highlight the matched text in a context snippet, and
 selecting a hit lands exactly — a note opens that note, a timeline hit scrolls
 to that day.
 
+Searches can be scoped to tags, from any screen. Every `#tag` you type in the
+palette counts as scope rather than text: `#SF6 #ベガ #置き攻め` lists every
+note and entry carrying all three tags (AND), and `#sf6 コンボ` looks for
+"コンボ" only inside `#sf6`. Tags are matched the way the Timeline chips are,
+so `#SF6` and `#sf6` are the same tag. Picking a tag from the entry points adds
+it as a chip in front of the input; a chip is removed by clicking it, or with
+Backspace in an empty field (last chip first). When the Timeline is filtered
+by a tag, `⌘K` opens the palette with that chip already set. Scoped results
+show their count, and the empty message names the tags it looked inside.
+
 ![Command palette](images/palette.png)
 
 ## Language

--- a/docs/features.md
+++ b/docs/features.md
@@ -143,7 +143,7 @@ can line the journal up with other time- or location-based data.
 | `list_notes`          | List all notes with tags, a short preview, and their origin         |
 | `read_note`           | Read a note's metadata (time, tags, context) and Markdown body      |
 | `backlinks`           | List the records that link to a note with `[[…]]`                   |
-| `search`              | Search notes and timeline entries                                   |
+| `search`              | Search notes and timeline entries, optionally within a set of tags  |
 | `list_timeline_dates` | List the dates that have timeline entries                           |
 | `read_timeline`       | Read one day's entries with time, text, tags, location, and device  |
 | `read_timeline_range` | Read entries between two days, optionally filtered by tag           |

--- a/mcp-cli/src/server.rs
+++ b/mcp-cli/src/server.rs
@@ -274,7 +274,8 @@ impl McpServer {
         &self,
         Parameters(param): Parameters<QueryParam>,
     ) -> Result<Json<SearchOutput>, String> {
-        let hits = magical_merchant_core::search_all(&self.data_dir, &param.query).map_err(err)?;
+        let hits =
+            magical_merchant_core::search_all(&self.data_dir, &param.query, &[]).map_err(err)?;
         Ok(Json(SearchOutput {
             hits: hits.into_iter().map(Into::into).collect(),
         }))

--- a/mcp-cli/src/server.rs
+++ b/mcp-cli/src/server.rs
@@ -120,8 +120,12 @@ pub(crate) struct FilenameParam {
 
 #[derive(Deserialize, schemars::JsonSchema)]
 pub(crate) struct QueryParam {
-    /// Substring to look for; matching ignores case
+    /// Substring to look for; matching ignores case. May be empty when `tags` is given
     query: String,
+    /// Only records carrying every one of these `#tags` (with or without the `#`,
+    /// case-insensitive). With an empty `query`, lists every record carrying them
+    #[serde(default)]
+    tags: Vec<String>,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -268,14 +272,14 @@ impl McpServer {
 
     #[tool(
         name = "search",
-        description = "Search notes and timeline entries for a substring, ignoring case; newest first"
+        description = "Search notes and timeline entries for a substring, ignoring case; newest first. Pass `tags` to search only records carrying every listed #tag, or `tags` with an empty query to list every record carrying them"
     )]
     fn search(
         &self,
         Parameters(param): Parameters<QueryParam>,
     ) -> Result<Json<SearchOutput>, String> {
-        let hits =
-            magical_merchant_core::search_all(&self.data_dir, &param.query, &[]).map_err(err)?;
+        let hits = magical_merchant_core::search_all(&self.data_dir, &param.query, &param.tags)
+            .map_err(err)?;
         Ok(Json(SearchOutput {
             hits: hits.into_iter().map(Into::into).collect(),
         }))

--- a/tauri-app/dev/ipc-mock.js
+++ b/tauri-app/dev/ipc-mock.js
@@ -309,15 +309,25 @@
       }
       return answers;
     },
-    search_all: ({ query }) => {
+    search_all: ({ query, tags }) => {
       const needle = query.trim().toLowerCase();
-      if (!needle) {
+      // 本流(core)の utils::tags と同じ規則: `#` の有無と ASCII の大小は見ない
+      const lower = (tag) => tag.replaceAll(/[A-Z]/g, (c) => c.toLowerCase());
+      const scope = tags
+        .map((tag) => lower(tag.trim().replace(/^#/, "")))
+        .filter((tag) => tag.length > 0);
+      if (!needle && scope.length === 0) {
         return [];
       }
+      // lib/tags.ts の TAG と同じ。ここは 1 行しか読まないのでコードは切り分けない
+      const TAG = /(?<![\p{L}\p{N}_-])#([\p{L}\p{N}_-]+)/gu;
+      const parseTags = (text) => [...new Set([...text.matchAll(TAG)].map((m) => lower(m[1])))];
+      const inScope = (own) => scope.every((tag) => own.includes(tag));
       /** 本流(core)と同じ形: 一致の前後を含む抜粋と、文字数の一致位置。 */
       const excerpt = (text) => {
         const flat = text.replaceAll("\n", " ");
-        const at = flat.toLowerCase().indexOf(needle);
+        // タグだけで絞った一覧には光らせる場所がない
+        const at = needle ? flat.toLowerCase().indexOf(needle) : -1;
         if (at === -1) {
           return { snippet: flat.slice(0, 90), match_start: null, match_len: null };
         }
@@ -334,7 +344,8 @@
       for (const [iso, lines] of timeline) {
         lines.forEach((raw, index) => {
           const text = raw.replace(/^- \[\d\d:\d\d:\d\d\] /, "").replace(/ \{.*\}$/, "");
-          if (!text.toLowerCase().includes(needle)) {
+          const own = parseTags(text);
+          if (!text.toLowerCase().includes(needle) || !inScope(own)) {
             return;
           }
           hits.push({
@@ -343,13 +354,13 @@
             date: iso,
             filename: null,
             index,
-            tags: [],
+            tags: own,
             ...excerpt(text),
           });
         });
       }
       for (const [filename, note] of notes) {
-        if (!note.body.toLowerCase().includes(needle)) {
+        if (!note.body.toLowerCase().includes(needle) || !inScope(note.tags)) {
           continue;
         }
         hits.push({

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -263,7 +263,7 @@ async fn resolve_places(
 #[tauri::command]
 fn search_all(handle: AppHandle, query: String) -> Result<Vec<SearchHit>, String> {
     let base_dir = app_base_dir(&handle)?;
-    magical_merchant_core::search_all(&base_dir, &query).map_err(|e| e.to_string())
+    magical_merchant_core::search_all(&base_dir, &query, &[]).map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -261,9 +261,13 @@ async fn resolve_places(
 }
 
 #[tauri::command]
-fn search_all(handle: AppHandle, query: String) -> Result<Vec<SearchHit>, String> {
+fn search_all(
+    handle: AppHandle,
+    query: String,
+    tags: Vec<String>,
+) -> Result<Vec<SearchHit>, String> {
     let base_dir = app_base_dir(&handle)?;
-    magical_merchant_core::search_all(&base_dir, &query, &[]).map_err(|e| e.to_string())
+    magical_merchant_core::search_all(&base_dir, &query, &tags).map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/tauri-app/src/components/CommandPalette.test.tsx
+++ b/tauri-app/src/components/CommandPalette.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, fireEvent, cleanup, waitFor } from "@solidjs/testing-library";
+import { mockIPC, clearMocks } from "@tauri-apps/api/mocks";
+import CommandPalette from "./CommandPalette";
+import type { SearchHit } from "../lib/commands";
+
+const TAGGED_HIT: SearchHit = {
+  kind: "timeline",
+  title: "走った #sync",
+  snippet: "走った #sync",
+  date: "2026-09-01",
+  filename: null,
+  index: 0,
+  tags: ["sync"],
+  match_start: null,
+  match_len: null,
+};
+
+function renderPalette(scopeTag: string | null) {
+  const searches: unknown[] = [];
+  mockIPC((cmd, args) => {
+    if (cmd === "search_all") {
+      searches.push(args);
+      return [TAGGED_HIT];
+    }
+    return [];
+  });
+  const { container } = render(() => (
+    <CommandPalette commands={[]} scopeTag={scopeTag} onSelectHit={() => {}} onClose={() => {}} />
+  ));
+  const input = container.querySelector<HTMLInputElement>(".palette-input");
+  if (!input) {
+    throw new Error("palette-input not found");
+  }
+  return { container, input, searches };
+}
+
+describe("CommandPalette with a tag scope", () => {
+  afterEach(() => {
+    cleanup();
+    clearMocks();
+    document.body.innerHTML = "";
+  });
+
+  // 絞った状態をそのまま眺められるのが、範囲を引き継ぐ意味
+  it("lists everything under the tag before anything is typed", async () => {
+    const { container, searches } = renderPalette("sync");
+
+    expect(container.querySelector(".palette-scope")?.textContent).toContain("#sync");
+    await waitFor(() => expect(searches).toContainEqual({ query: "", tags: ["sync"] }));
+    await waitFor(() => expect(container.textContent).toContain("走った #sync"));
+  });
+
+  it("narrows the typed text to the tag", async () => {
+    const { input, searches } = renderPalette("sync");
+    fireEvent.input(input, { target: { value: "走" } });
+
+    await waitFor(() => expect(searches).toContainEqual({ query: "走", tags: ["sync"] }));
+  });
+
+  it("drops the chip on Backspace in an empty field", () => {
+    const { container, input } = renderPalette("sync");
+
+    fireEvent.keyDown(input, { key: "Backspace" });
+
+    expect(container.querySelector(".palette-scope")).toBeNull();
+  });
+
+  it("drops the chip when it is clicked", () => {
+    const { container } = renderPalette("sync");
+    const chip = container.querySelector<HTMLButtonElement>(".palette-scope");
+
+    chip?.click();
+
+    expect(container.querySelector(".palette-scope")).toBeNull();
+  });
+
+  it("opens unscoped when no tag is handed over", () => {
+    const { container } = renderPalette(null);
+
+    expect(container.querySelector(".palette-scope")).toBeNull();
+  });
+});

--- a/tauri-app/src/components/CommandPalette.test.tsx
+++ b/tauri-app/src/components/CommandPalette.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { render, fireEvent, cleanup, waitFor } from "@solidjs/testing-library";
 import { mockIPC, clearMocks } from "@tauri-apps/api/mocks";
 import CommandPalette from "./CommandPalette";
-import type { SearchHit } from "../lib/commands";
+import type { Note, SearchHit } from "../lib/commands";
 
 const TAGGED_HIT: SearchHit = {
   kind: "timeline",
@@ -16,23 +16,41 @@ const TAGGED_HIT: SearchHit = {
   match_len: null,
 };
 
-function renderPalette(scopeTag: string | null) {
+/** zero-query の入り口にタグ行を出すためのノート。 */
+const TAGGED_NOTES: Note[] = [
+  {
+    path: "notes/20260901_090000.md",
+    filename: "20260901_090000.md",
+    time: "2026-09-01T09:00:00",
+    tags: ["sf6", "ベガ"],
+    preview: "ベガ対策",
+  },
+];
+
+function renderPalette(scopeTags: string[], hits: SearchHit[] = [TAGGED_HIT]) {
   const searches: unknown[] = [];
   mockIPC((cmd, args) => {
     if (cmd === "search_all") {
       searches.push(args);
-      return [TAGGED_HIT];
+      return hits;
+    }
+    if (cmd === "list_notes") {
+      return TAGGED_NOTES;
     }
     return [];
   });
   const { container } = render(() => (
-    <CommandPalette commands={[]} scopeTag={scopeTag} onSelectHit={() => {}} onClose={() => {}} />
+    <CommandPalette commands={[]} scopeTags={scopeTags} onSelectHit={() => {}} onClose={() => {}} />
   ));
   const input = container.querySelector<HTMLInputElement>(".palette-input");
   if (!input) {
     throw new Error("palette-input not found");
   }
-  return { container, input, searches };
+  const chips = (): string[] =>
+    [...container.querySelectorAll<HTMLButtonElement>(".palette-scope")].map(
+      (chip) => chip.textContent ?? "",
+    );
+  return { container, input, searches, chips };
 }
 
 describe("CommandPalette with a tag scope", () => {
@@ -44,40 +62,90 @@ describe("CommandPalette with a tag scope", () => {
 
   // 絞った状態をそのまま眺められるのが、範囲を引き継ぐ意味
   it("lists everything under the tag before anything is typed", async () => {
-    const { container, searches } = renderPalette("sync");
+    const { container, chips, searches } = renderPalette(["sync"]);
 
-    expect(container.querySelector(".palette-scope")?.textContent).toContain("#sync");
+    expect(chips()).toEqual(["#sync"]);
     await waitFor(() => expect(searches).toContainEqual({ query: "", tags: ["sync"] }));
     await waitFor(() => expect(container.textContent).toContain("走った #sync"));
   });
 
   it("narrows the typed text to the tag", async () => {
-    const { input, searches } = renderPalette("sync");
+    const { input, searches } = renderPalette(["sync"]);
     fireEvent.input(input, { target: { value: "走" } });
 
     await waitFor(() => expect(searches).toContainEqual({ query: "走", tags: ["sync"] }));
   });
 
-  it("drops the chip on Backspace in an empty field", () => {
-    const { container, input } = renderPalette("sync");
+  it("shows one chip per tag and requires all of them", async () => {
+    const { chips, searches } = renderPalette(["sf6", "ベガ"]);
+
+    expect(chips()).toEqual(["#sf6", "#ベガ"]);
+    await waitFor(() => expect(searches).toContainEqual({ query: "", tags: ["sf6", "ベガ"] }));
+  });
+
+  // 打った `#タグ` はチップにならず、そのまま範囲として効く
+  it("sends typed hashtags as scope, not as query text", async () => {
+    const { input, chips, searches } = renderPalette([]);
+    fireEvent.input(input, { target: { value: "#SF6 #ベガ コンボ" } });
+
+    await waitFor(() =>
+      expect(searches).toContainEqual({ query: "コンボ", tags: ["sf6", "ベガ"] }),
+    );
+    expect(chips()).toEqual([]);
+  });
+
+  it("adds typed hashtags to the chips", async () => {
+    const { input, searches } = renderPalette(["sf6"]);
+    fireEvent.input(input, { target: { value: "#ベガ" } });
+
+    await waitFor(() => expect(searches).toContainEqual({ query: "", tags: ["sf6", "ベガ"] }));
+  });
+
+  it("drops only the last chip on Backspace in an empty field", () => {
+    const { input, chips } = renderPalette(["sf6", "ベガ"]);
 
     fireEvent.keyDown(input, { key: "Backspace" });
 
-    expect(container.querySelector(".palette-scope")).toBeNull();
+    expect(chips()).toEqual(["#sf6"]);
   });
 
-  it("drops the chip when it is clicked", () => {
-    const { container } = renderPalette("sync");
-    const chip = container.querySelector<HTMLButtonElement>(".palette-scope");
+  it("drops the chip that is clicked", () => {
+    const { container, chips } = renderPalette(["sf6", "ベガ"]);
+    const first = container.querySelector<HTMLButtonElement>(".palette-scope");
 
-    chip?.click();
+    first?.click();
 
-    expect(container.querySelector(".palette-scope")).toBeNull();
+    expect(chips()).toEqual(["#ベガ"]);
+  });
+
+  // 入り口のタグ行は文字を貼らず、チップとして範囲に足す
+  it("turns a home tag row into a chip", async () => {
+    const { container, chips, searches } = renderPalette([]);
+    let row: HTMLButtonElement | undefined;
+    await waitFor(() => {
+      row = [...container.querySelectorAll<HTMLButtonElement>(".palette-row")].find((r) =>
+        r.textContent?.includes("#sf6"),
+      );
+      expect(row).toBeDefined();
+    });
+
+    row?.click();
+
+    expect(chips()).toEqual(["#sf6"]);
+    await waitFor(() => expect(searches).toContainEqual({ query: "", tags: ["sf6"] }));
+  });
+
+  it("names every tag in the empty message", async () => {
+    const { container } = renderPalette(["sf6", "ベガ"], []);
+
+    await waitFor(() =>
+      expect(container.querySelector(".palette-empty")?.textContent).toContain("#sf6 #ベガ"),
+    );
   });
 
   it("opens unscoped when no tag is handed over", () => {
-    const { container } = renderPalette(null);
+    const { chips } = renderPalette([]);
 
-    expect(container.querySelector(".palette-scope")).toBeNull();
+    expect(chips()).toEqual([]);
   });
 });

--- a/tauri-app/src/components/CommandPalette.tsx
+++ b/tauri-app/src/components/CommandPalette.tsx
@@ -10,7 +10,7 @@ import { t } from "../lib/i18n";
 import { isImeComposing } from "../lib/ime";
 import { toNoteItems } from "../lib/items";
 import { countNoteTags, dayJumpHits, recentNoteHits } from "../lib/palette-home";
-import { searchRequest } from "../lib/search-scope";
+import { scopeLabel, searchRequest } from "../lib/search-scope";
 import { splitSnippet } from "../lib/snippet-highlight";
 import type { SnippetParts } from "../lib/snippet-highlight";
 
@@ -24,8 +24,8 @@ interface PaletteCommand {
 
 interface CommandPaletteProps {
   commands: PaletteCommand[];
-  /** 開いた画面から引き継ぐ検索の範囲(タグ)。開いた後はパレットの中で外せる。 */
-  scopeTag?: string | null;
+  /** 開いた画面から引き継ぐ検索の範囲(タグ、AND)。開いた後はパレットの中で外せる。 */
+  scopeTags?: string[];
   onSelectHit: (hit: SearchHit) => void;
   onClose: () => void;
 }
@@ -47,11 +47,11 @@ interface PaletteSection {
 
 interface SearchSource {
   query: string;
-  tag: string | null;
+  tags: string[];
 }
 
 function searchHits(source: SearchSource): Promise<SearchHit[]> {
-  const request = searchRequest(source.query, source.tag);
+  const request = searchRequest(source.query, source.tags);
   if (!request) {
     return Promise.resolve([]);
   }
@@ -71,21 +71,39 @@ const HOME_TAG_LIMIT = 6;
 export default function CommandPalette(props: CommandPaletteProps): JSX.Element {
   const [query, setQuery] = createSignal("");
   // 開いた瞬間の範囲を初期値にするだけ。開いている間に外から変わることはない
-  const [scope, setScope] = createSignal<string | null>(props.scopeTag ?? null);
+  const [scope, setScope] = createSignal<string[]>(props.scopeTags ?? []);
   const [cursor, setCursor] = createSignal(0);
   // 打鍵はまとめるが、チップの付け外しは即時に効かせる。1 回の操作で結果が変わる
   const debouncedQuery = createDebouncedAccessor(query, SEARCH_DEBOUNCE_MS);
   const [hits] = createResource<SearchHit[], SearchSource>(
-    () => ({ query: debouncedQuery(), tag: scope() }),
+    () => ({ query: debouncedQuery(), tags: scope() }),
     searchHits,
   );
 
-  /** 範囲は検索の入り口なので、zero-query でもチップがあれば結果を出す。 */
-  const browsing = (): boolean => Boolean(query().trim() || scope());
+  /**
+   * いま効いている範囲。チップに加えて、打った `#タグ` も入る(searchRequest)。
+   *
+   * 打った `#タグ` はチップにしない。打っている途中で `#sf` がチップになると
+   * 続きが打てず、`#sf6` と `#sf` のどちらを消したいかも分からなくなる。
+   * 打ったままの文字が範囲として効けばよく、消すのも文字を消すだけでいい。
+   */
+  const activeTags = createMemo(() => searchRequest(debouncedQuery(), scope())?.tags ?? []);
 
-  const clearScope = (): void => {
-    setScope(null);
+  /** 範囲は検索の入り口なので、zero-query でもチップがあれば結果を出す。 */
+  const browsing = (): boolean => Boolean(query().trim() || scope().length > 0);
+
+  let inputRef: HTMLInputElement | undefined;
+
+  const removeScope = (tag: string): void => {
+    setScope((tags) => tags.filter((candidate) => candidate !== tag));
     setCursor(0);
+  };
+
+  /** 範囲は足していく(AND)。置き換えると二つ目のタグで一つ目が消える。 */
+  const addScope = (tag: string): void => {
+    setScope((tags) => (tags.includes(tag) ? tags : [...tags, tag]));
+    setCursor(0);
+    inputRef?.focus();
   };
 
   // zero-query の入り口。どれも既存の IPC から導出するだけで、開いた瞬間に
@@ -103,7 +121,6 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
     };
   });
 
-  let inputRef: HTMLInputElement | undefined;
   onMount(() => inputRef?.focus());
 
   const matchingCommands = createMemo(() => {
@@ -144,13 +161,9 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
         icon: "magnifying-glass",
         label: `#${tag.tag}`,
         meta: t().palette.count(tag.count),
-        run: () => {
-          // タグは着地先が一つに決まらないので、範囲として引き継ぐ。文字列に
-          // すると本文の一致も混ざり、しかもそこから絞って打ち足せない
-          setScope(tag.tag);
-          setCursor(0);
-          inputRef?.focus();
-        },
+        // タグは着地先が一つに決まらないので、範囲として引き継ぐ。文字列に
+        // すると本文の一致も混ざり、しかもそこから絞って打ち足せない
+        run: () => addScope(tag.tag),
       }));
       return [
         { title: t().palette.commands, rows: commands },
@@ -169,9 +182,10 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
       run: () => props.onSelectHit(hit),
     }));
     // 範囲の中では件数も出す。「この中に何件あるか」が絞り込みの手応えになる
-    const hitsTitle = scope()
-      ? `${t().palette.hits} · ${t().palette.count(hitRows.length)}`
-      : t().palette.hits;
+    const hitsTitle =
+      activeTags().length > 0
+        ? `${t().palette.hits} · ${t().palette.count(hitRows.length)}`
+        : t().palette.hits;
     return [
       { title: t().palette.commands, rows: commands },
       { title: hitsTitle, rows: hitRows },
@@ -188,10 +202,11 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
       props.onClose();
       return;
     }
-    // 空の入力欄で Backspace を押したら、その手前にあるチップが消える
-    if (e.key === "Backspace" && !query() && scope()) {
+    // 空の入力欄で Backspace を押したら、その手前にあるチップ(最後の一つ)が消える
+    const last = scope().at(-1);
+    if (e.key === "Backspace" && !query() && last !== undefined) {
       e.preventDefault();
-      clearScope();
+      removeScope(last);
       return;
     }
     if (e.key === "ArrowDown") {
@@ -228,20 +243,20 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
       <div class="palette" role="dialog" aria-modal="true" aria-label={t().palette.dialogLabel}>
         <div class="palette-input-row">
           <Icon name="magnifying-glass" size={17} />
-          <Show when={scope()}>
-            {(scoped) => (
+          <For each={scope()}>
+            {(tag) => (
               <button
                 type="button"
                 class="tag-chip tag-chip--active palette-scope"
                 title={t().palette.removeScope}
-                aria-label={`${t().palette.scopeTag(scoped())} · ${t().palette.removeScope}`}
-                onClick={clearScope}
+                aria-label={`${t().palette.scopeTag(tag)} · ${t().palette.removeScope}`}
+                onClick={() => removeScope(tag)}
               >
-                #{scoped()}
+                #{tag}
                 <Icon name="x" size={11} />
               </button>
             )}
-          </Show>
+          </For>
           <input
             ref={inputRef}
             type="text"
@@ -303,7 +318,9 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
 
           <Show when={browsing() && !hits.loading && !hits()?.length}>
             <p class="palette-empty">
-              {scope() ? t().palette.emptyScoped(scope() ?? "") : t().palette.empty}
+              {activeTags().length > 0
+                ? t().palette.emptyScoped(scopeLabel(activeTags()))
+                : t().palette.empty}
             </p>
           </Show>
         </div>

--- a/tauri-app/src/components/CommandPalette.tsx
+++ b/tauri-app/src/components/CommandPalette.tsx
@@ -10,6 +10,7 @@ import { t } from "../lib/i18n";
 import { isImeComposing } from "../lib/ime";
 import { toNoteItems } from "../lib/items";
 import { countNoteTags, dayJumpHits, recentNoteHits } from "../lib/palette-home";
+import { searchRequest } from "../lib/search-scope";
 import { splitSnippet } from "../lib/snippet-highlight";
 import type { SnippetParts } from "../lib/snippet-highlight";
 
@@ -23,6 +24,8 @@ interface PaletteCommand {
 
 interface CommandPaletteProps {
   commands: PaletteCommand[];
+  /** 開いた画面から引き継ぐ検索の範囲(タグ)。開いた後はパレットの中で外せる。 */
+  scopeTag?: string | null;
   onSelectHit: (hit: SearchHit) => void;
   onClose: () => void;
 }
@@ -42,11 +45,17 @@ interface PaletteSection {
   rows: PaletteRow[];
 }
 
-function searchHits(query: string): Promise<SearchHit[]> {
-  if (!query.trim()) {
+interface SearchSource {
+  query: string;
+  tag: string | null;
+}
+
+function searchHits(source: SearchSource): Promise<SearchHit[]> {
+  const request = searchRequest(source.query, source.tag);
+  if (!request) {
     return Promise.resolve([]);
   }
-  return typedInvoke("search_all", { query });
+  return typedInvoke("search_all", request);
 }
 
 /**
@@ -61,8 +70,23 @@ const HOME_TAG_LIMIT = 6;
 
 export default function CommandPalette(props: CommandPaletteProps): JSX.Element {
   const [query, setQuery] = createSignal("");
+  // 開いた瞬間の範囲を初期値にするだけ。開いている間に外から変わることはない
+  const [scope, setScope] = createSignal<string | null>(props.scopeTag ?? null);
   const [cursor, setCursor] = createSignal(0);
-  const [hits] = createResource(createDebouncedAccessor(query, SEARCH_DEBOUNCE_MS), searchHits);
+  // 打鍵はまとめるが、チップの付け外しは即時に効かせる。1 回の操作で結果が変わる
+  const debouncedQuery = createDebouncedAccessor(query, SEARCH_DEBOUNCE_MS);
+  const [hits] = createResource<SearchHit[], SearchSource>(
+    () => ({ query: debouncedQuery(), tag: scope() }),
+    searchHits,
+  );
+
+  /** 範囲は検索の入り口なので、zero-query でもチップがあれば結果を出す。 */
+  const browsing = (): boolean => Boolean(query().trim() || scope());
+
+  const clearScope = (): void => {
+    setScope(null);
+    setCursor(0);
+  };
 
   // zero-query の入り口。どれも既存の IPC から導出するだけで、開いた瞬間に
   // 1 回読めば足りる
@@ -99,7 +123,7 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
       run: command.run,
     }));
 
-    if (!query().trim()) {
+    if (!browsing()) {
       const entry = home();
       const days: PaletteRow[] = (entry?.days ?? []).map((day) => ({
         key: `day:${day.hit.date}`,
@@ -121,9 +145,11 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
         label: `#${tag.tag}`,
         meta: t().palette.count(tag.count),
         run: () => {
-          // タグは着地先が一つに決まらないので、検索として引き継ぐ
-          setQuery(tag.tag);
+          // タグは着地先が一つに決まらないので、範囲として引き継ぐ。文字列に
+          // すると本文の一致も混ざり、しかもそこから絞って打ち足せない
+          setScope(tag.tag);
           setCursor(0);
+          inputRef?.focus();
         },
       }));
       return [
@@ -142,9 +168,13 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
       highlight: splitSnippet(hit.snippet, hit.match_start, hit.match_len),
       run: () => props.onSelectHit(hit),
     }));
+    // 範囲の中では件数も出す。「この中に何件あるか」が絞り込みの手応えになる
+    const hitsTitle = scope()
+      ? `${t().palette.hits} · ${t().palette.count(hitRows.length)}`
+      : t().palette.hits;
     return [
       { title: t().palette.commands, rows: commands },
-      { title: t().palette.hits, rows: hitRows },
+      { title: hitsTitle, rows: hitRows },
     ].filter((section) => section.rows.length > 0);
   });
 
@@ -156,6 +186,12 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
     if (e.key === "Escape") {
       e.preventDefault();
       props.onClose();
+      return;
+    }
+    // 空の入力欄で Backspace を押したら、その手前にあるチップが消える
+    if (e.key === "Backspace" && !query() && scope()) {
+      e.preventDefault();
+      clearScope();
       return;
     }
     if (e.key === "ArrowDown") {
@@ -192,6 +228,20 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
       <div class="palette" role="dialog" aria-modal="true" aria-label={t().palette.dialogLabel}>
         <div class="palette-input-row">
           <Icon name="magnifying-glass" size={17} />
+          <Show when={scope()}>
+            {(scoped) => (
+              <button
+                type="button"
+                class="tag-chip tag-chip--active palette-scope"
+                title={t().palette.removeScope}
+                aria-label={`${t().palette.scopeTag(scoped())} · ${t().palette.removeScope}`}
+                onClick={clearScope}
+              >
+                #{scoped()}
+                <Icon name="x" size={11} />
+              </button>
+            )}
+          </Show>
           <input
             ref={inputRef}
             type="text"
@@ -251,8 +301,10 @@ export default function CommandPalette(props: CommandPaletteProps): JSX.Element 
             )}
           </For>
 
-          <Show when={query().trim() && !hits.loading && !hits()?.length}>
-            <p class="palette-empty">{t().palette.empty}</p>
+          <Show when={browsing() && !hits.loading && !hits()?.length}>
+            <p class="palette-empty">
+              {scope() ? t().palette.emptyScoped(scope() ?? "") : t().palette.empty}
+            </p>
           </Show>
         </div>
       </div>

--- a/tauri-app/src/layouts/AppLayout.tsx
+++ b/tauri-app/src/layouts/AppLayout.tsx
@@ -296,7 +296,7 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
 
       <Show when={shell.paletteOpen()}>
         <CommandPalette
-          scopeTag={shell.paletteScope()?.tag ?? null}
+          scopeTags={shell.paletteScope()?.tags ?? []}
           commands={[
             {
               id: "new-note",

--- a/tauri-app/src/layouts/AppLayout.tsx
+++ b/tauri-app/src/layouts/AppLayout.tsx
@@ -16,6 +16,7 @@ import type { Theme } from "../lib/theme";
 import { MODE_ICONS, MODE_LABELS, ROUTES } from "../lib/routes";
 import type { RoutePath } from "../lib/routes";
 import { typedInvoke } from "../lib/commands";
+import { paletteScopeAt } from "../lib/search-scope";
 import { firstWidgetAction } from "../lib/widget-actions";
 import type { WidgetAction } from "../lib/widget-actions";
 import { getDeviceSignals, warmLocation } from "../lib/client-context";
@@ -57,6 +58,16 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
       shell.togglePopover("sync");
     }
   });
+
+  const isActive = (path: RoutePath): boolean => location.pathname === path;
+
+  /**
+   * Timeline でタグを選んで絞っているなら、その中を探す。全体を探したければ
+   * パレットのチップを外せばよく、逆(絞り込みを後から思い出す)は難しい
+   */
+  const openSearch = (): void => {
+    shell.openPalette(paletteScopeAt(location.pathname, shell.timelineTag()));
+  };
 
   const newNote = (): void => {
     shell.closePalette();
@@ -141,7 +152,7 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
     const onKeyDown = (e: KeyboardEvent): void => {
       if (isMetaK(e)) {
         e.preventDefault();
-        shell.openPalette();
+        openSearch();
         return;
       }
       if (isMetaN(e)) {
@@ -173,8 +184,6 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
     onCleanup(() => document.removeEventListener("pointerdown", onPointerDown));
   });
 
-  const isActive = (path: RoutePath): boolean => location.pathname === path;
-
   return (
     <div class="app">
       <header class="header">
@@ -197,7 +206,7 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
           {MODE_LABELS[location.pathname as RoutePath] ?? "Timeline"}
         </span>
 
-        <button type="button" class="search-field" onClick={() => shell.openPalette()}>
+        <button type="button" class="search-field" onClick={openSearch}>
           <Icon name="magnifying-glass" size={15} />
           <span class="search-field-label">{t().header.searchPlaceholder}</span>
           <span class="key-badge">⌘K</span>
@@ -210,7 +219,7 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
             class="icon-button header-action header-action--search"
             title={t().header.search}
             aria-label={t().header.search}
-            onClick={() => shell.openPalette()}
+            onClick={openSearch}
           >
             <Icon name="magnifying-glass" size={18} />
           </button>
@@ -287,6 +296,7 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
 
       <Show when={shell.paletteOpen()}>
         <CommandPalette
+          scopeTag={shell.paletteScope()?.tag ?? null}
           commands={[
             {
               id: "new-note",

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -95,7 +95,11 @@ interface CommandMap {
   list_timeline_dates: { args: void; result: string[] };
   read_timeline_by_date: { args: { date: string }; result: string[] };
   delete_timeline_entry: { args: { date: string; index: number }; result: void };
-  search_all: { args: { query: string }; result: SearchHit[] };
+  /**
+   * `tags` は範囲。全部を持つ記録だけが返り、query が空でも tags があれば
+   * そのタグの付いた記録を全部返す。
+   */
+  search_all: { args: { query: string; tags: string[] }; result: SearchHit[] };
   /** このノートを `[[ID]]` で指している記録。開くたびに走査で導出される。 */
   find_backlinks: { args: { filename: string }; result: SearchHit[] };
   /**

--- a/tauri-app/src/lib/i18n.ts
+++ b/tauri-app/src/lib/i18n.ts
@@ -200,6 +200,9 @@ const ja = {
     empty: "一致するものがありません",
     count: (count: number) => `${count}件`,
     newNote: "新規ノート",
+    scopeTag: (tag: string) => `#${tag} で絞り込み`,
+    removeScope: "絞り込みを外す",
+    emptyScoped: (tag: string) => `#${tag} の中に一致するものがありません`,
   },
   editor: {
     copyCode: "コードをコピー",
@@ -440,6 +443,9 @@ const en: Messages = {
     empty: "Nothing matches",
     count: (count: number) => `${count}`,
     newNote: "New note",
+    scopeTag: (tag: string) => `Scoped to #${tag}`,
+    removeScope: "Remove the scope",
+    emptyScoped: (tag: string) => `Nothing in #${tag} matches`,
   },
   editor: {
     copyCode: "Copy the code",

--- a/tauri-app/src/lib/i18n.ts
+++ b/tauri-app/src/lib/i18n.ts
@@ -202,7 +202,8 @@ const ja = {
     newNote: "新規ノート",
     scopeTag: (tag: string) => `#${tag} で絞り込み`,
     removeScope: "絞り込みを外す",
-    emptyScoped: (tag: string) => `#${tag} の中に一致するものがありません`,
+    // 引数は「#a #b」の形に揃えた範囲の文字(scopeLabel)。タグが幾つでも一文で済む
+    emptyScoped: (scope: string) => `${scope} の中に一致するものがありません`,
   },
   editor: {
     copyCode: "コードをコピー",
@@ -445,7 +446,7 @@ const en: Messages = {
     newNote: "New note",
     scopeTag: (tag: string) => `Scoped to #${tag}`,
     removeScope: "Remove the scope",
-    emptyScoped: (tag: string) => `Nothing in #${tag} matches`,
+    emptyScoped: (scope: string) => `Nothing in ${scope} matches`,
   },
   editor: {
     copyCode: "Copy the code",

--- a/tauri-app/src/lib/search-scope.test.ts
+++ b/tauri-app/src/lib/search-scope.test.ts
@@ -1,29 +1,80 @@
 import { describe, it, expect } from "vitest";
-import { paletteScopeAt, searchRequest } from "./search-scope";
+import { paletteScopeAt, scopeLabel, searchRequest } from "./search-scope";
 import { ROUTES } from "./routes";
 
 describe("searchRequest", () => {
   it("does not search when nothing is typed and no tag is set", () => {
-    expect(searchRequest("   ", null)).toBeNull();
+    expect(searchRequest("   ", [])).toBeNull();
   });
 
   it("searches the typed text across everything without a tag", () => {
-    expect(searchRequest("retry", null)).toEqual({ query: "retry", tags: [] });
+    expect(searchRequest("retry", [])).toEqual({ query: "retry", tags: [] });
   });
 
   // タグで絞った状態は、何も打たなくても眺められる一覧になる
-  it("lists everything under the tag when only a tag is set", () => {
-    expect(searchRequest("", "sync")).toEqual({ query: "", tags: ["sync"] });
+  it("lists everything under the chip when only a chip is set", () => {
+    expect(searchRequest("", ["sync"])).toEqual({ query: "", tags: ["sync"] });
   });
 
-  it("narrows the typed text to the tag", () => {
-    expect(searchRequest("retry", "sync")).toEqual({ query: "retry", tags: ["sync"] });
+  it("narrows the typed text to the chip", () => {
+    expect(searchRequest("retry", ["sync"])).toEqual({ query: "retry", tags: ["sync"] });
+  });
+
+  // チップは AND。両方付いている記録だけが残る
+  it("requires every chip at once", () => {
+    expect(searchRequest("", ["sf6", "ベガ"])).toEqual({ query: "", tags: ["sf6", "ベガ"] });
+  });
+
+  describe("typed #tags", () => {
+    it("turns one typed tag into scope and leaves no text", () => {
+      expect(searchRequest("#sync", [])).toEqual({ query: "", tags: ["sync"] });
+    });
+
+    // 「#SF6 #ベガ #置き攻め」と打つだけで、三つ全部の付いた記録が並ぶ
+    it("turns several typed tags into an AND scope", () => {
+      expect(searchRequest("#SF6 #ベガ #置き攻め", [])).toEqual({
+        query: "",
+        tags: ["sf6", "ベガ", "置き攻め"],
+      });
+    });
+
+    // タグの文字は Timeline のチップと同じ規則で寄せる。大文字の SF6 も sf6 と同じタグ
+    it("normalises typed tags the way the timeline chips do", () => {
+      expect(searchRequest("#SF6", [])).toEqual({ query: "", tags: ["sf6"] });
+    });
+
+    it("keeps the remaining text as the query, without the tag tokens", () => {
+      expect(searchRequest("#sf6 コンボ", [])).toEqual({ query: "コンボ", tags: ["sf6"] });
+    });
+
+    it("collapses the gap a removed tag leaves in the middle of the text", () => {
+      expect(searchRequest("中 #sf6  段", [])).toEqual({ query: "中 段", tags: ["sf6"] });
+    });
+
+    it("adds typed tags after the chips", () => {
+      expect(searchRequest("#ベガ", ["sf6"])).toEqual({ query: "", tags: ["sf6", "ベガ"] });
+    });
+
+    it("does not repeat a tag that is both typed and chipped", () => {
+      expect(searchRequest("#sync #sync", ["sync"])).toEqual({ query: "", tags: ["sync"] });
+    });
+
+    // `C#` や URL の `#frag` はタグではない。本文の規則(tags.ts)をそのまま使う
+    it("leaves a hash that is not a tag in the text", () => {
+      expect(searchRequest("C# 入門", [])).toEqual({ query: "C# 入門", tags: [] });
+    });
+  });
+});
+
+describe("scopeLabel", () => {
+  it("joins the tags with their hashes", () => {
+    expect(scopeLabel(["sf6", "ベガ"])).toBe("#sf6 #ベガ");
   });
 });
 
 describe("paletteScopeAt", () => {
   it("carries the timeline's active tag into the palette", () => {
-    expect(paletteScopeAt(ROUTES.TIMELINE, "sync")).toEqual({ tag: "sync" });
+    expect(paletteScopeAt(ROUTES.TIMELINE, "sync")).toEqual({ tags: ["sync"] });
   });
 
   it("opens an unscoped palette when no tag is active", () => {

--- a/tauri-app/src/lib/search-scope.test.ts
+++ b/tauri-app/src/lib/search-scope.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { paletteScopeAt, searchRequest } from "./search-scope";
+import { ROUTES } from "./routes";
+
+describe("searchRequest", () => {
+  it("does not search when nothing is typed and no tag is set", () => {
+    expect(searchRequest("   ", null)).toBeNull();
+  });
+
+  it("searches the typed text across everything without a tag", () => {
+    expect(searchRequest("retry", null)).toEqual({ query: "retry", tags: [] });
+  });
+
+  // タグで絞った状態は、何も打たなくても眺められる一覧になる
+  it("lists everything under the tag when only a tag is set", () => {
+    expect(searchRequest("", "sync")).toEqual({ query: "", tags: ["sync"] });
+  });
+
+  it("narrows the typed text to the tag", () => {
+    expect(searchRequest("retry", "sync")).toEqual({ query: "retry", tags: ["sync"] });
+  });
+});
+
+describe("paletteScopeAt", () => {
+  it("carries the timeline's active tag into the palette", () => {
+    expect(paletteScopeAt(ROUTES.TIMELINE, "sync")).toEqual({ tag: "sync" });
+  });
+
+  it("opens an unscoped palette when no tag is active", () => {
+    expect(paletteScopeAt(ROUTES.TIMELINE, null)).toBeUndefined();
+  });
+
+  // Notes 画面には絞り込みチップが無い。見えていない範囲を黙って掛けない
+  it("ignores the timeline tag on other routes", () => {
+    expect(paletteScopeAt(ROUTES.NOTES, "sync")).toBeUndefined();
+  });
+});

--- a/tauri-app/src/lib/search-scope.ts
+++ b/tauri-app/src/lib/search-scope.ts
@@ -4,27 +4,47 @@
  * Timeline でタグを選んで絞った状態と ⌘K の検索は、もともと別々だった。
  * 絞ったまま探せるように、選んでいるタグをパレットに引き継いで
  * `search_all` の範囲として渡す。
+ *
+ * 範囲はタグの並びで、全部の付いた記録だけが残る(AND)。「#SF6 #ベガ #置き攻め」
+ * のように、ノートを何枚も横断して一つの話題を集めたいときの形。
  */
 
 import { ROUTES } from "./routes";
+import { normalizeTag, parseTags, splitTagged } from "./tags";
 
 export interface PaletteScope {
-  /** 絞り込んでいるタグ(`#` なし)。 */
-  tag: string;
+  /** 絞り込んでいるタグ(`#` なし)。全部の付いた記録だけが残る。 */
+  tags: string[];
 }
 
 /**
  * `search_all` に渡す引数。何も打たず範囲も無ければ `null` — 発行しない。
  * タグだけあるときは空のクエリで呼び、そのタグの付いた記録を全部もらう。
+ *
+ * 打った文字の中の `#タグ` も範囲に数える。チップにするには行を選ぶ手間が
+ * 要るが、打つだけなら手が止まらない。本文の `#タグ` と同じ規則(tags.ts)で
+ * 拾うので、Timeline のチップと同じ字に寄る。残った文字だけが本文の検索語。
  */
 export function searchRequest(
   query: string,
-  tag: string | null,
+  scope: string[],
 ): { query: string; tags: string[] } | null {
-  if (!query.trim() && !tag) {
+  const text = splitTagged(query)
+    .filter((segment) => !segment.tag)
+    .map((segment) => segment.text)
+    .join("")
+    .replaceAll(/\s+/g, " ")
+    .trim();
+  const tags = [...new Set([...scope.map((tag) => normalizeTag(tag)), ...parseTags(query)])];
+  if (!text && tags.length === 0) {
     return null;
   }
-  return { query, tags: tag ? [tag] : [] };
+  return { query: text, tags };
+}
+
+/** 範囲を一目で示す文字。「#sf6 #ベガ」の形で、見出しや空の案内に出す。 */
+export function scopeLabel(tags: string[]): string {
+  return tags.map((tag) => `#${tag}`).join(" ");
 }
 
 /**
@@ -38,7 +58,7 @@ export function paletteScopeAt(
   timelineTag: string | null,
 ): PaletteScope | undefined {
   if (pathname === ROUTES.TIMELINE && timelineTag) {
-    return { tag: timelineTag };
+    return { tags: [timelineTag] };
   }
   return undefined;
 }

--- a/tauri-app/src/lib/search-scope.ts
+++ b/tauri-app/src/lib/search-scope.ts
@@ -1,0 +1,44 @@
+/**
+ * パレット検索の範囲。
+ *
+ * Timeline でタグを選んで絞った状態と ⌘K の検索は、もともと別々だった。
+ * 絞ったまま探せるように、選んでいるタグをパレットに引き継いで
+ * `search_all` の範囲として渡す。
+ */
+
+import { ROUTES } from "./routes";
+
+export interface PaletteScope {
+  /** 絞り込んでいるタグ(`#` なし)。 */
+  tag: string;
+}
+
+/**
+ * `search_all` に渡す引数。何も打たず範囲も無ければ `null` — 発行しない。
+ * タグだけあるときは空のクエリで呼び、そのタグの付いた記録を全部もらう。
+ */
+export function searchRequest(
+  query: string,
+  tag: string | null,
+): { query: string; tags: string[] } | null {
+  if (!query.trim() && !tag) {
+    return null;
+  }
+  return { query, tags: tag ? [tag] : [] };
+}
+
+/**
+ * ⌘K を押した場所で、パレットに引き継ぐ範囲を決める。
+ *
+ * 引き継ぐのは Timeline にいるときだけ。他の画面ではチップが見えておらず、
+ * 見えていない絞り込みを黙って掛けると「無いはずがない」検索結果になる。
+ */
+export function paletteScopeAt(
+  pathname: string,
+  timelineTag: string | null,
+): PaletteScope | undefined {
+  if (pathname === ROUTES.TIMELINE && timelineTag) {
+    return { tag: timelineTag };
+  }
+  return undefined;
+}

--- a/tauri-app/src/lib/shell.tsx
+++ b/tauri-app/src/lib/shell.tsx
@@ -1,5 +1,6 @@
 import { createContext, createSignal, useContext, onCleanup } from "solid-js";
 import type { Accessor, JSX } from "solid-js";
+import type { PaletteScope } from "./search-scope";
 
 /** 同時に開けるポップオーバーは 1 つだけ。 */
 type PopoverName = "sync" | "theme" | "calendar" | "note-meta" | "new-note-menu" | null;
@@ -17,8 +18,16 @@ export interface Shell {
   togglePopover: (name: Exclude<PopoverName, null>) => void;
   closePopovers: () => void;
   paletteOpen: Accessor<boolean>;
-  openPalette: () => void;
+  /** 開いたときに引き継いだ範囲。無ければ全体を探す。 */
+  paletteScope: Accessor<PaletteScope | null>;
+  openPalette: (scope?: PaletteScope) => void;
   closePalette: () => void;
+  /**
+   * Timeline で絞り込んでいるタグ。Timeline の中だけで持つと ⌘K の
+   * 処理(AppLayout)から見えないので、ここに引き上げてある。
+   */
+  timelineTag: Accessor<string | null>;
+  setTimelineTag: (tag: string | null) => void;
   toast: Accessor<Toast | null>;
   showToast: (message: string, undo?: () => void) => void;
   dismissToast: () => void;
@@ -40,6 +49,8 @@ export function useShell(): Shell {
 export function ShellProvider(props: { children: JSX.Element }): JSX.Element {
   const [popover, setPopover] = createSignal<PopoverName>(null);
   const [paletteOpen, setPaletteOpen] = createSignal(false);
+  const [paletteScope, setPaletteScope] = createSignal<PaletteScope | null>(null);
+  const [timelineTag, setTimelineTag] = createSignal<string | null>(null);
   const [toast, setToast] = createSignal<Toast | null>(null);
   const [dataVersion, setDataVersion] = createSignal(0);
 
@@ -60,11 +71,15 @@ export function ShellProvider(props: { children: JSX.Element }): JSX.Element {
     },
     closePopovers: () => setPopover(null),
     paletteOpen,
-    openPalette: () => {
+    paletteScope,
+    openPalette: (scope) => {
       setPopover(null);
+      setPaletteScope(scope ?? null);
       setPaletteOpen(true);
     },
     closePalette: () => setPaletteOpen(false),
+    timelineTag,
+    setTimelineTag,
     toast,
     showToast: (message, undo) => {
       clearToastTimer();

--- a/tauri-app/src/styles/palette.css
+++ b/tauri-app/src/styles/palette.css
@@ -31,6 +31,15 @@
   color: var(--app-text-faint);
 }
 
+/* 引き継いだタグの範囲。入力欄の前に付き、外すまで検索はこの中だけ。
+   見た目は Timeline の選択中チップと同じ(tags.css)で、入力欄の高さに収める */
+.palette-input-row .palette-scope {
+  padding: 3px 9px;
+  gap: 4px;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
 .palette-input {
   flex: 1;
   border: none;

--- a/tauri-app/src/views/Timeline.tsx
+++ b/tauri-app/src/views/Timeline.tsx
@@ -97,8 +97,9 @@ export default function Timeline(): JSX.Element {
   const [extraDates, setExtraDates] = createSignal<string[]>([]);
   /** カレンダーで選ばれた、これから見せたい日。表示できたら消す。 */
   const [jumpTo, setJumpTo] = createSignal<string | null>(null);
-  /** 絞り込み中のタグ。1 つだけ選べる。 */
-  const [tagFilter, setTagFilter] = createSignal<string | null>(null);
+  /** 絞り込み中のタグ。1 つだけ選べる。⌘K に引き継ぐので shell が持つ。 */
+  const tagFilter = shell.timelineTag;
+  const setTagFilter = shell.setTimelineTag;
   /** 選択モード。入っている間だけ本文がクリックで選択できる。 */
   const [selecting, setSelecting] = createSignal(false);
   const [selected, setSelected] = createSignal<ReadonlySet<string>>(new Set());


### PR DESCRIPTION
## なぜやるか

Timeline でタグを選んで絞り込んでも、⌘K の検索は絞り込みを知らず全体を探していた。
タグ絞り込みはクライアント側、検索は Rust の `search_all` と、経路が完全に別だったため。
あわせて `#SF6 #ベガ #置き攻め` のように複数タグで、Notes からも一つの話題を集められるようにする。

## やったこと

絞り込み中のタグがパレットまで届き、パレットで打った `#タグ` と合わせて検索の範囲(AND)になる(緑が新しい経路)。

```mermaid
flowchart LR
  tl["Timeline のタグ絞り込み"] --> shell["shell(絞り込み中のタグ)"]
  shell --> pal["⌘K パレット(チップ + 打った #タグ)"]
  pal -- "query + tags(AND)" --> core["core: search_all"]
  mcp["MCP: search"] -- "tags(任意)" --> core

  classDef added stroke:#3fb950,stroke-width:3px
  class shell added
  linkStyle 0,1,2,3 stroke:#3fb950,stroke-width:3px
```

- どの画面からでも、パレットに `#SF6 #ベガ #置き攻め` と打てば全部のタグを持つノートと記録が並び、続けて打った文字はその中の検索語になる
  - Timeline で絞り込み中に開くと、そのタグがチップとして最初から付く。パレットのホームでタグを選んでもチップが足される
  - チップは ✕ か空欄で Backspace(最後の一つ)で外せる。打った `#タグ` はチップにせず、文字を消せば外れる
- `search_all` がタグの範囲を受ける(複数なら AND、`#` の有無と大小は無視、空クエリならタグの付いた記録を全部)。MCP の `search` ツールも同じ引数を任意で受ける
- ついでに直した: タイムラインのヒットが `tags` を常に空で返していた

## やらなかったこと

- Notes 画面から開いたときは Timeline の絞り込みを引き継がない。チップが見えていない画面で黙って絞ると「無いはずがない」結果になる
- 絞り込み中のタグを shell に引き上げたので、Timeline ↔ Notes を行き来しても絞り込みが残るようになった(以前は Timeline を離れるとリセット)。意図と違えば戻す
