### PR TITLE
build(just): cut the recipe list from 37 to 21

### DIFF
--- a/.claude/skills/sync-storage/SKILL.md
+++ b/.claude/skills/sync-storage/SKILL.md
@@ -71,4 +71,4 @@ local scan → diff → one `POST /sync/bulk`.
   links; handled in AppLayout (`onOpenUrl` + `getCurrent` for cold start);
   note rows navigate with `?file=<filename>`
 - Widget sources live in `tauri-app/android-widget/`, injected by
-  `just android-widget-setup`
+  `just android-setup`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
             cargo-android-${{ runner.os }}-
       - name: Generate the Android project
         run: nix develop .#android --command just tauri_app::android-init
-      # android-widget-setup を含む。ウィジェットのソースを入れた状態で組む
+      # android-setup を含む。ウィジェットのソースを入れた状態で組む
       - name: The debug APK builds
         run: nix develop .#android --command just tauri_app::android-build-debug
       - uses: actions/cache/save@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,6 @@ jobs:
       - name: Generate the Android project
         run: nix develop .#android --command just tauri_app::android-init
 
-      - name: Install the home screen widget sources
-        run: nix develop .#android --command just tauri_app::android-widget-setup
-
       - name: Restore the signing keystore
         env:
           KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
@@ -77,11 +74,11 @@ jobs:
           keyPassword=$KEY_PASSWORD
           EOF
 
-      - name: Inject the signing config
-        run: nix develop .#android --command just tauri_app::android-sign-setup
-
+      # ウィジェットの注入と署名設定は android-build-release の依存で走る。
+      # keystore.properties を書いた後でないと android-sign-setup が落ちるので、
+      # このステップは keystore の復元より後に置くこと
       - name: Build the signed APK
-        run: nix develop .#android --command just tauri_app::android-release-build
+        run: nix develop .#android --command just tauri_app::android-build-release
 
       - name: Collect the APK
         id: apk

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,37 +66,25 @@ fetch what they need:
 
 ### Root recipes
 
-| Command              | Description                         | CI  |
-| -------------------- | ----------------------------------- | --- |
-| `just fmt`           | Format all files (`nix fmt`)        | ✓   |
-| `just check`         | Lint + type check (Rust + frontend) | ✓   |
-| `just test`          | Run all tests (Rust + frontend)     | ✓   |
-| `just verify`        | `fmt` → `check` → `test`            |     |
-| `just dev`           | Start Tauri development server      |     |
-| `just android-init`  | Initialize Android target           |     |
-| `just android-dev`   | Development on Android device       |     |
-| `just android-build` | Build Android APK                   |     |
-| `just build`         | Build macOS .app (Apple Silicon)    |     |
+| Command       | Description                         | CI  |
+| ------------- | ----------------------------------- | --- |
+| `just fmt`    | Format all files (`nix fmt`)        | ✓   |
+| `just check`  | Lint + type check (Rust + frontend) | ✓   |
+| `just test`   | Run all tests (Rust + frontend)     | ✓   |
+| `just verify` | `fmt` → `check` → `test`            |     |
+| `just dev`    | Start Tauri development server      |     |
 
-### Android release recipes (`tauri_app::`)
-
-| Command                                   | Description                               |
-| ----------------------------------------- | ----------------------------------------- |
-| `just tauri_app::android-sign-setup`      | Re-inject the signing config into Gradle  |
-| `just tauri_app::android-widget-setup`    | Re-install the home screen widget sources |
-| `just tauri_app::android-build-release`   | Build a signed release APK                |
-| `just tauri_app::android-install-release` | Build and install it over USB             |
+Everything else is reached through its module — `just tauri_app::…`,
+`just rust::…`, `just workers::…`. Run `just --list <module>` to see them.
 
 ### Rust recipes (`rust::`)
 
