### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "magical-merchant-app"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64 0.23.1",
  "battery",
@@ -2708,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "magical-merchant-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "magical-merchant-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "criterion",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magical-merchant-cli"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "MCP server exposing Magical Merchant notes to AI agents"
 license.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magical-merchant-core"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Framework-independent core logic for the Magical Merchant note-taking app"
 license.workspace = true

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -17,7 +17,8 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "magical-merchant";
-  version = "0.2.0";
+  # tauri.conf.json が唯一の出どころ。release.yml もそこと tag を突き合わせる
+  version = (lib.importJSON ../tauri-app/src-tauri/tauri.conf.json).version;
 
   src = lib.fileset.toSource {
     root = ../.;

--- a/tauri-app/package.json
+++ b/tauri-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magical-merchant",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "magical-merchant-app"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Tauri desktop and mobile shell for the Magical Merchant note-taking app"
 license.workspace = true

--- a/tauri-app/src-tauri/tauri.conf.json
+++ b/tauri-app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegram/nicegram-app-schemas/refs/heads/main/tauri/tauri.conf.json",
   "productName": "Magical Merchant",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "identifier": "com.magical-merchant.app",
   "build": {
     "frontendDist": "../dist",

--- a/workers/package.json
+++ b/workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magical-merchant-sync",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## なぜやるか

v0.3.0 から 124 コミット。テンプレ・glyph・MCP の書き込み・CLI と機能が乗ったので、区切りとして 0.4.0 を打つ。
release.yml は tag と `tauri.conf.json` の不一致を拒むので、tag の前に全マニフェストを揃えておく。

## やったこと

- 7 つのマニフェスト (Cargo.toml ×3、package.json ×2、tauri.conf.json、Cargo.lock) を 0.4.0 に
- `nix/package.nix` の version を `tauri.conf.json` から読む形にした
  - 0.3.0 のとき上げ忘れて `0.2.0` のまま配られていた。書く場所を 1 つにして再発を断つ

## やらなかったこと

- 1.0.0 にはしない。conflict の控えの置き場 (#172) でディスク配置がまだ動くので、互換を宣言するには早い

## 資料

- マージ後に main で `git tag v0.4.0 && git push origin v0.4.0`。release.yml が APK を Releases に付ける
