### PR TITLE
fix(notes): reload the open note when the data version changes

### DIFF
--- a/tauri-app/src/layouts/AppLayout.tsx
+++ b/tauri-app/src/layouts/AppLayout.tsx
@@ -3,6 +3,7 @@ import type { JSX } from "solid-js";
 import { useLocation, useNavigate, A } from "@solidjs/router";
 import { getCurrent, onOpenUrl } from "@tauri-apps/plugin-deep-link";
 import type { UnlistenFn } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import Icon from "../components/Icon";
 import CommandPalette from "../components/CommandPalette";
 import SyncPopover from "../components/SyncPopover";
@@ -195,6 +196,33 @@ function Chrome(props: { children?: JSX.Element }): JSX.Element {
     };
     document.addEventListener("pointerdown", onPointerDown);
     onCleanup(() => document.removeEventListener("pointerdown", onPointerDown));
+
+    // 目を離しているあいだに CLI・MCP・他の端末が data/ を書き換えている。
+    // アプリはファイルを監視しないので、戻ってきた瞬間を合図に読み直す。
+    // Android では凍結されたプロセスが起きる唯一の合図でもある
+    const onVisible = (): void => {
+      if (document.visibilityState === "visible") {
+        shell.refreshData();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    onCleanup(() => document.removeEventListener("visibilitychange", onVisible));
+
+    // デスクトップでは窓を隠さずに他のアプリへ移るので visibilitychange が
+    // 来ない。窓のフォーカスが戻ったことは Tauri 側からしか分からない
+    let unlistenFocus: UnlistenFn | undefined;
+    void (async () => {
+      try {
+        unlistenFocus = await getCurrentWindow().onFocusChanged(({ payload: focused }) => {
+          if (focused) {
+            shell.refreshData();
+          }
+        });
+      } catch {
+        // 窓が無い(ブラウザハーネス・テスト)。visibilitychange だけで動く
+      }
+    })();
+    onCleanup(() => unlistenFocus?.());
   });
 
   return (

--- a/tauri-app/src/views/Workspace.test.tsx
+++ b/tauri-app/src/views/Workspace.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@solidjs/testing-library";
+import { mockIPC, mockWindows, clearMocks } from "@tauri-apps/api/mocks";
+import { MemoryRouter, Route } from "@solidjs/router";
+import type { JSX } from "solid-js";
+import { ShellProvider, useShell } from "../lib/shell";
+import type { Shell } from "../lib/shell";
+import Workspace from "./Workspace";
+
+// 本物の Milkdown は ProseMirror 一式を連れてくる。ここで見たいのは
+// 「編集中に本文を読み直さない」という判断だけなので、開いているという
+// 事実だけを持つ板に差し替える
+vi.mock(import("../components/MilkdownEditor"), () => ({
+  default: (props: { defaultValue?: string }): JSX.Element => {
+    const el = document.createElement("div");
+    el.dataset.testid = "editor-body";
+    el.textContent = props.defaultValue ?? "";
+    return el;
+  },
+}));
+
+const FILENAME = "20260903_120000.md";
+const BODY_BEFORE = "# 会議メモ\n\nここまで書いた";
+const BODY_AFTER = "# 会議メモ (同期後)\n\n他の端末で足された行";
+
+/** ディスクの中身。テストの途中で外から書き換わったことにする。 */
+let diskBody: string;
+/** 呼ばれた Tauri コマンドの記録。読み直し経路が何も書かないことを見る。 */
+let calls: string[];
+
+const WRITE_COMMANDS = ["update_draft", "create_draft", "set_note_view", "delete_note"];
+
+const countOf = (command: string): number => calls.filter((c) => c === command).length;
+
+const HANDLERS: Record<string, () => unknown> = {
+  list_notes: () => [
+    {
+      path: `/data/notes/${FILENAME}`,
+      filename: FILENAME,
+      time: "2026-09-03T12:00:00+09:00",
+      tags: [],
+      preview: diskBody,
+    },
+  ],
+  list_templates: () => [],
+  find_backlinks: () => [],
+  read_note: () => ({ body: diskBody, revision: `rev-${diskBody.length}` }),
+  read_note_meta: () => ({}),
+};
+
+let shell: Shell | undefined;
+
+function CaptureShell(): JSX.Element {
+  shell = useShell();
+  return null;
+}
+
+/** ノートを 1 件開いた状態まで進める。狭い画面では詳細を開くまで本文が出ない。 */
+async function renderWorkspace(): Promise<void> {
+  render(() => (
+    <ShellProvider>
+      <CaptureShell />
+      <MemoryRouter>
+        <Route path="/" component={Workspace} />
+      </MemoryRouter>
+    </ShellProvider>
+  ));
+  fireEvent.click(await screen.findByRole("button", { name: /会議メモ/u }));
+  await waitFor(() => expect(screen.getByText("ここまで書いた")).toBeDefined());
+}
+
+function titleInput(): HTMLInputElement {
+  return screen.getByPlaceholderText<HTMLInputElement>("タイトル");
+}
+
+describe("Workspace › 外から書き換わったノートの読み直し", () => {
+  beforeEach(() => {
+    diskBody = BODY_BEFORE;
+    calls = [];
+    shell = undefined;
+    mockWindows("main");
+    mockIPC((cmd) => {
+      calls.push(cmd);
+      const handler = HANDLERS[cmd];
+      if (!handler) {
+        throw new Error(`unexpected command ${cmd}`);
+      }
+      return handler();
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    clearMocks();
+    document.body.innerHTML = "";
+  });
+
+  // 同期でダウンロードされた変更が、開いたままのノートに届く
+  it("reloads the open note when dataVersion increases", async () => {
+    await renderWorkspace();
+    expect(titleInput().value).toBe("会議メモ");
+
+    diskBody = BODY_AFTER;
+    shell?.refreshData();
+
+    await waitFor(() => expect(screen.getByText("他の端末で足された行")).toBeDefined());
+    expect(titleInput().value).toBe("会議メモ (同期後)");
+    expect(countOf("read_note")).toBe(2);
+    // 読み直しは読むだけ。ここで書き戻すと、相手の版を自分の版で潰す
+    for (const command of WRITE_COMMANDS) {
+      expect(countOf(command)).toBe(0);
+    }
+  });
+
+  // エディタを開いたまま本文を差し替えると、カーソル・選択・IME が消える
+  it("leaves the body alone while the editor is open", async () => {
+    await renderWorkspace();
+    fireEvent.keyDown(titleInput(), { key: "Enter" });
+    await waitFor(() => expect(screen.getByTestId("editor-body")).toBeDefined());
+    const readsBefore = countOf("read_note");
+
+    diskBody = BODY_AFTER;
+    shell?.refreshData();
+
+    // 一覧の読み直しが届くまで待つ。そのうえで本文だけが読み直されないことを見る
+    await screen.findByText("会議メモ (同期後)");
+    expect(countOf("read_note")).toBe(readsBefore);
+    expect(screen.getByTestId("editor-body").textContent).toBe("ここまで書いた");
+    for (const command of WRITE_COMMANDS) {
+      expect(countOf(command)).toBe(0);
+    }
+  });
+});

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -116,19 +116,6 @@ export default function Workspace(): JSX.Element {
    */
   const revisions = new Map<string, string>();
 
-  // 同期やパレット操作の後にデータを取り直す。初回は createResource が読むので
-  // defer しないと全ノートの読み直しがマウント直後に二重で走る
-  createEffect(
-    on(
-      shell.dataVersion,
-      () => {
-        void refetchNotes();
-        void refetchTemplates();
-      },
-      { defer: true },
-    ),
-  );
-
   const visibleItems = createMemo<NoteItem[]>(() => {
     const dropped = new Set(hidden());
     return (notes() ?? []).filter((item) => !dropped.has(item.id));
@@ -140,6 +127,13 @@ export default function Workspace(): JSX.Element {
     const items = visibleItems();
     return items.find((item) => item.id === selectedId()) ?? items[0];
   });
+
+  /**
+   * いま見ているノートの id。一覧を取り直すと NoteItem は作り直されるので、
+   * 「見ているノートが変わった」を item の同一性で判断すると、保存や同期の
+   * たびに変わったことになる。id なら同じノートのあいだ動かない。
+   */
+  const selectedKey = createMemo<string | undefined>(() => selected()?.id);
 
   /**
    * ファイルに書く本文。タイトル欄とエディタは別々に見せているが、
@@ -235,21 +229,25 @@ export default function Workspace(): JSX.Element {
   };
 
   // ---- 選択中ノートの本文と表示モードを読む ----
-  createEffect(() => {
-    const item = selected();
-    // 別のノートに移ったら編集セッションは畳む。戻る先が前のノートの
-    // 本文のままだと、次の保存が他人のバックアップを潰す
-    sessionFile = null;
-    if (!item) {
-      batch(() => {
-        setNoteBody("");
-        setNoteTitle("");
-        setNoteView("editor");
-      });
-      return;
-    }
-    void loadNote(item);
-  });
+  // 追うのは「どのノートを見ているか」だけ。item そのものを追うと、一覧を
+  // 取り直すたびに本文を読み直し、開いているエディタの下で本文が入れ替わる
+  createEffect(
+    on(selectedKey, () => {
+      const item = selected();
+      // 別のノートに移ったら編集セッションは畳む。戻る先が前のノートの
+      // 本文のままだと、次の保存が他人のバックアップを潰す
+      sessionFile = null;
+      if (!item) {
+        batch(() => {
+          setNoteBody("");
+          setNoteTitle("");
+          setNoteView("editor");
+        });
+        return;
+      }
+      void loadNote(item);
+    }),
+  );
 
   const toggleNoteView = async (item: NoteItem): Promise<void> => {
     const next = toggledView(noteView());
@@ -363,6 +361,30 @@ export default function Workspace(): JSX.Element {
       void flushSave();
     }
   });
+
+  // 同期やパレット操作の後にデータを取り直す。初回は createResource が読むので
+  // defer しないと全ノートの読み直しがマウント直後に二重で走る
+  createEffect(
+    on(
+      shell.dataVersion,
+      () => {
+        void refetchNotes();
+        void refetchTemplates();
+        // 一覧を取り直しただけでは、開いたままのノートは古い本文を出し続ける。
+        // 同期で降ってきた版をここで読み直す。読むだけで、書き戻しはしない
+        const item = selected();
+        // エディタが開いている間は絶対に触らない。本文の差し替えは
+        // カーソル・選択・スクロール・IME の状態ごと壊す(editor skill)。
+        // 待っている保存があるときも同じ — タイトル欄に打った字はまだ
+        // ディスクに無いので、読み直せばそれを捨てることになる。
+        // どちらも次の Step(ファイル監視)でトーストを出して人に決めさせる
+        if (item && !editing() && !saveTimer) {
+          void loadNote(item);
+        }
+      },
+      { defer: true },
+    ),
+  );
 
   const startEditing = (point?: CaretPoint): void => {
     if (!selected()) {


### PR DESCRIPTION
## なぜやるか

同期でダウンロードした変更が、開いたままのノートに届かなかった。一覧は
`refreshData()` で取り直されるのに、本文だけが古いまま残る。

調べると本文の読み直しは `NoteItem` オブジェクトの同一性を追っていた。
一覧を取り直すたびに `NoteItem` は作り直されるので、実際には「一覧を
取り直すたび」に本文が読み直されていた — エディタが開いている最中も
含めて。Milkdown の下で本文を差し替えると、カーソル・選択・スクロール・
IME の状態がまとめて消える(editor skill「選択とスクロールを保つ」)。
届かないという不具合と、届いてはいけない場所に届くという不具合が、
同じ 1 本の線から出ていた。

## やったこと

- 本文の読み直しを、item ではなくノートの **id** で追うようにした。
  同じノートを見ているあいだ、一覧の取り直しでは走らない
- 代わりに `shell.dataVersion` の effect で明示的に読み直す。ただし
  エディタが開いている / 保存待ちがあるときは触らない。タイトル欄に
  打った字はまだディスクに無いので、読み直せば捨てることになる
- 読み直し経路は読むだけ。何も書き戻さない
- `visibilitychange`(復帰)と Tauri の窓フォーカスで `refreshData()`。
  Android の凍結プロセスが起きる合図はこれしかなく、デスクトップは逆に
  窓を隠さず他アプリへ移るので visibilitychange が来ない。両方要る
- Vitest で 2 本固定した: dataVersion が増えたら本文が読み直されること、
  エディタが開いている間は読み直されないこと。後者は変更前は落ちる

## やらなかったこと

- **ファイル監視(Phase 10 の Step 1 以降)は別 PR**。Rust の `notify`、
  `watch.rs`、`files-changed` イベント、自分の書き込みの抑止は入れていない
- 編集中に外から書き換えられたときのトースト(Step 3)。いまは何もせず、
  次の autosave が `Stale` になって既存の退避処理に入る
- 復帰時の `refreshData()` は一覧と本文を丸ごと取り直す。差分だけを取る
  仕組みは監視を入れるときに考える

## 資料

- `sample/plans/10-file-watch-auto-refresh.md` の Step 0
- `.claude/skills/editor/SKILL.md`(選択とスクロールを保つ)
- `core/src/note/revision.rs`(revision は本文のみの指紋)