-| Command                | Description                          | CI  |
-| ---------------------- | ------------------------------------ | --- |
-| `just rust::check`     | `cargo clippy` for all Rust crates   | ✓   |
-| `just rust::test`      | `cargo test` for all Rust crates     | ✓   |
-| `just rust::check-app` | `cargo clippy` for core + app crates |     |
-| `just rust::test-app`  | `cargo test` for core + app crates   |     |
-| `just rust::check-cli` | `cargo clippy` for cli crate         |     |
-| `just rust::test-cli`  | `cargo test` for cli crate           |     |
+| Command            | Description                        | CI  |
+| ------------------ | ---------------------------------- | --- |
+| `just rust::check` | `cargo clippy` for all Rust crates | ✓   |
+| `just rust::test`  | `cargo test` for all Rust crates   | ✓   |
+
+Scope a single crate with cargo directly (`cargo test -p magical-merchant-cli`).
 
 ### Frontend recipes (`tauri_app::`)
 
@@ -106,6 +94,25 @@ fetch what they need:
 | `just tauri_app::test`        | Vitest (unit + browser tests)      | ✓   |
 | `just tauri_app::dev`         | Start Tauri development server     |     |
 | `just tauri_app::dev-browser` | Vite + IPC mock in a plain browser |     |
+| `just tauri_app::build`       | Build macOS .app (Apple Silicon)   |     |
+| `just tauri_app::icons`       | Regenerate icons from the SVG      |     |
+
+### Android recipes (`tauri_app::`)
+
+| Command                                     | Description                                         | CI  |
+| ------------------------------------------- | --------------------------------------------------- | --- |
+| `just tauri_app::android-init`              | Generate `gen/android` (runs `icons` + the patches) |     |
+| `just tauri_app::android-setup`             | Re-apply the TLS + widget patches to `gen/android`  |     |
+| `just tauri_app::android-sign-setup`        | Re-inject the signing config into Gradle            |     |
+| `just tauri_app::android-dev`               | Development on a connected device                   |     |
+| `just tauri_app::android-build-debug`       | Build the debug APK                                 | ✓   |
+| `just tauri_app::android-build-release`     | Build a signed release APK                          |     |
+| `just tauri_app::android-install [variant]` | Build and install over USB (`debug` / `release`)    |     |
+
+`android-setup` runs on its own from `android-init` and from both build
+recipes; `android-sign-setup` needs `keystore.properties` and so hangs off
+`android-build-release` only. Call either by hand after regenerating
+`gen/android` some other way.
 
 > [!NOTE]
 > **CI column**: ✓ = recipes executed by GitHub Actions (`ci.yml`). CI uses

--- a/docs/install.md
+++ b/docs/install.md
@@ -71,7 +71,7 @@ and the CLI needs no configuration of its own.
 
 ```sh
 # Build the .app bundle
-just build
+just tauri_app::build
 
 # Copy to Applications
 cp -r "target/release/bundle/macos/Magical Merchant.app" /Applications/
@@ -112,4 +112,4 @@ call into `magical_merchant_core` — the app is never started. The "new note"
 bar (4×1) and the recent notes list (4×2) open the app on
 `magical-merchant://widget/…` deep links. Sources live in
 [`tauri-app/android-widget/`](../tauri-app/android-widget/README.md) and are
-injected into the generated Gradle project by `just android-widget-setup`.
+injected into the generated Gradle project by `just android-setup`.

--- a/justfile
+++ b/justfile
@@ -15,20 +15,5 @@ test: rust::test tauri_app::test workers::test
 
 verify: fmt check test
 
-# --- Dev shortcuts ---
-
+# 毎日叩くのはこれだけなので root に置く。他は `just tauri_app::…` を直接呼ぶ
 dev: tauri_app::dev
-
-icons: tauri_app::icons
-
-android-init: tauri_app::android-init
-
-android-dev: tauri_app::android-dev
-
-android-build: tauri_app::android-build
-
-android-build-debug: tauri_app::android-build-debug
-
-android-install: tauri_app::android-install
-
-build: tauri_app::build

--- a/rust/justfile
+++ b/rust/justfile
@@ -9,17 +9,3 @@ check:
 
 test:
   cargo test --workspace
-
-# --- Per-crate recipes ---
-
-check-app:
-  cargo clippy -p magical-merchant-core -p magical-merchant-app --all-targets -- -D warnings
-
-test-app:
-  cargo test -p magical-merchant-core -p magical-merchant-app
-
-check-cli:
-  cargo clippy -p magical-merchant-cli --all-targets -- -D warnings
-
-test-cli:
-  cargo test -p magical-merchant-cli

