### PR TITLE
fix(tauri-app): restore Android sync by bypassing the platform verifier

### DIFF
--- a/.claude/skills/sync-storage/SKILL.md
+++ b/.claude/skills/sync-storage/SKILL.md
@@ -62,6 +62,10 @@ local scan → diff → one `POST /sync/bulk`.
 - Auto sync runs a few seconds after any successful write
 - JWT: macOS Keychain; Android falls back to app-private file (mode 600) —
   keyring's in-memory fallback silently loses tokens
+- TLS: desktop verifies through the OS trust store (rustls-platform-verifier);
+  Android uses `webpki-roots` for the sync client because the platform
+  verifier reports OCSP-less certificates as Revoked
+  (`android_tls::sync_tls_config`, `tauri-app/android-tls/README.md`)
 
 ## Widgets & deep links
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,6 +2691,7 @@ dependencies = [
  "objc2-core-location",
  "objc2-foundation",
  "reqwest",
+ "rustls",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -2704,6 +2705,7 @@ dependencies = [
  "tokio",
  "url",
  "urlencoding",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4060,6 +4062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -5993,6 +5996,15 @@ name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/tauri-app/android-tls/README.md
+++ b/tauri-app/android-tls/README.md
@@ -17,6 +17,23 @@ JNI lookup finds no class; without the Rust side the verifier has no `Context`.
 Either way the APK installs, the app opens, and only **sync** breaks — with a
 certificate error that says nothing about the real cause.
 
+## Currently bypassed for sync
+
+The wiring above is in place and initialises, but the sync client does not
+use it yet. Android's revocation checker throws for any certificate without
+an OCSP responder, and the Kotlin half maps every such exception to
+`Revoked`; Let's Encrypt, Google Trust Services and SSL.com — every CA
+Cloudflare can issue from — dropped OCSP in 2025, so sync failed with
+`invalid peer certificate: Revoked` on every device. Until upstream ships
+its fix (an allowlist of CRL hosts in the `.aar` manifest — see
+[rustls-platform-verifier#221] and [#179]), `android_tls::sync_tls_config`
+builds the sync client's TLS config from `webpki-roots` instead. Remove that
+function and the `rustls` / `webpki-roots` dependencies once the platform
+verifier verifies the sync host again; everything else here stays as is.
+
+[rustls-platform-verifier#221]: https://github.com/rustls/rustls-platform-verifier/issues/221
+[#179]: https://github.com/rustls/rustls-platform-verifier/pull/179
+
 ## Why a patcher
 
 `src-tauri/gen/android/` is gitignored and recreated by `tauri android init`,

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -56,6 +56,13 @@ ndk-context = "0.1"
 # 渡す初期化が要るので、reqwest 越しではなく直に呼べるところに置く。
 # 0.7 は jni 0.22 を使う版で、上の jni と同じものに解決させるために要る
 rustls-platform-verifier = "0.7"
+# 同期の HTTPS だけは上の検証器を通さない。Android の失効チェックは OCSP
+# 応答者の無い証明書を Revoked と誤判定し、Cloudflare で選べる CA は全部
+# OCSP をやめている (rustls/rustls-platform-verifier#221)。Mozilla のルート束で
+# 検証する。上流が CRL 配布ホストの許可リストを .aar に同梱したら外す。
+# rustls は reqwest が既定 feature 付きで持っているものと同じ版に解決させる
+rustls = "0.23"
+webpki-roots = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"

--- a/tauri-app/src-tauri/src/android_tls.rs
+++ b/tauri-app/src-tauri/src/android_tls.rs
@@ -29,6 +29,36 @@ pub(crate) fn init() {
     });
 }
 
+/// 同期クライアント用の TLS 設定。端末の検証器を迂回し、Mozilla のルート束で
+/// 検証する。
+///
+/// 端末の検証器 (rustls-platform-verifier の Kotlin 側) は失効チェック付きで
+/// PKIX 検証を走らせ、`CertPathValidatorException` を理由を見ずに Revoked に
+/// 写す。Android の RevocationChecker は OCSP 応答者の無い証明書で
+/// 「Certificate does not specify OCSP responder」を投げ、CRL への切り替えは
+/// 平文 HTTP が既定で禁止されているので届かない。Let's Encrypt・Google Trust
+/// Services・SSL.com は 2025 年に OCSP をやめたので、Cloudflare で選べる CA は
+/// 全部この経路で落ちる。同期先の証明書は失効していない (CRL で確認済み)。
+/// 上流: rustls/rustls-platform-verifier#221 (症状)、#179 (対処の議論)。
+///
+/// 上流の恒久策は CRL 配布ホストの許可リストを .aar の manifest に同梱する
+/// こと。それが出たらこの関数と Cargo.toml の rustls / webpki-roots を消して
+/// `reqwest::Client::new()` に戻す。`init` と Gradle 側の配線はそのために残す。
+///
+/// 失うもの: 端末に入れた独自 CA と失効チェック。同期先は自分の Worker 1 台で、
+/// 失効チェックは端末の検証器でも実質 OCSP 頼みだったので、どちらも要らない。
+pub(crate) fn sync_tls_config() -> Result<rustls::ClientConfig, rustls::Error> {
+    let mut roots = rustls::RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    // reqwest 0.13 の rustls feature が選ぶ provider と同じものを明示する。
+    // `ClientConfig::builder()` は provider が 2 つ入っていると panic する
+    let provider = std::sync::Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+    Ok(rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()?
+        .with_root_certificates(roots)
+        .with_no_client_auth())
+}
+
 fn install() -> Result<(), jni::errors::Error> {
     let ctx = ndk_context::android_context();
     // SAFETY: tao がアプリ起動時に入れたポインタ。プロセスが生きている間有効。

--- a/tauri-app/src-tauri/src/sync.rs
+++ b/tauri-app/src-tauri/src/sync.rs
@@ -163,7 +163,7 @@ impl HttpClient {
             .header("Authorization", self.auth())
             .send()
             .await
-            .map_err(|e| SyncErrorInfo::new("network", format!("Network error: {e}")))?;
+            .map_err(network_error)?;
 
         let resp = check_status(resp, "get_sync_state").await?;
 
@@ -180,7 +180,7 @@ impl HttpClient {
             .json(&req)
             .send()
             .await
-            .map_err(|e| SyncErrorInfo::new("network", format!("Network error: {e}")))?;
+            .map_err(network_error)?;
 
         if resp.status() == reqwest::StatusCode::CONFLICT {
             return Err(SyncErrorInfo::new(
@@ -195,6 +195,24 @@ impl HttpClient {
             .await
             .map_err(|e| SyncErrorInfo::other(format!("Failed to parse bulk response: {e}")))
     }
+}
+
+/// reqwest 0.12 以降の `Display` は「error sending request for url (…)」で
+/// 止まり、DNS・TCP・TLS のどこで落ちたかは `source()` を辿らないと出てこない。
+/// Android の TLS 検証は Java 経由で、ログも無いので、この連鎖が唯一の手がかり。
+fn network_error(e: reqwest::Error) -> SyncErrorInfo {
+    SyncErrorInfo::new("network", format!("Network error: {}", describe(&e)))
+}
+
+fn describe(e: &dyn std::error::Error) -> String {
+    let mut out = e.to_string();
+    let mut cur = e.source();
+    while let Some(s) = cur {
+        out.push_str(": ");
+        out.push_str(&s.to_string());
+        cur = s.source();
+    }
+    out
 }
 
 /// 非成功ステータスを kind 付きエラーに変換する。
@@ -615,6 +633,27 @@ mod tests {
         let info = SyncErrorInfo::other("boom");
         assert_eq!(info.kind, "other");
         assert!(info.message.contains("boom"));
+    }
+
+    #[test]
+    fn describe_walks_the_source_chain() {
+        #[derive(Debug)]
+        struct Outer(std::io::Error);
+        impl std::fmt::Display for Outer {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("error sending request")
+            }
+        }
+        impl std::error::Error for Outer {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+        let inner = std::io::Error::other("invalid peer certificate: UnknownIssuer");
+        assert_eq!(
+            describe(&Outer(inner)),
+            "error sending request: invalid peer certificate: UnknownIssuer"
+        );
     }
 
     #[test]

--- a/tauri-app/src-tauri/src/sync.rs
+++ b/tauri-app/src-tauri/src/sync.rs
@@ -137,6 +137,24 @@ struct DownloadedFile {
 
 // ──────────── HTTP client ────────────
 
+// Android 側は失敗しうるので、両方を同じ型で呼べるように揃える
+#[allow(clippy::unnecessary_wraps)]
+#[cfg(not(target_os = "android"))]
+fn http_client() -> Result<reqwest::Client, SyncErrorInfo> {
+    Ok(reqwest::Client::new())
+}
+
+/// Android だけ端末の検証器を迂回する。理由は `android_tls::sync_tls_config`
+#[cfg(target_os = "android")]
+fn http_client() -> Result<reqwest::Client, SyncErrorInfo> {
+    let tls = crate::android_tls::sync_tls_config()
+        .map_err(|e| SyncErrorInfo::other(format!("TLS setup failed: {e}")))?;
+    reqwest::Client::builder()
+        .tls_backend_preconfigured(tls)
+        .build()
+        .map_err(|e| SyncErrorInfo::other(format!("HTTP client setup failed: {}", describe(&e))))
+}
+
 struct HttpClient {
     http: reqwest::Client,
     base_url: String,
@@ -144,12 +162,12 @@ struct HttpClient {
 }
 
 impl HttpClient {
-    fn new(base_url: String, token: String) -> Self {
-        Self {
-            http: reqwest::Client::new(),
+    fn new(base_url: String, token: String) -> Result<Self, SyncErrorInfo> {
+        Ok(Self {
+            http: http_client()?,
             base_url: base_url.trim_end_matches('/').to_string(),
             token,
-        }
+        })
     }
 
     fn auth(&self) -> String {
@@ -331,7 +349,7 @@ async fn do_sync(handle: &AppHandle) -> Result<SyncResult, SyncErrorInfo> {
         ));
     }
 
-    let client = HttpClient::new(config.workers_url, token);
+    let client = HttpClient::new(config.workers_url, token)?;
 
     // 他端末と同時に同期すると CAS で弾かれる。ユーザーに再試行させる理由はないので
     // 取得し直して自動でやり直す


### PR DESCRIPTION
## なぜやるか

Android で同期が `Network error: error sending request for url (…)` で止まっていた。
9/1 の reqwest 0.13 更新で証明書検証が端末の検証器(rustls-platform-verifier)経由になったが、その Kotlin 側は失効チェックの例外を理由を見ずに Revoked に写す。
Android の失効チェックは OCSP 応答者の無い証明書で例外を投げ、Cloudflare で選べる CA(Let's Encrypt / Google Trust Services / SSL.com)は全部 2025 年に OCSP をやめている。
証明書自体は失効していない(CRL で確認)。上流は rustls/rustls-platform-verifier#221 で追跡中で、修正は未着手。

## やったこと

Android の同期クライアントだけ、端末の検証器を通さず Mozilla のルート束で検証する(緑が新しい経路、赤の破線が通らなくなった経路)。

```mermaid
flowchart LR
  sync["同期クライアント (reqwest)"] --> roots["webpki-roots<br/>(Mozilla のルート束)"]
  sync -.-> pv["端末の検証器<br/>(rustls-platform-verifier)"]
  pv -.-> rc["Android の失効チェック<br/>OCSP 無し → Revoked"]
  roots --> host["同期ホスト (Cloudflare Worker)"]

  classDef added stroke:#3fb950,stroke-width:3px
  class roots added
  linkStyle 1,2 stroke:#f85149,stroke-width:3px
```

- 同期エラーの表示に原因の連鎖が付く。reqwest 0.12 以降の `Display` は接続層の理由を落とすので、`invalid peer certificate: Revoked` が見えるまで原因が分からなかった
- 端末の検証器の配線(Kotlin AAR・ProGuard・JNI 初期化)は残す。上流の修正が出たら関数 1 つと依存 2 つを消すだけで戻せる(手順は `android_tls.rs` の doc と `android-tls/README.md`)
- 失うのは端末に入れた独自 CA と失効チェック。同期先は自分の Worker 1 台なので要らない

## やらなかったこと

- CRL 配布ホストへの平文 HTTP を `network_security_config` で許可する方式。端末の信頼ストアを保てる上流と同じ方向だが、debug ビルドが dev サーバー向けに `usesCleartextTraffic=true` に依存していて、その切り分けが先に要る
- Android にロガーを入れる件。検証器の `log::warn!` は今も消えている

## 資料

- rustls/rustls-platform-verifier#221(症状の報告と対処の議論)
- rustls/rustls-platform-verifier#179(上流の恒久策)
- 実機確認: moto g52j(Android 12)で Worker に `GET /sync-state` と `POST /sync/bulk` が届き、Mac で書いた記録が降りてきた
