### PR TITLE
ci(android): stop racing the disk cleanup for the SDK path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,11 +253,16 @@ jobs:
           key: cargo-android-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'flake.lock') }}
           restore-keys: |
             cargo-android-${{ runner.os }}-
+      # ランナーが置く ANDROID_SDK_ROOT (/usr/local/lib/android/sdk) は落とす。
+      # nix の devshell が入れる ANDROID_HOME と別の SDK を指すので、両方が
+      # 生きていると Gradle が「SDK の場所が複数ある」と言って組み立てを拒む。
+      # 上の rm がその実体を消すまでの間だけ起きるので、負けると落ちて勝つと
+      # 通るレースになっていた。env を消すほうが待つより確実
       - name: Generate the Android project
-        run: nix develop .#android --command just tauri_app::android-init
+        run: env -u ANDROID_SDK_ROOT nix develop .#android --command just tauri_app::android-init
       # android-setup を含む。ウィジェットのソースを入れた状態で組む
       - name: The debug APK builds
-        run: nix develop .#android --command just tauri_app::android-build-debug
+        run: env -u ANDROID_SDK_ROOT nix develop .#android --command just tauri_app::android-build-debug
       - uses: actions/cache/save@v6
         if: github.ref == 'refs/heads/main' && steps.cargo-cache.outputs.cache-hit != 'true'
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,10 @@ jobs:
           gc-max-store-size-linux: 6G
           save: false
 
+      # ci.yml と同じ理由で消す。ここは rm が同期なので今は当たらないが、
+      # 消えたパスを指したままの環境変数に配信ビルドを預ける必要はない
       - name: Generate the Android project
-        run: nix develop .#android --command just tauri_app::android-init
+        run: env -u ANDROID_SDK_ROOT nix develop .#android --command just tauri_app::android-init
 
       - name: Restore the signing keystore
         env:
@@ -78,7 +80,7 @@ jobs:
       # keystore.properties を書いた後でないと android-sign-setup が落ちるので、
       # このステップは keystore の復元より後に置くこと
       - name: Build the signed APK
-        run: nix develop .#android --command just tauri_app::android-build-release
+        run: env -u ANDROID_SDK_ROOT nix develop .#android --command just tauri_app::android-build-release
 
       - name: Collect the APK
         id: apk


### PR DESCRIPTION
## なぜやるか

PR #182 の android ジョブが落ちた。エラーは Gradle の
「Several environment variables and/or system properties contain different
paths to the SDK」で、`ANDROID_HOME`(nix の devshell が入れる SDK)と
`ANDROID_SDK_ROOT`(ランナーの `/usr/local/lib/android/sdk`)が挙がっていた。
同じコミットを再実行したら通った。

この 2 つは以前から両方セットされている。勝敗を決めていたのは数ステップ前の
`rm -rf /usr/local/lib/android` で、実体が消えた後なら Gradle は古い
`ANDROID_SDK_ROOT` を無視し、消える前なら「SDK が 2 つある」と言って拒む。
`rm` は 72 秒を節約するために意図的に非同期にしてあるので、**テスト対象の
コードと無関係なレースの勝敗でビルドが決まる**状態になっていた。

## やったこと

- `ci.yml` の Android 2 ステップを `env -u ANDROID_SDK_ROOT nix develop …` にした。
  環境変数を消すほうが `rm` の完了を待つより確実で、72 秒も返さずに済む
- `release.yml` にも同じ手当てを入れた。こちらは `rm` が同期なので今は当たらないが、
  直前に自分で消したパスを指したままの環境変数に配信ビルドを預けている状態だった。
  気付く場所がリリース中では遅い

## やらなかったこと

- `rm -rf` を同期に戻すことはしていない。72 秒の節約はそのまま残す
- ランナーが `ANDROID_SDK_ROOT` を置くこと自体は変えられない。消すのは
  nix の devshell に入る 2 か所だけで、他のジョブには触っていない

## 資料

- 落ちた実行: https://github.com/Xantibody/magical-merchant/actions/runs/33739123935
- 同一コミットの再実行が pass したことがレースの証拠