--- a/tauri-app/android-signing/README.md
+++ b/tauri-app/android-signing/README.md
@@ -53,7 +53,7 @@ From the `tauri-app/` directory:
 just android-build-release
 
 # …or build and install onto a USB-connected device in one step
-just android-install-release
+just android-install release
 ```
 
 The signed APK is written to:
@@ -70,7 +70,7 @@ transfer, email to yourself, etc.), then open it on the device and allow
 
 Bump `versionCode` (and `versionName`) in
 `src-tauri/gen/android/app/tauri.properties`, rebuild, and install over the
-existing app with `adb install -r …` (what `android-install-release` does). The
+existing app with `adb install -r …` (what `android-install release` does). The
 same signing key lets it install as an update rather than a conflicting app.
 
 ## Verifying the signature (optional)

--- a/tauri-app/android-tls/README.md
+++ b/tauri-app/android-tls/README.md
@@ -21,9 +21,10 @@ certificate error that says nothing about the real cause.
 
 `src-tauri/gen/android/` is gitignored and recreated by `tauri android init`,
 so the Gradle edit cannot simply live there. `apply-tls.go` re-applies it and
-runs as the last step of `just android-init`. Like `../android-signing/` and
-`../android-widget/`, every inserted region is wrapped in marker comments and
-stripped before re-insertion, so any number of runs yields the same file.
+runs as part of `just android-setup`, which `android-init` and the build
+recipes depend on. Like `../android-signing/` and `../android-widget/`, every
+inserted region is wrapped in marker comments and stripped before
+re-insertion, so any number of runs yields the same file.
 
 Two regions go into `build.gradle.kts` and one into `proguard-rules.pro`:
 

--- a/tauri-app/android-widget/README.md
+++ b/tauri-app/android-widget/README.md
@@ -131,11 +131,11 @@ the keyboard-top markdown toolbar falls back to jittery JS positioning). After
 a Tauri upgrade, diff the regenerated stub against ours before re-applying.
 
 ```sh
