### PR TITLE
feat(sync): take a cross-process lock before syncing

### DIFF
--- a/.claude/skills/sync-storage/SKILL.md
+++ b/.claude/skills/sync-storage/SKILL.md
@@ -58,6 +58,10 @@ local scan → diff → one `POST /sync/bulk`.
 - The client **never sends its own state** (would read undownloaded keys as
   deletions and erase notes everywhere)
 - Writes use `expected_etag` compare-and-swap; losing races retry
+- **One sync per data directory**: `engine::run` takes an exclusive lock on
+  `<base>/.sync.lock` at its entry (`core/src/sync/lock.rs`) and fails with
+  `kind: "busy"` if another process holds it. The app's `AtomicBool` only
+  drives the "syncing" indicator; the file lock is the authority
 - Conflicts keep the loser as `….sync-conflict-<ts>.md` in R2 and on disk;
   conflict copies are excluded from scanning
 - Auto sync runs a few seconds after any successful write

--- a/core/src/sync.rs
+++ b/core/src/sync.rs
@@ -14,6 +14,8 @@ pub mod config;
 #[cfg(feature = "sync-client")]
 pub mod engine;
 #[cfg(feature = "sync-client")]
+pub mod lock;
+#[cfg(feature = "sync-client")]
 pub mod token;
 
 /// 1 回の同期でおきたことの内訳。

--- a/core/src/sync/engine.rs
+++ b/core/src/sync/engine.rs
@@ -18,6 +18,7 @@ use super::client::{
 };
 use super::conflict;
 use super::diff::{self, RemoteFile, SyncAction};
+use super::lock::SyncLock;
 use super::scan::{self, LocalFile};
 use super::state::{FileSyncRecord, SyncState};
 use super::{SyncError, SyncResult};
