### PR TITLE
fix(tauri-app): keep the note body in place when editing starts

### DIFF
--- a/tauri-app/src/components/MilkdownEditor.tsx
+++ b/tauri-app/src/components/MilkdownEditor.tsx
@@ -41,6 +41,22 @@ interface MilkdownEditorProps {
   noteLinks?: () => NoteLinkTarget[];
 }
 
+/**
+ * 実際にスクロールしている要素。エディタは中身に合わせて伸びるだけで、
+ * スクロールはプレビューと同じ親(Workspace の .detail-body)が担う。
+ * クラス名で結ばずに overflow を見るのは、この部品を置く側の構造に
+ * 依存させないため。
+ */
+function closestScroller(el: HTMLElement): HTMLElement | undefined {
+  for (let node: HTMLElement | null = el; node; node = node.parentElement) {
+    const { overflowY } = getComputedStyle(node);
+    if (overflowY === "auto" || overflowY === "scroll") {
+      return node;
+    }
+  }
+  return undefined;
+}
+
 export default function MilkdownEditor(props: MilkdownEditorProps): JSX.Element {
   let ref: HTMLDivElement | undefined;
   let editor: Editor | undefined;
@@ -54,10 +70,10 @@ export default function MilkdownEditor(props: MilkdownEditorProps): JSX.Element 
     if (!caret) {
       return;
     }
-    // 入力はすぐ受け付ける(モバイルはここでキーボードが開き始める)。
-    // 編集モードでスクロールするのはプレビューの親ではなく .milkdown-editor
+    // 入力はすぐ受け付ける(モバイルはここでキーボードが開き始める)
     created.action((ctx) => ctx.get(editorViewCtx).focus());
-    const scroller = ref;
+    // scrollTop はプレビューを押した瞬間に同じスクロール要素で測ったもの
+    const scroller = ref ? closestScroller(ref) : undefined;
 
     // コードの装飾や図は create の後から伸びてくる。高さが足りないうちに
     // scrollTop を戻すとクランプされ、同じ座標が別の行を指してしまう。
@@ -86,7 +102,8 @@ export default function MilkdownEditor(props: MilkdownEditorProps): JSX.Element 
       created.action((ctx) => {
         const view = ctx.get(editorViewCtx);
         const found = view.posAtCoords({ left: caret.x, top: caret.y });
-        // プレビューとエディタで行の高さは微妙に違う。外したら末尾に倒す
+        // 幾何はプレビューと揃えてある(workspace.test.ts)が、図の描き直しなどで
+        // 外れることはある。そのときは末尾に倒す
         const selection = found
           ? TextSelection.near(view.state.doc.resolve(found.pos))
           : Selection.atEnd(view.state.doc);

--- a/tauri-app/src/styles/editor.css
+++ b/tauri-app/src/styles/editor.css
@@ -1,7 +1,12 @@
+/* エディタ自身はスクロールしない。プレビューと同じく .detail-body に
+   任せる — 自分でスクロールすると .detail-body の余白が固定の額縁になり、
+   押した瞬間のスクロール量を別の要素へ写し替えることになる。
+   短い本文でも余白を押して書き始められるよう、欄いっぱいには伸ばす */
 .milkdown-editor {
+  display: flex;
+  flex-direction: column;
   width: 100%;
-  height: 100%;
-  overflow-y: auto;
+  min-height: 100%;
   cursor: text;
   border: none;
   outline: none;
@@ -19,14 +24,12 @@
   font-family: var(--font-sans);
   line-height: var(--font-lineheight-4);
   color: var(--app-text);
-  min-height: 100%;
   cursor: text;
 }
 
 .milkdown-editor .milkdown {
   display: flex;
   flex-direction: column;
-  height: 100%;
 }
 
 /* ブロックは .milkdown ではなく .ProseMirror の直下に並ぶ。間隔は

--- a/tauri-app/src/styles/editor.css
+++ b/tauri-app/src/styles/editor.css
@@ -7,15 +7,16 @@
   outline: none;
 }
 
+/* 余白と文字サイズはプレビュー(.markdown-preview)と同じく .detail-body から
+   受け取る。ここで独自に持つと、プレビューを押して編集に入った瞬間に
+   本文がずれて見える(workspace.test.ts が両者の幾何を突き合わせている) */
 .milkdown-editor .milkdown,
 .milkdown-editor .ProseMirror {
   outline: none !important;
   border: none !important;
   box-shadow: none !important;
   flex: 1;
-  padding: var(--size-4) var(--size-5);
   font-family: var(--font-sans);
-  font-size: var(--font-size-2);
   line-height: var(--font-lineheight-4);
   color: var(--app-text);
   min-height: 100%;
@@ -26,29 +27,28 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding: 0;
 }
 
-.milkdown-editor .milkdown > * + * {
+/* ブロックは .milkdown ではなく .ProseMirror の直下に並ぶ。間隔は
+   markdown-preview.css の `.markdown-preview > * + *` と同じ値 */
+.milkdown-editor .ProseMirror > * + * {
   margin-top: var(--size-3);
 }
 
+/* 見出しの行の高さは normalize のまま(プレビューも同じ) */
 .milkdown-editor h1 {
   font-size: var(--font-size-5);
   font-weight: var(--font-weight-7);
-  line-height: var(--font-lineheight-1);
 }
 
 .milkdown-editor h2 {
   font-size: var(--font-size-4);
   font-weight: var(--font-weight-6);
-  line-height: var(--font-lineheight-2);
 }
 
 .milkdown-editor h3 {
   font-size: var(--font-size-3);
   font-weight: var(--font-weight-6);
-  line-height: var(--font-lineheight-2);
 }
 
 .milkdown-editor strong {
@@ -206,7 +206,6 @@
   border-left: 3px solid var(--app-border);
   padding-left: var(--size-3);
   color: var(--app-text-muted);
-  font-style: italic;
 }
 
 .milkdown-editor ul,

--- a/tauri-app/src/styles/markdown-preview.css
+++ b/tauri-app/src/styles/markdown-preview.css
@@ -126,17 +126,21 @@
 
 /* Shiki dual theme: data-theme に応じて CSS 変数で配色を切り替える。
    下地は Shiki のテーマ色ではなく .markdown-preview pre の --app-surface-2 に
-   任せる。インラインコードや mermaid の図と同じ下地に揃える (#75) */
+   任せる。インラインコードや mermaid の図と同じ下地に揃える (#75)。
+   transparent は span にだけ当てる — pre.shiki 自身にも当てると詳細度で
+   .markdown-preview pre に勝ち、下地が消えて編集に入った瞬間に箱が現れる */
 .markdown-preview .shiki,
 .markdown-preview .shiki span {
   color: var(--shiki-light);
+}
+
+.markdown-preview .shiki span {
   background-color: transparent;
 }
 
 [data-theme="dark"] .markdown-preview .shiki,
 [data-theme="dark"] .markdown-preview .shiki span {
   color: var(--shiki-dark);
-  background-color: transparent;
 }
 
 /* ---- ノート間リンク。タイトルで描かれ、押すとそのノートが開く ---- */

--- a/tauri-app/src/styles/markdown-preview.css
+++ b/tauri-app/src/styles/markdown-preview.css
@@ -33,11 +33,12 @@
 
 .markdown-preview pre {
   /* normalize の max-content フィットを解除して本文幅に(editor.css と同じ理由)。
-     padding はタイムラインのカードが窮屈にならないよう既存のまま */
+     padding も editor.css の pre と同じ。違うと編集に入るときにコードブロックの
+     高さが変わり、その下の本文がずれる */
   max-inline-size: none;
   width: 100%;
   background: var(--app-surface-2);
-  padding: var(--size-3);
+  padding: var(--size-5);
   border-radius: var(--radius-2);
   overflow-x: auto;
 }
@@ -45,6 +46,10 @@
 .markdown-preview pre code {
   background: none;
   padding: 0;
+  /* editor.css と同じくブロックにする。インラインのままだと pre 自身の
+     行の高さ(strut)が乗り、コードブロックがエディタより数 px 高くなる */
+  display: block;
+  min-height: 1em;
 }
 
 .markdown-preview blockquote {
@@ -70,11 +75,11 @@
 }
 
 /* Mermaid: 図は本文のように折り返せないので、幅に合わせて縮めて置く。
-   mermaid が SVG に付ける max-width が原寸なので、拡大はされない */
+   mermaid が SVG に付ける max-width が原寸なので、拡大はされない。
+   上下の間隔は他のブロックと同じ(エディタで図だけを見せる状態と揃える) */
 .markdown-preview .mermaid-block {
   display: flex;
   justify-content: center;
-  margin-block: var(--size-4);
   cursor: zoom-in;
 }
 

--- a/tauri-app/src/styles/workspace.test.ts
+++ b/tauri-app/src/styles/workspace.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { page } from "vitest/browser";
+
+/**
+ * プレビューを押すと、その場でエディタに入れ替わる。文字の位置や大きさが
+ * 少しでも違うと本文が目に見えてズレ、「押した座標の文字にカーソルを置く」
+ * 前提も崩れる。同じ本文を両方の DOM で組み、ブロックごとの幾何を突き合わせる。
+ */
+
+const BLOCKS = `
+  <p>一段目の本文。</p>
+  <h2>見出し</h2>
+  <p>二段目の本文。</p>
+  <pre><code>const a = 1;</code></pre>
+  <blockquote><p>引用</p></blockquote>
+  <p>結び。</p>`;
+
+const BLOCK_SELECTORS = [
+  ":scope > p:nth-of-type(1)",
+  ":scope > h2",
+  ":scope > p:nth-of-type(2)",
+  ":scope > pre",
+  ":scope > blockquote",
+  ":scope > p:nth-of-type(3)",
+];
+
+const SVG = '<svg viewBox="0 0 200 100" width="200" height="100"></svg>';
+
+function preview(blocks: string): string {
+  return `<div class="markdown-preview">${blocks}</div>`;
+}
+
+function editor(blocks: string): string {
+  return `
+    <div class="milkdown-editor">
+      <div class="milkdown">
+        <div class="ProseMirror editor" contenteditable="true">${blocks}</div>
+      </div>
+    </div>`;
+}
+
+function element(selector: string, root: ParentNode = document): HTMLElement {
+  const found = root.querySelector<HTMLElement>(selector);
+  if (!found) {
+    throw new Error(`expected ${selector} to be mounted`);
+  }
+  return found;
+}
+
+function mountDetail(body: string): HTMLElement {
+  document.body.innerHTML = `
+    <div class="app">
+      <header class="header">header</header>
+      <main class="app-main">
+        <div class="workspace workspace--detail">
+          <div class="detail-pane">
+            <input class="note-title-input" value="タイトル" />
+            <div class="detail-body">${body}</div>
+          </div>
+        </div>
+      </main>
+    </div>`;
+  return element(".detail-body");
+}
+
+/** ブロックの入れ物。プレビューは .markdown-preview、エディタは .ProseMirror */
+function blockRoot(body: HTMLElement): HTMLElement {
+  return body.querySelector<HTMLElement>(".ProseMirror") ?? element(".markdown-preview", body);
+}
+
+interface Geometry {
+  left: number;
+  width: number;
+  top: number;
+  fontSize: string;
+  lineHeight: string;
+  fontStyle: string;
+}
+
+/** サブピクセルの揺れは丸めて捨てる */
+function round(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/** 位置は本文欄の左上からの相対 */
+function geometry(target: HTMLElement, body: HTMLElement): Geometry {
+  const rect = target.getBoundingClientRect();
+  const origin = body.getBoundingClientRect();
+  const style = getComputedStyle(target);
+  return {
+    left: round(rect.left - origin.left),
+    width: round(rect.width),
+    top: round(rect.top - origin.top),
+    fontSize: style.fontSize,
+    lineHeight: style.lineHeight,
+    fontStyle: style.fontStyle,
+  };
+}
+
+function measureBlocks(body: string): Record<string, Geometry> {
+  const detail = mountDetail(body);
+  const root = blockRoot(detail);
+  return Object.fromEntries(
+    BLOCK_SELECTORS.map((selector) => [selector, geometry(element(selector, root), detail)]),
+  );
+}
+
+describe("note body: preview and editor draw the same page", () => {
+  beforeAll(async () => {
+    await import("../index.css");
+    // これらは index.css に無い(遅延ビューと一緒に読まれる)ので明示する
+    await import("./workspace.css");
+    await import("./editor.css");
+    await import("./markdown-preview.css");
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // 本文欄の余白はモバイル(767px 以下)で変わる。両方の幅で見る
+  it.each([
+    ["mobile", 414, 896],
+    ["desktop", 1280, 800],
+  ])("keeps every block where the preview drew it (%s)", async (_name, width, height) => {
+    await page.viewport(width, height);
+    const previewed = measureBlocks(preview(BLOCKS));
+    const edited = measureBlocks(editor(BLOCKS));
+
+    expect(edited).toEqual(previewed);
+  });
+
+  // mermaid はカーソルが離れている間、エディタでもソースを隠して図だけを見せる。
+  // その状態の図と、その次のブロックがプレビューと同じ高さに来ること
+  it("hangs a mermaid figure at the same height in both", () => {
+    const before = "<p>前</p>";
+    const after = "<p>後</p>";
+    const previewBody = mountDetail(
+      preview(`${before}<div class="mermaid-block">${SVG}</div>${after}`),
+    );
+    const previewSvg = geometry(element("svg", previewBody), previewBody);
+    const previewAfter = geometry(
+      element(":scope > p:nth-of-type(2)", blockRoot(previewBody)),
+      previewBody,
+    );
+
+    const editorBody = mountDetail(
+      editor(
+        `${before}<div class="code-block-view has-diagram"><pre><code>graph TD</code></pre>` +
+          `<div class="mermaid-editor-preview">${SVG}</div></div>${after}`,
+      ),
+    );
+    const editorSvg = geometry(element("svg", editorBody), editorBody);
+    const editorAfter = geometry(
+      element(":scope > p:nth-of-type(2)", blockRoot(editorBody)),
+      editorBody,
+    );
+
+    expect(editorSvg).toEqual(previewSvg);
+    expect(editorAfter).toEqual(previewAfter);
+  });
+});

--- a/tauri-app/src/styles/workspace.test.ts
+++ b/tauri-app/src/styles/workspace.test.ts
@@ -7,13 +7,16 @@ import { page } from "vitest/browser";
  * 前提も崩れる。同じ本文を両方の DOM で組み、ブロックごとの幾何を突き合わせる。
  */
 
-const BLOCKS = `
+/** プレビューのコードブロックは Shiki が `pre.shiki` として出す */
+function bodyBlocks(preClass: string): string {
+  return `
   <p>一段目の本文。</p>
   <h2>見出し</h2>
   <p>二段目の本文。</p>
-  <pre><code>const a = 1;</code></pre>
+  <pre class="${preClass}"><code>const a = 1;</code></pre>
   <blockquote><p>引用</p></blockquote>
   <p>結び。</p>`;
+}
 
 const BLOCK_SELECTORS = [
   ":scope > p:nth-of-type(1)",
@@ -75,6 +78,7 @@ interface Geometry {
   fontSize: string;
   lineHeight: string;
   fontStyle: string;
+  backgroundColor: string;
 }
 
 /** サブピクセルの揺れは丸めて捨てる */
@@ -94,6 +98,7 @@ function geometry(target: HTMLElement, body: HTMLElement): Geometry {
     fontSize: style.fontSize,
     lineHeight: style.lineHeight,
     fontStyle: style.fontStyle,
+    backgroundColor: style.backgroundColor,
   };
 }
 
@@ -124,8 +129,8 @@ describe("note body: preview and editor draw the same page", () => {
     ["desktop", 1280, 800],
   ])("keeps every block where the preview drew it (%s)", async (_name, width, height) => {
     await page.viewport(width, height);
-    const previewed = measureBlocks(preview(BLOCKS));
-    const edited = measureBlocks(editor(BLOCKS));
+    const previewed = measureBlocks(preview(bodyBlocks("shiki")));
+    const edited = measureBlocks(editor(bodyBlocks("")));
 
     expect(edited).toEqual(previewed);
   });

--- a/tauri-app/src/styles/workspace.test.ts
+++ b/tauri-app/src/styles/workspace.test.ts
@@ -159,4 +159,30 @@ describe("note body: preview and editor draw the same page", () => {
     expect(editorSvg).toEqual(previewSvg);
     expect(editorAfter).toEqual(previewAfter);
   });
+
+  // スクロールするのは両モードとも .detail-body。エディタが自分で
+  // スクロールすると .detail-body の余白が固定の額縁になり、押した瞬間の
+  // scrollTop を別の要素に写し替える必要が生まれる
+  it("scrolls the body itself while editing, not the editor", () => {
+    const paragraphs = Array.from({ length: 80 }, (_, i) => `<p>段落 ${i}</p>`).join("");
+    const body = mountDetail(editor(paragraphs));
+    const milkdown = element(".milkdown-editor", body);
+
+    expect(body.scrollHeight).toBeGreaterThan(body.clientHeight);
+    expect(milkdown.scrollHeight).toBeLessThanOrEqual(milkdown.clientHeight + 0.5);
+  });
+
+  // 短い本文でも、余白を押せば書き始められるようエディタは欄いっぱいに伸びる
+  it("stretches a short editor to the bottom of the body", () => {
+    const body = mountDetail(editor("<p>一行だけ</p>"));
+    const style = getComputedStyle(body);
+    const inner =
+      body.clientHeight -
+      Number.parseFloat(style.paddingTop) -
+      Number.parseFloat(style.paddingBottom);
+
+    expect(element(".ProseMirror", body).getBoundingClientRect().height).toBeGreaterThanOrEqual(
+      inner - 0.5,
+    );
+  });
 });


### PR DESCRIPTION
## なぜやるか

プレビュー中のノートを押して編集に入ると、本文が右下にずれ、段落の間隔やコードブロックの大きさも変わって見えた。
エディタが独自の余白・文字サイズ・見出しの行高を持ち、さらに自分でスクロールしていたため、プレビューと幾何が一致していなかった。

## やったこと

- エディタ側の独自の余白・文字サイズ・見出し行高・引用の斜体を外し、プレビューと同じく `.detail-body` から受け取るようにした
  - 段落間隔のセレクタはブロックが実際に並ぶ階層(`.ProseMirror` 直下)に向け直した
  - プレビュー側は `pre` の余白とインラインコードのブロック化をエディタに揃えた
- エディタは自分でスクロールせず、プレビューと同じ `.detail-body` が唯一のスクロール要素になった。押した瞬間のスクロール量はその要素に戻す
- ついでに直した: プレビューのコードブロックに Shiki の透明背景が勝って箱が消え、編集に入った瞬間に箱が現れていた
- 両モードの DOM を実 Chromium で並べ、段落・見出し・`pre` の位置・幅・文字サイズ・間隔が一致することを見るレイアウトテストを足した

## やらなかったこと

- Mermaid の図の下のブロックを押すとカーソルが 1 ブロックずれる件は、main でも同じで今回は触っていない。図が描かれる前の `pre` に対して座標を解決しているのが原因