-just android-widget-setup
+just android-setup
 ```
 
 `android-build-debug` and `android-build-release` depend on it, so
-`just android-install` / `just android-install-release` pick the widgets up on
+`just android-install` / `just android-install release` pick the widgets up on
 their own. `just android-dev` does **not** — run the recipe once by hand before
 `android-dev` if you want the widgets in a dev build.
 

--- a/tauri-app/justfile
+++ b/tauri-app/justfile
@@ -6,9 +6,6 @@ default:
 setup:
   pnpm install
 
-assets: setup
-  pnpm run build
-
 check: setup
   oxlint src/
   tsgo -b --noEmit
@@ -33,59 +30,49 @@ icons: setup
   pnpm tauri icon src-tauri/icons/icons.json
   cp src-tauri/icons/icon.svg public/icon.svg
 
+# --- Android ---
+
 # gen/android は Tauri 既定のランチャーアイコンを持って生成される。
 # 入れ直さないと配信 APK が Tauri のロゴのままになるので、init と一続きにする。
-# TLS 設定も同様: gen/android を作り直した時点でしか要らないので、ここに置く。
 android-init: setup
   pnpm tauri android init
   just icons
-  just android-tls-setup
+  just android-setup
 
-# Point the app module at the Kotlin half of rustls-platform-verifier, which
-# reqwest needs to reach Android's trust store (idempotent; re-run after
-# `tauri android init` regenerates gen/android). See android-tls/README.md.
-android-tls-setup:
+# gen/android を作り直すたびに当て直す生成物パッチ (どちらも冪等):
+#   - rustls-platform-verifier の Kotlin 側を app モジュールに繋ぐ。reqwest が
+#     Android のトラストストアに届くのに要る (android-tls/README.md)
+#   - ホーム画面ウィジェットのソースを入れ、receiver を manifest に登録する
+#     (android-widget/README.md)
+# 署名だけは keystore.properties を要求して失敗しうるので android-sign-setup に分けてある。
+android-setup:
   go run android-tls/apply-tls.go
+  go run android-widget/apply-widget.go
+
+# リリース署名の設定を、生成された build.gradle.kts に注入する (冪等)。
+# keystore.properties が無いと失敗するので android-setup とは別建て。
+# キーストアの初回準備は android-signing/README.md を参照。
+android-sign-setup:
+  go run android-signing/apply-signing.go
 
 android-dev: setup
   pnpm tauri android dev
 
-android-build:
-  pnpm tauri android build
-
-android-build-debug: android-widget-setup
+android-build-debug: android-setup
   pnpm tauri android build --debug --target aarch64
 
-android-install: android-build-debug
-  adb install src-tauri/gen/android/app/build/outputs/apk/universal/debug/app-universal-debug.apk
-
-# Inject the release signing config into the generated build.gradle.kts
-# (idempotent; re-run after `tauri android init` regenerates gen/android).
-# See android-signing/README.md for one-time keystore setup.
-android-sign-setup:
-  go run android-signing/apply-signing.go
-
-# Install the home screen widget sources into gen/android and register the
-# receivers in the generated manifest (idempotent; re-run after
-# `tauri android init`). See android-widget/README.md.
-android-widget-setup:
-  go run android-widget/apply-widget.go
-
-# Build a signed release APK. Requires keystore.properties.
+# 署名済みリリース APK。keystore.properties が要る。
 # arm64 のみ: x86 系はエミュレータ専用で実機には要らず、universal だと
 # 4 ABI ぶんの .so で APK が 52MB まで膨らむ。
-android-build-release: android-widget-setup android-sign-setup
+android-build-release: android-setup android-sign-setup
   pnpm tauri android build --apk --target aarch64
 
-# Same, but from a checkout with no gen/android yet (CI). keystore.properties
-# has to be written after android-init, so this recipe does not build on its own —
-# see .github/workflows/release.yml.
-android-release-build: setup
-  pnpm tauri android build --apk --target aarch64
-
-# Build and install the signed release APK onto a connected device (-r updates in place).
-android-install-release: android-build-release
-  adb install -r src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release.apk
+# ビルドして USB 接続の端末に入れる (-r で上書き更新)。
+# `just android-install` で debug、`just android-install release` で署名済み。
+# --target aarch64 でも Tauri は出力名を universal のままにする。
+android-install variant="debug":
+  just android-build-{{variant}}
+  adb install -r src-tauri/gen/android/app/build/outputs/apk/universal/{{variant}}/app-universal-{{variant}}.apk
 
 build:
   pnpm tauri build --bundles app


### PR DESCRIPTION
## なぜやるか

`just --list` が 37 レシピまで膨らんで、メニューとして読めなくなっていた。大半は仕事ではなく転送で、root の 7 個は `tauri_app::` を呼び直すだけ、`rust::` の per-crate 4 個は呼び出し元ゼロ、`android-build-release` と `android-release-build` は依存が違うだけの同名対だった。21 に減らした。

## やったこと

Android レシピの依存関係（緑が今回まとめて新設したもの）:

```mermaid
flowchart LR
  init["android-init"] --> setup["android-setup"]
  dbg["android-build-debug"] --> setup
  rel["android-build-release"] --> setup
  rel --> sign["android-sign-setup"]
  inst["android-install variant"] --> dbg
  inst --> rel

  classDef added stroke:#3fb950,stroke-width:3px
  class setup,inst added
```

- **入口を root の 5 個に絞った** — 毎日叩く `fmt` / `check` / `test` / `verify` / `dev` だけ残し、あとはモジュール経由で呼ぶ。呼び出し元のないレシピ（`rust::` の per-crate、`assets`、署名なし APK ビルド）も落とした
- **生成物パッチとインストールを畳んだ** — 前提なしで冪等な 2 本を `android-setup` に統合。`android-install` は APK の出力パスが debug/release で対称なので、variant を引数に取る 1 本にした
- **CI の追従は release.yml だけ** — ci.yml は元から `just tauri_app::…` を直呼びしていて無変更。release.yml はウィジェット注入と署名設定がビルドの依存で走るようになり、3 ステップが 1 つになった

## やらなかったこと

- `android-sign-setup` は `android-setup` に統合しなかった。`apply-signing.go` は `keystore.properties` が無いと非ゼロ終了するので、混ぜるとキーストアを持たない人の `android-init` が壊れる。署名が要るビルドにだけぶら下げてある