@@ -26,6 +27,12 @@ const MAX_SYNC_ATTEMPTS: usize = 3;
 
 /// 1 回の同期。呼び出し側は認証済みの `HttpClient` を渡す。
 pub async fn run(client: &HttpClient, base_dir: &Path) -> Result<SyncResult, SyncError> {
+    // 同じデータディレクトリを見ている他のプロセス (アプリと CLI) と同時に走ると、
+    // 最後に書いたほうの `.sync-state.json` が残って相手の記録が消える。
+    // 再試行のあいだも手放さないので、ここで 1 回だけ取る。
+    // 名前付きで束縛すること: `let _ = ` だとその場で解放されてしまう
+    let _lock = SyncLock::acquire(base_dir)?;
+
     // 他端末と同時に同期すると CAS で弾かれる。ユーザーに再試行させる理由はないので
     // 取得し直して自動でやり直す
     for attempt in 1..=MAX_SYNC_ATTEMPTS {
@@ -490,6 +497,21 @@ mod tests {
         let actions = vec![delete_local("notes/a.md")];
 
         assert!(refuse_wholesale_local_deletion(&actions, &locals).is_ok());
+    }
+
+    /// ロックは入口で取る。取れないまま走査や HTTP に進むと、
+    /// もう一方のプロセスが書いている最中の状態を読んでしまう。
+    /// 到達できない宛先を渡してあるので、通信まで進んでいれば kind は `network` になる。
+    #[tokio::test]
+    async fn a_held_lock_stops_the_run_before_it_talks_to_the_server() {
+        let dir = tempfile::tempdir().unwrap();
+        let held = SyncLock::acquire(dir.path()).unwrap();
+
+        let client = HttpClient::new(reqwest::Client::new(), "http://127.0.0.1:1", "token");
+        let err = run(&client, dir.path()).await.unwrap_err();
+
+        assert_eq!(err.kind, "busy");
+        drop(held);
     }
 
     #[test]

--- a/core/src/sync/lock.rs
+++ b/core/src/sync/lock.rs
@@ -1,0 +1,157 @@
+//! 同期のプロセス間排他。
+//!
+//! アプリ側の「同期中」フラグ (`AtomicBool`) はプロセス内でしか効かない。
+//! アプリと CLI が同時に同期すると `.sync-state.json` を後勝ちで上書きし合い、
+//! `to_local_state` が「手元に無い」として落としたキーが相手の状態から消える。
+//! 次の同期でそれは差分として蘇り、偽の競合コピーになる (`diff.rs`)。
+//! 排他はプロセスをまたぐ必要があるので、ファイルシステムに置く。
+
+use std::fs::{self, File, TryLockError};
+use std::path::Path;
+
+use super::SyncError;
+
+/// `data/` の外に置く。中に置けばロックファイル自身が同期対象になる。
+const LOCK_FILENAME: &str = ".sync.lock";
+
+/// 生きているあいだだけ同期してよい。落とすと解放される。
+///
+/// ロックの実体は開いたファイル記述子に付く advisory lock なので、
+/// プロセスが panic で落ちても kill されても OS が確実に外す。
+/// 「前回の異常終了で残ったロックファイル」を人手で消す必要はない。
+#[derive(Debug)]
+pub struct SyncLock {
+    file: File,
+}
+
+impl SyncLock {
+    /// 取れなければ待たずに `busy` を返す。
+    /// 同期は次の書き込みでも自動で走るので、順番待ちで固まるより見送るほうが安い。
+    pub fn acquire(base_dir: &Path) -> Result<Self, SyncError> {
+        // 初回起動直後はアプリのデータディレクトリ自体がまだ無いことがある
+        fs::create_dir_all(base_dir).map_err(|e| {
+            SyncError::other(format!(
+                "Failed to prepare the sync lock directory ({}): {e}",
+                base_dir.display()
+            ))
+        })?;
+
+        let path = base_dir.join(LOCK_FILENAME);
+        // truncate も削除もしない。意味を持つのはロックそのもので中身ではなく、
+        // 消したり切り詰めたりすれば、ロックを持っていない側が持っている側の
+        // ファイルに触ることになる
+        let file = File::options()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(&path)
+            .map_err(|e| {
+                SyncError::other(format!(
+                    "Failed to open the sync lock ({}): {e}",
+                    path.display()
+                ))
+            })?;
+
+        match file.try_lock() {
+            Ok(()) => Ok(Self { file }),
+            Err(TryLockError::WouldBlock) => Err(SyncError::new(
+                "busy",
+                "Another sync is already running (the app or the CLI). Try again in a moment.",
+            )),
+            // ロックが取れたか分からないなら同期しない。
+            // 排他できていないまま進むほうが高くつく
+            Err(TryLockError::Error(e)) => Err(SyncError::other(format!(
+                "Failed to lock {}: {e}",
+                path.display()
+            ))),
+        }
+    }
+}
+
+impl Drop for SyncLock {
+    fn drop(&mut self) {
+        // ファイルを閉じても外れるが、解放の責任がこの型にあることを明示しておく
+        let _ = self.file.unlock();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LOCK_FILENAME, SyncLock};
+    use std::path::Path;
+    use std::process::Command;
+
+    /// 子プロセスに「どのディレクトリを取りにいくか」を渡す。
+    const CHILD_DIR_ENV: &str = "MM_SYNC_LOCK_TEST_DIR";
+    /// 自分自身を起動し直すので、テスト名がそのまま子プロセスの入口になる。
+    const CHILD_TEST: &str = "sync::lock::tests::a_second_process_cannot_take_a_held_lock";
+
+    #[test]
+    fn the_lock_file_lives_outside_the_synced_tree() {
+        let dir = tempfile::tempdir().unwrap();
+        let _lock = SyncLock::acquire(dir.path()).unwrap();
+
+        assert!(dir.path().join(LOCK_FILENAME).exists());
+        assert!(!dir.path().join("data").exists());
+    }
+
+    #[test]
+    fn the_lock_is_released_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let _lock = SyncLock::acquire(dir.path()).unwrap();
+        }
+
+        assert!(SyncLock::acquire(dir.path()).is_ok());
+    }
+
+    /// スレッドを 2 つ回しても「プロセス間」を確かめたことにはならないので、
+    /// テストバイナリ自身をもう 1 つ起動して、この同じテストを子として走らせる。
+    #[test]
+    fn a_second_process_cannot_take_a_held_lock() {
+        // 子として起動された側。ロックを取りにいって結果を親に報告する
+        if let Ok(dir) = std::env::var(CHILD_DIR_ENV) {
+            match SyncLock::acquire(Path::new(&dir)) {
+                Ok(_) => println!("child: acquired"),
+                Err(e) => println!("child: {}", e.kind),
+            }
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let _held = SyncLock::acquire(dir.path()).unwrap();
+
+        let out = Command::new(std::env::current_exe().unwrap())
+            .args([CHILD_TEST, "--exact", "--nocapture"])
+            .env(CHILD_DIR_ENV, dir.path())
+            .output()
+            .unwrap();
+
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("child: busy"),
+            "the child process should have been refused; it said:\n{stdout}{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    /// 上のテストが「子を起動したつもりで何も走らせていなかった」に化けないよう、
+    /// ロックが空いていれば子は取れることも確かめる。
+    #[test]
+    fn a_second_process_takes_a_free_lock() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let out = Command::new(std::env::current_exe().unwrap())
+            .args([CHILD_TEST, "--exact", "--nocapture"])
+            .env(CHILD_DIR_ENV, dir.path())
+            .output()
+            .unwrap();
+
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("child: acquired"),
+            "the child process should have taken the free lock; it said:\n{stdout}{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}

--- a/core/src/sync/scan.rs
+++ b/core/src/sync/scan.rs
@@ -54,9 +54,14 @@ impl ScanCache {
     }
 
     /// 書けなくても致命ではない。次のスキャンが全件ハッシュに戻るだけ。
+    ///
+    /// それでも書き換えは原子的にする。`fs::write` は先に切り詰めるので、
+    /// 書いている途中で落ちると半端な JSON が残り、そこから同期が始まると
+    /// 全ファイルを読み直す羽目になる。書き手が同時に 2 つ走りうる
+    /// (アプリと CLI) 場所で、途中の状態を他人に見せない意味もある。
     fn save(&self, base_dir: &Path) {
         if let Ok(content) = serde_json::to_string(self) {
-            let _ = fs::write(base_dir.join(CACHE_FILENAME), content);
+            let _ = crate::utils::fs::write_atomic(&base_dir.join(CACHE_FILENAME), content);
         }
     }
 }
@@ -395,6 +400,35 @@ mod tests {
         let files = scan_local_files(dir.path()).unwrap();
 
         assert_eq!(files[0].content_hash, compute_hash(b"hello"));
+    }
+
+    /// 落ちても半端な JSON を残さない。置き換えは rename なので、先に開いた
+    /// 読み手は最後まで旧内容を読み切れる。`fs::write` は書く前に切り詰めるので、
+    /// 同じ読み手が空か途中までの JSON を読むことになる。
+    #[test]
+    fn the_cache_is_replaced_whole_rather_than_truncated_in_place() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(CACHE_FILENAME);
+        fs::write(&path, "previous cache").unwrap();
+        let reader = File::open(&path).unwrap();
+
+        let mut cache = ScanCache::default();
+        cache.files.insert(
+            "notes/a.md".to_string(),
+            CachedHash {
+                mtime_ms: 1,
+                size: 5,
+                hash: "hash-a".to_string(),
+            },
+        );
+        cache.save(dir.path());
+
+        assert_eq!(std::io::read_to_string(reader).unwrap(), "previous cache");
+        assert!(
+            fs::read_to_string(&path)
+                .unwrap()
+                .contains("\"notes/a.md\"")
+        );
     }
 
     /// キャッシュは data の外に置く。data 配下だと自分自身が同期対象になる。

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -31,6 +31,14 @@ One sync is `GET /sync-state` → local scan → diff → one `POST /sync/bulk`:
 > and erase the notes on every device. Writes use `expected_etag` for
 > compare-and-swap, and the client retries a losing race automatically.
 
+Only one sync at a time may touch a data directory. A run takes an exclusive
+lock on `<base>/.sync.lock` before it does anything else and holds it to the
+end; anyone who finds it taken gives up with `busy` rather than waiting. Two
+runs would otherwise overwrite each other's `.sync-state.json`, and the keys
+lost that way come back as conflicts on the next sync. The lock lives on the
+open file descriptor, so a crash releases it — there is never a stale lock to
+clear by hand.
+
 Turning on **Auto sync** (sync popover, or `autoSync` in the nix-darwin
 module) runs a sync a few seconds after any successful write, so a note taken
 on the phone reaches the Mac without touching the sync button.

--- a/tauri-app/src/lib/sync-status.test.ts
+++ b/tauri-app/src/lib/sync-status.test.ts
@@ -51,29 +51,32 @@ describe("describeSyncResult", () => {
 describe("describeSyncError", () => {
   it("maps notConfigured to needs-setup", () => {
     const ui = describeSyncError({ kind: "notConfigured", message: "Sync is not set up." });
-    expect(ui?.status).toBe("needs-setup");
-    expect(ui?.message).toContain("Sync is not set up.");
+    expect(ui.status).toBe("needs-setup");
+    expect(ui.message).toContain("Sync is not set up.");
   });
 
   it("maps notAuthenticated to needs-setup", () => {
     const ui = describeSyncError({ kind: "notAuthenticated", message: "Not logged in." });
-    expect(ui?.status).toBe("needs-setup");
+    expect(ui.status).toBe("needs-setup");
   });
 
   it("maps network errors to error with message", () => {
     const ui = describeSyncError({ kind: "network", message: "Network error: timeout" });
-    expect(ui?.status).toBe("error");
-    expect(ui?.message).toBe("Network error: timeout");
+    expect(ui.status).toBe("error");
+    expect(ui.message).toBe("Network error: timeout");
   });
 
-  it("ignores busy (another sync running)", () => {
+  // アプリ内の再入だけでなく、CLI がロックを持っているときにも返ってくる。
+  // 待機に戻さないと "syncing" のまま固まり、以後の同期が始められない
+  it("returns to idle without a message when another process is syncing", () => {
     const ui = describeSyncError({ kind: "busy", message: "Sync already in progress" });
-    expect(ui).toBeNull();
+    expect(ui.status).toBe("idle");
+    expect(ui.message).toBe("");
   });
 
   it("handles plain string errors from older code paths", () => {
     const ui = describeSyncError("something broke");
-    expect(ui?.status).toBe("error");
-    expect(ui?.message).toBe("something broke");
+    expect(ui.status).toBe("error");
+    expect(ui.message).toBe("something broke");
   });
 });

--- a/tauri-app/src/lib/sync-status.ts
+++ b/tauri-app/src/lib/sync-status.ts
@@ -13,7 +13,7 @@ interface SyncErrorInfo {
 }
 
 export interface SyncUiState {
-  status: "success" | "error" | "needs-setup";
+  status: "idle" | "success" | "error" | "needs-setup";
   message: string;
 }
 
@@ -48,15 +48,18 @@ export function describeSyncResult(result: SyncResultPayload): SyncUiState {
   return { status: "success", message };
 }
 
-/** null は「表示しない」(別の同期が進行中など) */
-export function describeSyncError(err: unknown): SyncUiState | null {
+export function describeSyncError(err: unknown): SyncUiState {
   const info: SyncErrorInfo =
     typeof err === "object" && err !== null && "message" in err
       ? (err as SyncErrorInfo)
       : { kind: "other", message: String(err) };
 
+  // 別の同期が走っていただけ。アプリ内の再入だけでなく、CLI が同じ
+  // データディレクトリのロックを持っているときもここに来る。異常ではないので
+  // 何も知らせないが、待機に戻すのは必須: "syncing" のまま止めると
+  // syncNow の再入ガードに引っかかり、以後どの同期も始まらなくなる
   if (info.kind === "busy") {
-    return null;
+    return { status: "idle", message: "" };
   }
   if (info.kind === "notConfigured" || info.kind === "notAuthenticated") {
     return { status: "needs-setup", message: info.message };

--- a/tauri-app/src/lib/sync.ts
+++ b/tauri-app/src/lib/sync.ts
@@ -91,12 +91,12 @@ export function createSyncState(onSynced: () => void): SyncState {
 
   const applyError = (err: unknown): void => {
     const ui = describeSyncError(err);
-    if (!ui) {
-      return;
-    }
     setStatus(ui.status);
     setMessage(ui.message);
-    setAlertVersion((v) => v + 1);
+    // 待機に戻るだけの結果 (別プロセスが同期中) でポップオーバーを開かない
+    if (ui.status === "error" || ui.status === "needs-setup") {
+      setAlertVersion((v) => v + 1);
+    }
   };
 
   const syncNow = async (): Promise<void> => {


### PR DESCRIPTION
## なぜやるか

同期のプロセス間排他が無い。src-tauri の `AtomicBool` はプロセス内だけの
フラグで、CLI や別インスタンスが同時に同期するのを止められない。両者が
`.sync-state.json` を書くと後勝ちになり、負けたほうが記録したキーは消える。
`to_local_state` は手元に無いキーを落とすので、生き残った state には相手が
ダウンロード直後のファイルが載っておらず、次の同期でそれが差分に見えて偽の
競合コピーが生まれる(`core/src/sync/diff.rs`)。データを失う経路であり、
Phase 11 Step 3(CLI の `sync`)が入れば普通の使い方で踏める。

## やったこと

- `core/src/sync/lock.rs` を追加。`engine::run` の入口で `<base>/.sync.lock`
  を排他ロックし、CAS 再試行のあいだも手放さない。取れなければ待たずに
  `kind: "busy"` を返す(同期は次の書き込みでも走るので、待つより見送る)
- ロックは `std::fs::File::try_lock`(1.89 で安定)。計画の `fs4` は使わない。
  同じ flock なのに依存が 1 つも増えず、`Cargo.lock` が動かないので
  `nix/cli.nix` の `importCargoLock` にも Android / MCP-only ビルドにも影響しない。
  ファイル記述子に付くロックなので、クラッシュしても OS が外す
- アプリの `AtomicBool` は「同期中」表示のために残すが、正は OS ロック
- `busy` で UI が固まるのを直した。`describeSyncError` が `null` を返し、
  呼び出し側が早期 return するため `status` が "syncing" のまま残り、
  `syncNow` の再入ガードで以後どの同期も始められなくなっていた。
  待機に戻すだけで何も表示しない(別プロセスの同期は異常ではない)
- `.scan-cache.json` を `write_atomic` に寄せた。`fs::write` は先に切り詰めるので、
  途中で落ちると半端な JSON が残り、次のスキャンが全件ハッシュに戻る

テスト: ロックは自分自身を子プロセスとして起動して確かめる(スレッドでは
プロセス間の排他を確かめたことにならない)。ロックが空いていれば子が取れる
ことも別テストで押さえ、「子が実は何も走っていなかった」で通らないようにした。
`engine::run` が通信より前にロックを見ることは、到達できない宛先を渡して
`kind` が `network` にならないことで固定した。

## やらなかったこと

Phase 11 の残り(issue #170)。この PR は Step 2 だけ。

- Step 3: CLI の `sync` / `login` サブコマンド
- Step 4: 書き込み後の自動同期(CLI / MCP)
- Step 5: アプリの auto sync 判断を Rust へ寄せる

## 資料

- issue #170
- `sample/plans/11-cli-sync.md` Step 2
- 前段: #182(同期エンジンの core 移設)
