### PR TITLE
refactor(core): pass note provenance as a single argument

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use chrono::Local;
-use magical_merchant_core::{CoreError, NoteFilename, NoteSummary, Revision};
+use magical_merchant_core::{CoreError, NoteFilename, NoteSummary, Provenance, Revision};
 
 use crate::notes::{self, WriteError};
 
@@ -143,7 +143,13 @@ pub(crate) fn create(data_dir: &Path, body: &str) -> Result<Option<NoteFilename>
     if body.trim().is_empty() {
         return Ok(None);
     }
-    let path = magical_merchant_core::create_draft_note(data_dir, body, &[], &notes::context())?;
+    let path = magical_merchant_core::create_draft_note(
+        data_dir,
+        body,
+        &[],
+        &notes::context(),
+        Provenance::default(),
+    )?;
     let name = path
         .file_name()
         .and_then(|n| n.to_str())
@@ -202,8 +208,14 @@ mod tests {
     use tempfile::TempDir;
 
     fn seed(base: &Path, body: &str) -> NoteFilename {
-        let path =
-            magical_merchant_core::create_draft_note(base, body, &[], &Context::default()).unwrap();
+        let path = magical_merchant_core::create_draft_note(
+            base,
+            body,
+            &[],
+            &Context::default(),
+            Provenance::default(),
+        )
+        .unwrap();
         NoteFilename::parse(path.file_name().unwrap().to_str().unwrap()).unwrap()
     }
 

--- a/cli/src/notes.rs
+++ b/cli/src/notes.rs
@@ -91,10 +91,18 @@ pub(crate) fn overwrite(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use magical_merchant_core::Provenance;
     use tempfile::TempDir;
 
     fn seed(base: &Path, body: &str) -> NoteFilename {
-        let path = magical_merchant_core::create_draft_note(base, body, &[], &context()).unwrap();
+        let path = magical_merchant_core::create_draft_note(
+            base,
+            body,
+            &[],
+            &context(),
+            Provenance::default(),
+        )
+        .unwrap();
         NoteFilename::parse(path.file_name().unwrap().to_str().unwrap()).unwrap()
     }
 

--- a/cli/src/server.rs
+++ b/cli/src/server.rs
@@ -7,7 +7,9 @@ use chrono::NaiveDate;
 use magical_merchant_core::utils::frontmatter;
 use magical_merchant_core::utils::paths::place_cache_path;
 use magical_merchant_core::utils::place::{PlaceCache, place_key};
-use magical_merchant_core::{GlyphFormat, GlyphName, NoteFilename, Revision, parse_timeline_entry};
+use magical_merchant_core::{
+    GlyphFormat, GlyphName, NoteFilename, Provenance, Revision, parse_timeline_entry,
+};
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::{Json, Parameters};
 use rmcp::model::{
@@ -479,6 +481,7 @@ impl McpServer {
             &param.body,
             &tags,
             &notes::context(),
+            Provenance::default(),
         )
         .map_err(err)?;
         let filename = path
@@ -902,7 +905,14 @@ mod tests {
             &[(9, "a", &here), (10, "b", &nearby)],
         );
         write_day(tmp.path(), "2026-03-01", &[(9, "c", &far)]);
-        magical_merchant_core::create_draft_note(tmp.path(), "note", &[], &here).unwrap();
+        magical_merchant_core::create_draft_note(
+            tmp.path(),
+            "note",
+            &[],
+            &here,
+            Provenance::default(),
+        )
+        .unwrap();
         name_shibuya(tmp.path(), "en");
 
         let out = server(tmp.path()).list_places().unwrap().0;
@@ -928,7 +938,14 @@ mod tests {
             "2026-01-15",
             &[(9, "#run 朝", &ctx), (10, "#run 夜 #rest", &ctx)],
         );
-        magical_merchant_core::create_draft_note(tmp.path(), "設計 #rust", &[], &ctx).unwrap();
+        magical_merchant_core::create_draft_note(
+            tmp.path(),
+            "設計 #rust",
+            &[],
+            &ctx,
+            Provenance::default(),
+        )
+        .unwrap();
 
         let out = server(tmp.path()).list_tags().unwrap().0;
 
@@ -947,6 +964,7 @@ mod tests {
             "# 題\n本文 #rust",
             &["Memo".to_string()],
             &mac_at_shibuya(),
+            Provenance::default(),
         )
         .unwrap();
         name_shibuya(tmp.path(), "ja");

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -18,10 +18,10 @@ pub use glyph::{
 };
 pub use note::error::NoteError;
 pub use note::{
-    NoteSummary, Revision, Snapshot, create_draft_note, create_note_from_entry, delete_note,
-    list_note_history, list_notes, read_note, read_note_by_filename, read_note_history,
-    read_note_meta, repair_notes, restore_note, snapshot_note, update_note, update_note_meta,
-    update_note_origin, update_note_view,
+    NoteSummary, Revision, Snapshot, create_draft_note, delete_note, list_note_history, list_notes,
+    read_note, read_note_by_filename, read_note_history, read_note_meta, repair_notes,
+    restore_note, snapshot_note, update_note, update_note_meta, update_note_origin,
+    update_note_view,
 };
 pub use search::{HitKind, SearchHit, find_backlinks, search_all};
 pub use template::{
@@ -37,5 +37,7 @@ pub use utils::device::Context as DeviceContext;
 pub use utils::frontmatter;
 /// 1 件ぶんのノートメタデータ。中身は frontmatter そのもの。
 pub use utils::frontmatter::NoteFrontmatter as NoteMeta;
+/// ノートを作るときにだけ書ける出自。作成の入口はこれを 1 つ受け取る。
+pub use utils::frontmatter::Provenance;
 pub use utils::markdown::{TimelineEntry, parse_timeline_entry};
 pub use utils::validated::{GlyphFormat, GlyphName, NoteFilename};

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -17,33 +17,18 @@ use crate::utils::device::Context;
 use crate::utils::frontmatter::{self, Provenance};
 use crate::utils::validated::NoteFilename;
 
+/// ノートを 1 本作る。出自([`Provenance`])は作成時にしか書けない記録で、
+/// 何も名乗らないなら [`Provenance::default`]。タイムラインエントリの昇格は
+/// `origin` を添えた同じ呼び出し — 経路ごとに関数を生やすと、出自の記録が
+/// 1 つ増えるたびに全部のシグネチャが壊れる。
 pub fn create_draft_note(
     base_dir: &Path,
     body: &str,
     tags: &[String],
     context: &Context,
+    provenance: Provenance<'_>,
 ) -> Result<PathBuf, CoreError> {
-    Notes::new(base_dir.to_path_buf()).create(body, tags, context, Provenance::default())
-}
-
-/// タイムラインエントリを昇格させてノートを作る。frontmatter の `origin` に
-/// 元エントリの日時を刻む以外は `create_draft_note` と同じ。
-pub fn create_note_from_entry(
-    base_dir: &Path,
-    body: &str,
-    tags: &[String],
-    context: &Context,
-    origin: &str,
-) -> Result<PathBuf, CoreError> {
-    Notes::new(base_dir.to_path_buf()).create(
-        body,
-        tags,
-        context,
-        Provenance {
-            origin: Some(origin),
-            ..Provenance::default()
-        },
-    )
+    Notes::new(base_dir.to_path_buf()).create(body, tags, context, provenance)
 }
 
 /// 本文を書き換える。`expected` に読んだときの [`Revision`] を添えると、
@@ -141,15 +126,27 @@ mod tests {
         }
     }
 
+    /// 何も名乗らない普通の新規ノート。作成そのものを見るテスト以外は
+    /// これを通す — 出自が 1 つ増えるたびに全テストが書き換わる形にしない。
+    fn draft(tmp: &TempDir, body: &str, tags: &[String]) -> Result<PathBuf, CoreError> {
+        create_draft_note(
+            tmp.path(),
+            body,
+            tags,
+            &mock_context(),
+            Provenance::default(),
+        )
+    }
+
     #[test]
-    fn test_create_note_from_entry_records_origin() {
+    fn a_note_promoted_from_an_entry_records_its_origin() {
         let tmp = TempDir::new().unwrap();
-        let path = create_note_from_entry(
+        let path = create_draft_note(
             tmp.path(),
             "エントリ本文 #memo",
             &["memo".to_string()],
             &mock_context(),
-            "2026-08-13T08:30:00",
+            promoted_from("2026-08-13T08:30:00"),
         )
         .unwrap();
 
@@ -168,7 +165,14 @@ mod tests {
     #[test]
     fn test_create_draft_note_returns_path() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "draft body", &[], &mock_context()).unwrap();
+        let path = create_draft_note(
+            tmp.path(),
+            "draft body",
+            &[],
+            &mock_context(),
+            Provenance::default(),
+        )
+        .unwrap();
         let content = fs::read_to_string(&path).unwrap();
         // origin はエントリ由来のノートだけの記録。普通の新規ノートに書くと
         // 全ノートが「どこかのエントリから来た」ことになってしまう
@@ -181,7 +185,7 @@ mod tests {
     #[test]
     fn test_update_note_overwrites() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "original", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "original", &[]).unwrap();
 
         update_note(&path, "updated", &mock_context(), None).unwrap();
 
@@ -195,7 +199,7 @@ mod tests {
     #[test]
     fn update_note_keeps_the_creation_time() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "original", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "original", &[]).unwrap();
         let original = fs::read_to_string(&path).unwrap();
         let (fm_before, _) = frontmatter::parse::<NoteFrontmatter>(&original).unwrap();
 
@@ -212,7 +216,7 @@ mod tests {
     #[test]
     fn update_note_stamps_the_updated_time() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "original", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "original", &[]).unwrap();
         let filename = filename_of(&path);
         assert_eq!(read_note_meta(tmp.path(), &filename).unwrap().updated, None);
 
@@ -229,7 +233,7 @@ mod tests {
     #[test]
     fn update_note_refuses_to_overwrite_a_body_that_moved_since_it_was_read() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "original", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "original", &[]).unwrap();
         let read = Revision::of(&read_note(&path).unwrap());
         update_note(&path, "someone else", &mock_context(), None).unwrap();
 
@@ -244,7 +248,7 @@ mod tests {
     #[test]
     fn update_note_with_the_current_revision_writes_and_returns_the_next_one() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "original", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "original", &[]).unwrap();
         let read = Revision::of(&read_note(&path).unwrap());
 
         let next = update_note(&path, "mine", &mock_context(), Some(&read)).unwrap();
@@ -261,7 +265,7 @@ mod tests {
     #[test]
     fn a_metadata_edit_does_not_make_the_body_revision_stale() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "original", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "original", &[]).unwrap();
         let filename = filename_of(&path);
         let read = Revision::of(&read_note(&path).unwrap());
         update_note_view(tmp.path(), &filename, Some("mindmap")).unwrap();
@@ -278,7 +282,7 @@ mod tests {
     #[test]
     fn update_note_meta_and_view_do_not_stamp_updated() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "body", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "body", &[]).unwrap();
         let filename = filename_of(&path);
 
         update_note_meta(tmp.path(), &filename, sample_time(), &[]).unwrap();
@@ -291,7 +295,7 @@ mod tests {
     #[test]
     fn update_note_meta_keeps_the_updated_time() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "body", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "body", &[]).unwrap();
         let filename = filename_of(&path);
         update_note(&path, "edited", &mock_context(), None).unwrap();
         let stamped = read_note_meta(tmp.path(), &filename).unwrap().updated;
@@ -310,7 +314,7 @@ mod tests {
     #[test]
     fn update_note_keeps_the_creation_context() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "original", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "original", &[]).unwrap();
 
         let other_device = Context {
             battery: Some(1),
@@ -330,13 +334,7 @@ mod tests {
     #[test]
     fn update_note_keeps_tags_that_predate_the_hash_syntax() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(
-            tmp.path(),
-            "original",
-            &["sync".to_string()],
-            &mock_context(),
-        )
-        .unwrap();
+        let path = draft(&tmp, "original", &["sync".to_string()]).unwrap();
 
         update_note(&path, "updated", &mock_context(), None).unwrap();
 
@@ -354,13 +352,7 @@ mod tests {
     fn test_list_notes_returns_summaries() {
         let tmp = TempDir::new().unwrap();
         let tags = vec!["rust".to_string(), "test".to_string()];
-        create_draft_note(
-            tmp.path(),
-            "# Hello\nBody text here",
-            &tags,
-            &mock_context(),
-        )
-        .unwrap();
+        draft(&tmp, "# Hello\nBody text here", &tags).unwrap();
 
         let notes = list_notes(tmp.path()).unwrap();
         assert_eq!(notes.len(), 1);
@@ -372,7 +364,7 @@ mod tests {
     #[test]
     fn test_read_note() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "full content", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "full content", &[]).unwrap();
         let content = read_note(&path).unwrap();
         assert!(content.contains("full content"));
     }
@@ -382,7 +374,7 @@ mod tests {
     #[test]
     fn read_note_returns_body_without_frontmatter() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "# Title\nbody", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "# Title\nbody", &[]).unwrap();
 
         assert_eq!(read_note(&path).unwrap(), "# Title\nbody");
     }
@@ -390,7 +382,7 @@ mod tests {
     #[test]
     fn read_note_by_filename_returns_body_without_frontmatter() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "# Title\nbody", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "# Title\nbody", &[]).unwrap();
         let fname = path.file_name().unwrap().to_str().unwrap();
         let note_filename = NoteFilename::parse(fname).unwrap();
 
@@ -402,7 +394,7 @@ mod tests {
     #[test]
     fn test_delete_note_success() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "to delete", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "to delete", &[]).unwrap();
         assert!(path.exists());
         let fname = path.file_name().unwrap().to_str().unwrap();
         let note_filename = NoteFilename::parse(fname).unwrap();
@@ -432,7 +424,7 @@ mod tests {
     #[test]
     fn test_read_note_by_filename() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "readable content", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "readable content", &[]).unwrap();
         let fname = path.file_name().unwrap().to_str().unwrap();
         let note_filename = NoteFilename::parse(fname).unwrap();
         let content = read_note_by_filename(tmp.path(), &note_filename).unwrap();
@@ -473,8 +465,7 @@ mod tests {
     #[test]
     fn read_note_meta_returns_time_tags_and_context() {
         let tmp = TempDir::new().unwrap();
-        let path =
-            create_draft_note(tmp.path(), "body", &["sync".to_string()], &mock_context()).unwrap();
+        let path = draft(&tmp, "body", &["sync".to_string()]).unwrap();
 
         let meta = read_note_meta(tmp.path(), &filename_of(&path)).unwrap();
 
@@ -496,8 +487,7 @@ mod tests {
     #[test]
     fn update_note_meta_replaces_time_and_tags() {
         let tmp = TempDir::new().unwrap();
-        let path =
-            create_draft_note(tmp.path(), "body", &["old".to_string()], &mock_context()).unwrap();
+        let path = draft(&tmp, "body", &["old".to_string()]).unwrap();
         let filename = filename_of(&path);
 
         update_note_meta(tmp.path(), &filename, sample_time(), &["log".to_string()]).unwrap();
@@ -512,7 +502,7 @@ mod tests {
     #[test]
     fn update_note_meta_keeps_body_and_context() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "# Title\nbody", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "# Title\nbody", &[]).unwrap();
         let filename = filename_of(&path);
 
         update_note_meta(tmp.path(), &filename, sample_time(), &[]).unwrap();
@@ -543,7 +533,7 @@ mod tests {
     #[test]
     fn update_note_view_sets_mindmap() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "body", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "body", &[]).unwrap();
         let filename = filename_of(&path);
 
         update_note_view(tmp.path(), &filename, Some("mindmap")).unwrap();
@@ -555,7 +545,7 @@ mod tests {
     #[test]
     fn update_note_view_none_clears_the_key() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "body", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "body", &[]).unwrap();
         let filename = filename_of(&path);
         update_note_view(tmp.path(), &filename, Some("mindmap")).unwrap();
 
@@ -568,7 +558,7 @@ mod tests {
     #[test]
     fn update_note_view_keeps_body_time_and_context() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "# Title\nbody", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "# Title\nbody", &[]).unwrap();
         let filename = filename_of(&path);
         let before = read_note_meta(tmp.path(), &filename).unwrap();
 
@@ -584,7 +574,7 @@ mod tests {
     #[test]
     fn update_note_keeps_the_view_mode() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "original", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "original", &[]).unwrap();
         let filename = filename_of(&path);
         update_note_view(tmp.path(), &filename, Some("mindmap")).unwrap();
 
@@ -598,7 +588,7 @@ mod tests {
     #[test]
     fn update_note_meta_keeps_the_view_mode() {
         let tmp = TempDir::new().unwrap();
-        let path = create_draft_note(tmp.path(), "body", &[], &mock_context()).unwrap();
+        let path = draft(&tmp, "body", &[]).unwrap();
         let filename = filename_of(&path);
         update_note_view(tmp.path(), &filename, Some("mindmap")).unwrap();
 
@@ -608,13 +598,20 @@ mod tests {
         assert_eq!(meta.view, Some("mindmap".to_string()));
     }
 
+    fn promoted_from(origin: &str) -> Provenance<'_> {
+        Provenance {
+            origin: Some(origin),
+            ..Provenance::default()
+        }
+    }
+
     fn promoted_note(tmp: &TempDir) -> NoteFilename {
-        let path = create_note_from_entry(
+        let path = create_draft_note(
             tmp.path(),
             "エントリ本文",
             &[],
             &mock_context(),
-            "2026-08-13T08:30:00",
+            promoted_from("2026-08-13T08:30:00"),
         )
         .unwrap();
         filename_of(&path)

--- a/core/src/note/history.rs
+++ b/core/src/note/history.rs
@@ -141,12 +141,13 @@ pub fn restore_note(
 mod tests {
     use super::*;
     use crate::utils::device::Context;
-    use crate::utils::frontmatter::{self, NoteFrontmatter};
+    use crate::utils::frontmatter::{self, NoteFrontmatter, Provenance};
     use crate::{create_draft_note, read_note_by_filename, update_note};
     use tempfile::TempDir;
 
     fn note(base: &Path, body: &str) -> (PathBuf, NoteFilename) {
-        let path = create_draft_note(base, body, &[], &Context::default()).unwrap();
+        let path =
+            create_draft_note(base, body, &[], &Context::default(), Provenance::default()).unwrap();
         let filename = NoteFilename::parse(path.file_name().unwrap().to_str().unwrap()).unwrap();
         (path, filename)
     }

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -314,11 +314,17 @@ fn snippet(text: &str, lowered: &str, needle: &str) -> Excerpt {
 mod tests {
     use super::*;
     use crate::utils::device::Context;
+    use crate::utils::frontmatter::Provenance;
     use crate::{create_draft_note, save_timeline_entry};
     use tempfile::TempDir;
 
     fn context() -> Context {
         Context::default()
+    }
+
+    /// 検索に引っかける普通のノート。出自は検索の対象ではないので名乗らない。
+    fn draft(tmp: &TempDir, body: &str, tags: &[String]) -> Result<std::path::PathBuf, CoreError> {
+        create_draft_note(tmp.path(), body, tags, &context(), Provenance::default())
     }
 
     /// 一覧ペインは `# ` を落とした題を出す。パレットとバックリンクだけ
@@ -427,7 +433,7 @@ mod tests {
     #[test]
     fn finds_a_note_by_body_and_reports_its_filename() {
         let tmp = TempDir::new().unwrap();
-        create_draft_note(tmp.path(), "R2 のリトライ設計", &[], &context()).unwrap();
+        draft(&tmp, "R2 のリトライ設計", &[]).unwrap();
 
         let hits = search_all(tmp.path(), "リトライ", &[]).unwrap();
 
@@ -439,7 +445,7 @@ mod tests {
     #[test]
     fn finds_a_note_by_tag() {
         let tmp = TempDir::new().unwrap();
-        create_draft_note(tmp.path(), "body", &["sync".to_string()], &context()).unwrap();
+        draft(&tmp, "body", &["sync".to_string()]).unwrap();
 
         let hits = search_all(tmp.path(), "sync", &[]).unwrap();
 
@@ -476,7 +482,7 @@ mod tests {
     fn a_tag_only_hit_shows_the_start_of_the_body() {
         let tmp = TempDir::new().unwrap();
         let body = "本文はタグと無関係で長い".repeat(10);
-        create_draft_note(tmp.path(), &body, &["sync".to_string()], &context()).unwrap();
+        draft(&tmp, &body, &["sync".to_string()]).unwrap();
 
         let hits = search_all(tmp.path(), "sync", &[]).unwrap();
 
@@ -551,7 +557,7 @@ mod tests {
     #[test]
     fn a_tag_only_hit_has_no_match_position() {
         let tmp = TempDir::new().unwrap();
-        create_draft_note(tmp.path(), "本文", &["sync".to_string()], &context()).unwrap();
+        draft(&tmp, "本文", &["sync".to_string()]).unwrap();
 
         let hits = search_all(tmp.path(), "sync", &[]).unwrap();
 
@@ -579,13 +585,7 @@ mod tests {
     #[test]
     fn a_tag_scope_keeps_only_notes_carrying_the_tag() {
         let tmp = TempDir::new().unwrap();
-        create_draft_note(
-            tmp.path(),
-            "リトライ設計",
-            &["sync".to_string()],
-            &context(),
-        )
-        .unwrap();
+        draft(&tmp, "リトライ設計", &["sync".to_string()]).unwrap();
         write_second_note(tmp.path(), "20200101_000000.md", "リトライの雑記 #misc");
 
         let hits = search_all(tmp.path(), "リトライ", &scope(&["sync"])).unwrap();
@@ -602,7 +602,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         save_timeline_entry(tmp.path(), "走った #run", &context()).unwrap();
         save_timeline_entry(tmp.path(), "読んだ #book", &context()).unwrap();
-        create_draft_note(tmp.path(), "走る計画", &["run".to_string()], &context()).unwrap();
+        draft(&tmp, "走る計画", &["run".to_string()]).unwrap();
 
         let hits = search_all(tmp.path(), "", &scope(&["run"])).unwrap();
 
@@ -701,7 +701,7 @@ mod tests {
     #[test]
     fn a_timeline_entry_that_links_a_note_is_a_backlink() {
         let tmp = TempDir::new().unwrap();
-        let target = create_draft_note(tmp.path(), "指される側", &[], &context()).unwrap();
+        let target = draft(&tmp, "指される側", &[]).unwrap();
         let link = format!("これ参照 [[{}]]", stem_of(&target));
         save_timeline_entry(tmp.path(), &link, &context()).unwrap();
 
@@ -717,7 +717,7 @@ mod tests {
     #[test]
     fn a_link_deep_in_a_long_note_is_still_found() {
         let tmp = TempDir::new().unwrap();
-        let target = create_draft_note(tmp.path(), "指される側", &[], &context()).unwrap();
+        let target = draft(&tmp, "指される側", &[]).unwrap();
         let body = format!("{}\n[[{}]]", "あ".repeat(300), stem_of(&target));
         write_second_note(tmp.path(), "20200101_000000.md", &body);
 
@@ -731,8 +731,7 @@ mod tests {
     #[test]
     fn a_note_is_not_its_own_backlink() {
         let tmp = TempDir::new().unwrap();
-        let target =
-            create_draft_note(tmp.path(), "後で本文に自分を書く", &[], &context()).unwrap();
+        let target = draft(&tmp, "後で本文に自分を書く", &[]).unwrap();
         let stem = stem_of(&target);
         crate::update_note(&target, &format!("自分 [[{stem}]]"), &context(), None).unwrap();
 
@@ -748,7 +747,7 @@ mod tests {
     #[test]
     fn a_link_with_display_text_is_a_backlink() {
         let tmp = TempDir::new().unwrap();
-        let target = create_draft_note(tmp.path(), "指される側", &[], &context()).unwrap();
+        let target = draft(&tmp, "指される側", &[]).unwrap();
         let body = format!("詳しくは [[{}|前の話]] を見る", stem_of(&target));
         write_second_note(tmp.path(), "20200101_000000.md", &body);
 
@@ -766,7 +765,7 @@ mod tests {
     #[test]
     fn no_links_means_no_backlinks() {
         let tmp = TempDir::new().unwrap();
-        let target = create_draft_note(tmp.path(), "誰も指していない", &[], &context()).unwrap();
+        let target = draft(&tmp, "誰も指していない", &[]).unwrap();
         write_second_note(tmp.path(), "20200101_000000.md", "無関係なノート");
         save_timeline_entry(tmp.path(), "無関係なエントリ", &context()).unwrap();
 

--- a/core/src/template.rs
+++ b/core/src/template.rs
@@ -80,11 +80,15 @@ pub fn delete_template(base_dir: &Path, filename: &NoteFilename) -> Result<(), C
 /// 同じテンプレの今日のノートが既にあれば作らずにそれを返す。日次テンプレを
 /// ウィジェットから 1 日に何度も叩くのは普通のことで、そのたびに空の
 /// 「Daily」が増えるとテンプレのほうが邪魔になる。
+///
+/// `provenance` は呼ぶ側が名乗る出自。テンプレ名だけはここで埋める —
+/// ファイル名から導けるものを呼ぶ側に渡させても間違いが増えるだけ。
 pub fn create_note_from_template(
     base_dir: &Path,
     filename: &NoteFilename,
     context: &Context,
     locale: VarLocale,
+    provenance: Provenance<'_>,
 ) -> Result<CreatedNote, CoreError> {
     let (fm, body) = Templates::new(base_dir.to_path_buf()).read(filename)?;
     let name = template_name(filename);
@@ -115,7 +119,7 @@ pub fn create_note_from_template(
         context,
         Provenance {
             template: Some(name),
-            ..Provenance::default()
+            ..provenance
         },
     )?;
 
@@ -204,9 +208,14 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         daily(&tmp);
 
-        let created =
-            create_note_from_template(tmp.path(), &name("daily.md"), &context(), VarLocale::Ja)
-                .unwrap();
+        let created = create_note_from_template(
+            tmp.path(),
+            &name("daily.md"),
+            &context(),
+            VarLocale::Ja,
+            Provenance::default(),
+        )
+        .unwrap();
 
         let body = read_note(&created.path).unwrap();
         let today = Local::now().format("%Y-%m-%d").to_string();
@@ -221,9 +230,14 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         daily(&tmp);
 
-        let created =
-            create_note_from_template(tmp.path(), &name("daily.md"), &context(), VarLocale::Ja)
-                .unwrap();
+        let created = create_note_from_template(
+            tmp.path(),
+            &name("daily.md"),
+            &context(),
+            VarLocale::Ja,
+            Provenance::default(),
+        )
+        .unwrap();
 
         assert!(!read_note(&created.path).unwrap().contains("前回"));
     }
@@ -234,9 +248,14 @@ mod tests {
         daily(&tmp);
         seed_note(&tmp, "20260830_090000.md", "daily", 1);
 
-        let created =
-            create_note_from_template(tmp.path(), &name("daily.md"), &context(), VarLocale::Ja)
-                .unwrap();
+        let created = create_note_from_template(
+            tmp.path(),
+            &name("daily.md"),
+            &context(),
+            VarLocale::Ja,
+            Provenance::default(),
+        )
+        .unwrap();
 
         assert!(
             read_note(&created.path)
@@ -252,9 +271,14 @@ mod tests {
         daily(&tmp);
         seed_note(&tmp, "20260830_090000.md", "weekly", 1);
 
-        let created =
-            create_note_from_template(tmp.path(), &name("daily.md"), &context(), VarLocale::Ja)
-                .unwrap();
+        let created = create_note_from_template(
+            tmp.path(),
+            &name("daily.md"),
+            &context(),
+            VarLocale::Ja,
+            Provenance::default(),
+        )
+        .unwrap();
 
         assert!(!read_note(&created.path).unwrap().contains("前回"));
     }
@@ -264,8 +288,14 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         daily(&tmp);
 
-        create_note_from_template(tmp.path(), &name("daily.md"), &context(), VarLocale::Ja)
-            .unwrap();
+        create_note_from_template(
+            tmp.path(),
+            &name("daily.md"),
+            &context(),
+            VarLocale::Ja,
+            Provenance::default(),
+        )
+        .unwrap();
 
         let listed = list_notes(tmp.path()).unwrap();
         let month = Local::now().format("%Y-%m").to_string();
@@ -279,8 +309,14 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         daily(&tmp);
 
-        create_note_from_template(tmp.path(), &name("daily.md"), &context(), VarLocale::Ja)
-            .unwrap();
+        create_note_from_template(
+            tmp.path(),
+            &name("daily.md"),
+            &context(),
+            VarLocale::Ja,
+            Provenance::default(),
+        )
+        .unwrap();
 
         assert_eq!(
             list_notes(tmp.path()).unwrap()[0].template,
@@ -293,13 +329,23 @@ mod tests {
     fn the_same_template_reuses_todays_note() {
         let tmp = TempDir::new().unwrap();
         daily(&tmp);
-        let first =
-            create_note_from_template(tmp.path(), &name("daily.md"), &context(), VarLocale::Ja)
-                .unwrap();
+        let first = create_note_from_template(
+            tmp.path(),
+            &name("daily.md"),
+            &context(),
+            VarLocale::Ja,
+            Provenance::default(),
+        )
+        .unwrap();
 
-        let second =
-            create_note_from_template(tmp.path(), &name("daily.md"), &context(), VarLocale::Ja)
-                .unwrap();
+        let second = create_note_from_template(
+            tmp.path(),
+            &name("daily.md"),
+            &context(),
+            VarLocale::Ja,
+            Provenance::default(),
+        )
+        .unwrap();
 
         assert_eq!(second.path, first.path);
         assert!(second.reused);
@@ -313,9 +359,14 @@ mod tests {
         daily(&tmp);
         seed_note(&tmp, "20260830_090000.md", "daily", 1);
 
-        let created =
-            create_note_from_template(tmp.path(), &name("daily.md"), &context(), VarLocale::Ja)
-                .unwrap();
+        let created = create_note_from_template(
+            tmp.path(),
+            &name("daily.md"),
+            &context(),
+            VarLocale::Ja,
+            Provenance::default(),
+        )
+        .unwrap();
 
         assert!(!created.reused);
         assert_eq!(list_notes(tmp.path()).unwrap().len(), 2);
@@ -327,9 +378,14 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         save_template(tmp.path(), &name("w.md"), "{{weekday}}", &[]).unwrap();
 
-        let created =
-            create_note_from_template(tmp.path(), &name("w.md"), &context(), VarLocale::En)
-                .unwrap();
+        let created = create_note_from_template(
+            tmp.path(),
+            &name("w.md"),
+            &context(),
+            VarLocale::En,
+            Provenance::default(),
+        )
+        .unwrap();
 
         let body = read_note(&created.path).unwrap();
         assert!(["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].contains(&body.trim()));
@@ -339,8 +395,13 @@ mod tests {
     fn creating_from_a_missing_template_is_not_found() {
         let tmp = TempDir::new().unwrap();
 
-        let result =
-            create_note_from_template(tmp.path(), &name("nope.md"), &context(), VarLocale::Ja);
+        let result = create_note_from_template(
+            tmp.path(),
+            &name("nope.md"),
+            &context(),
+            VarLocale::Ja,
+            Provenance::default(),
+        );
 
         assert!(matches!(result, Err(CoreError::NotFound(_))));
     }

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -30,7 +30,7 @@ use base64::engine::general_purpose::STANDARD as B64;
 use device::ClientContext;
 use magical_merchant_core::{
     CreatedNote, GlyphFormat, GlyphName, GlyphSummary, NoteFilename, NoteMeta, NoteSummary,
-    Revision, SearchHit, TemplateDetail, TemplateSummary, VarLocale,
+    Provenance, Revision, SearchHit, TemplateDetail, TemplateSummary, VarLocale,
 };
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_deep_link::DeepLinkExt as _;
@@ -66,16 +66,17 @@ fn create_draft(
     let base_dir = app_base_dir(&handle)?;
     let context = device::get_context(client);
     // origin 付きはタイムラインエントリからの昇格。出自を frontmatter に刻む
-    let path = origin
-        .map_or_else(
-            || magical_merchant_core::create_draft_note(&base_dir, &body, &tags, &context),
-            |origin| {
-                magical_merchant_core::create_note_from_entry(
-                    &base_dir, &body, &tags, &context, &origin,
-                )
-            },
-        )
-        .map_err(|e| e.to_string())?;
+    let path = magical_merchant_core::create_draft_note(
+        &base_dir,
+        &body,
+        &tags,
+        &context,
+        Provenance {
+            origin: origin.as_deref(),
+            ..Provenance::default()
+        },
+    )
+    .map_err(|e| e.to_string())?;
     Ok(path.to_string_lossy().to_string())
 }
 
@@ -252,6 +253,7 @@ fn create_from_template(
         &filename,
         &context,
         VarLocale::parse(&locale),
+        Provenance::default(),
     )
     .map_err(|e| e.to_string())
 }


### PR DESCRIPTION
## なぜやるか

ノート作成の入口が、刻める frontmatter のキーを引数として個別に並べていた。
`create_draft_note` は無し、`create_note_from_entry` は `origin`、
`create_note_from_template` は自分で導いた `template`。出自を持つ構造体
`Provenance` は既にあるのに、キーが 1 つ増えるたびに 3 つのシグネチャと
全呼び出し元が壊れる形になっている。

次に足したいのは「どのツールで書いたか」(`source`)で、そのままだと同じ
書き換えをもう一度やることになる。挙動を変える前に、引数の形だけを直す。

## やったこと

- `create_draft_note` が `Provenance` を 1 つ受け取る唯一の入口になった
- `create_note_from_entry` は `origin` を入れた同じ呼び出しなので削除。
  optional な origin で分岐していた Tauri コマンドは `Option` をそのまま渡す
- `create_note_from_template` も `Provenance` を受け取る。ファイル名から
  導けるテンプレ名だけは今まで通り中で埋める
- `Provenance` をクレート直下に再エクスポート(CLI / MCP / Tauri 用)
- core のテストに `draft` ヘルパを足した。引数が動くたびに 30 個のテストが
  書き換わる形をやめる

挙動は不変。昇格経路以外は全て `Provenance::default()` を渡すので、
frontmatter のキーもファイルのバイト列も 1 つも変わらない。
テストは 388 件すべて緑(追加・削除なし)。

## やらなかったこと

Phase 9 の挙動側(別 PR):

- `NoteFrontmatter` への `source` キーと `Source` enum(`app` / `cli` /
  `mcp` / `widget`)、各呼び出し元が名乗る変更
- タイムラインの `StoredContext` に短いキー `s` を足す変更
- 表示側(`NoteMeta` の型、`contextRows` / `entryMeta` の行、i18n ラベル、
  `ipc-mock.js`、MCP の出力)

`context` を `Provenance` に畳むのも見送った。参照は `Default` を持てず
`Option<&Context>` にすると `format_note_markdown` の出力が変わりうるため、
挙動不変という今回の条件と合わない。

## 資料

- `sample/plans/09-frontmatter-source.md`(Structural / Behavioral の分割 1)
