### PR TITLE
fix(tauri-app): let note blocks fill the column instead of a ch measure

### DIFF
--- a/tauri-app/src/styles/base.css
+++ b/tauri-app/src/styles/base.css
@@ -14,6 +14,14 @@
 @import "open-props/fonts.min.css";
 @import "open-props/normalize.min.css";
 
+/* normalize は p / li / blockquote / 見出しに 20〜60ch の「読みやすい行長」を
+   上限幅として掛ける。ch は「0」の幅なので、日本語ではその半分ほどの文字数で
+   折り返され、段の右半分が空く。段幅は各ビュー(.detail-body の 640px、
+   タイムラインの 552px)が決めているので、要素側の上限は外す */
+:where(h1, h2, h3, h4, h5, h6, p, li, dd, dt, blockquote, figcaption, td) {
+  max-inline-size: none;
+}
+
 :root {
   --app-surface: var(--gray-0);
   --app-surface-2: var(--gray-1);

--- a/tauri-app/src/styles/workspace.test.ts
+++ b/tauri-app/src/styles/workspace.test.ts
@@ -165,6 +165,43 @@ describe("note body: preview and editor draw the same page", () => {
     expect(editorAfter).toEqual(previewAfter);
   });
 
+  // Open Props の normalize は p/li/blockquote/見出しに 20〜60ch の読みやすさ上限を
+  // 掛ける。ch は「0」の幅なので日本語では半分ほどの文字数で折り返され、段の
+  // 右半分が空く。段幅は .detail-body が決めるので、どのブロックも段いっぱいに伸びること
+  it.each([
+    ["preview", preview],
+    ["editor", editor],
+  ])("lets every block fill the column, not a ch-based measure (%s)", async (_name, wrap) => {
+    await page.viewport(1280, 800);
+    const long =
+      "日本語の本文は一文字が二桁ぶんの幅を持つので、桁で決めた上限幅ではすぐに折り返してしまう。";
+    const body = mountDetail(
+      wrap(
+        `<h2>${long}</h2><p>${long}</p><blockquote><p>${long}</p></blockquote><ul><li>${long}</li></ul>`,
+      ),
+    );
+    const root = blockRoot(body);
+    const column = root.getBoundingClientRect().width;
+    const quote = element(":scope > blockquote", root);
+    const quoteStyle = getComputedStyle(quote);
+    const quoteInner =
+      column -
+      Number.parseFloat(quoteStyle.borderLeftWidth) -
+      Number.parseFloat(quoteStyle.paddingLeft) -
+      Number.parseFloat(quoteStyle.paddingRight);
+    const list = element(":scope > ul", root);
+    const listInner = column - Number.parseFloat(getComputedStyle(list).paddingLeft);
+
+    expect(element(":scope > h2", root).getBoundingClientRect().width).toBeCloseTo(column, 0);
+    expect(element(":scope > p", root).getBoundingClientRect().width).toBeCloseTo(column, 0);
+    expect(quote.getBoundingClientRect().width).toBeCloseTo(column, 0);
+    expect(element("blockquote > p", root).getBoundingClientRect().width).toBeCloseTo(
+      quoteInner,
+      0,
+    );
+    expect(element("li", root).getBoundingClientRect().width).toBeCloseTo(listInner, 0);
+  });
+
   // スクロールするのは両モードとも .detail-body。エディタが自分で
   // スクロールすると .detail-body の余白が固定の額縁になり、押した瞬間の
   // scrollTop を別の要素に写し替える必要が生まれる


### PR DESCRIPTION
## なぜやるか

引用や箇条書きの本文が、640px の段の右半分を空けたまま折り返される。
Open Props の normalize が `p` に 60ch、`li` と `blockquote` に 45ch、見出しに 20〜35ch の「読みやすい行長」を上限幅として掛けており、ch は半角「0」の幅なので日本語ではその半分ほどの文字数で折り返されていた。引用とリストで目立つが、段落と見出しも同じ制限を受けていた。

## やったこと

- 見出し・段落・リスト項目・引用などの上限幅を、normalize の読み込み直後に解除した
  - 段幅は各ビュー(ノート本文 640px、タイムライン 552px)が決めているので、要素側の上限は仕事がない
  - normalize と同じ `:where()` の詳細度で書き、後続のルールには影響しない
- 長い日本語の見出し・段落・引用・リスト項目が段いっぱいに伸びることを、プレビューとエディタの両方の DOM で測るブラウザテストを足した

## やらなかったこと

- コードブロックで同じ解除を個別にしている editor.css / markdown-preview.css の整理。動いているものを触る理由がなく、まとめるなら別の構造変更として出す
