### PR TITLE
fix(editor): wait for the diagram before placing the tapped caret

### DIFF
--- a/tauri-app/src/components/MilkdownEditor.test.tsx
+++ b/tauri-app/src/components/MilkdownEditor.test.tsx
@@ -1,0 +1,91 @@
+import { render, cleanup } from "@solidjs/testing-library";
+import { describe, it, expect, afterEach } from "vitest";
+import { editorViewCtx } from "@milkdown/kit/core";
+import type { Editor } from "@milkdown/kit/core";
+import MilkdownEditor from "./MilkdownEditor";
+import type { CaretPoint } from "./MilkdownEditor";
+
+/**
+ * プレビューを押した場所からそのまま書き始められること。プレビューとエディタの
+ * 幾何は揃えてある(styles/workspace.test.ts)ので、同じ本文をエディタで 2 回組み、
+ * 1 回目に測った座標を 2 回目のカーソル位置として渡せば同じ話になる。
+ *
+ * 図は node view が非同期に描く。描き上がるまでブロックはソースの高さで並ぶので、
+ * ソースが図より背が高いこの本文では、待たずに座標を引くと図の下の段落を狙った
+ * 座標がソース(コードブロック)を指す (#168)。`%%` は mermaid のコメントなので、
+ * 図は小さいままソースだけが伸びる。
+ */
+const COMMENTS = Array.from({ length: 12 }, (_, i) => `%% 注釈 ${i}`).join("\n");
+const TAIL = "図の下の段落。";
+
+function body(diagram: string): string {
+  return ["図の上の段落。", "", "```mermaid", diagram, COMMENTS, "```", "", TAIL].join("\n");
+}
+
+const DRAWABLE = body("flowchart LR\n  A --> B");
+/** 描けないソース。図は永遠に来ないが、カーソルは置かれなければならない */
+const BROKEN = body("nosuchdiagram LR\n  A --> B");
+
+interface Mounted {
+  container: HTMLElement;
+  editor: () => Editor | undefined;
+}
+
+/** 図の描画が決着する(図が出る/描けなかったと知らせが出る)まで待って返す */
+async function mountEditor(source: string, caret?: CaretPoint): Promise<Mounted> {
+  let editor: Editor | undefined;
+  const { container } = render(() => (
+    <MilkdownEditor
+      defaultValue={source}
+      caret={caret}
+      onEditorReady={(created) => {
+        editor = created;
+      }}
+    />
+  ));
+
+  await expect
+    .poll(() => container.querySelector(".mermaid-editor-preview") !== null, { timeout: 5000 })
+    .toBe(true);
+
+  return { container, editor: () => editor };
+}
+
+/** その文字を持つ段落。trailing プラグインが足す末尾の空段落と取り違えない */
+function paragraph(container: HTMLElement, text: string): HTMLElement {
+  const found = [...container.querySelectorAll<HTMLElement>(".ProseMirror > p")].find(
+    (element) => element.textContent === text,
+  );
+  if (!found) {
+    throw new Error(`expected a paragraph reading ${text}`);
+  }
+  return found;
+}
+
+/** 段落の中の、押しても不自然でない一点 */
+function pointInside(element: HTMLElement): CaretPoint {
+  const rect = element.getBoundingClientRect();
+  return { x: rect.left + 6, y: rect.top + rect.height / 2, scrollTop: 0 };
+}
+
+/** カーソルが今どのブロックにいるか。文字で見るのが読み手には一番早い */
+function caretBlock(editor: Editor | undefined): string | undefined {
+  return editor?.action((ctx) => ctx.get(editorViewCtx).state.selection.$head.parent.textContent);
+}
+
+describe("MilkdownEditor caret placement", () => {
+  afterEach(() => cleanup());
+
+  it.each([
+    ["a diagram that draws", DRAWABLE],
+    ["a diagram that never draws", BROKEN],
+  ])("places the caret in the block the tap was on, below %s", async (_name, source) => {
+    const measured = await mountEditor(source);
+    const caret = pointInside(paragraph(measured.container, TAIL));
+    cleanup();
+
+    const editing = await mountEditor(source, caret);
+
+    await expect.poll(() => caretBlock(editing.editor()), { timeout: 3000 }).toBe(TAIL);
+  });
+});

--- a/tauri-app/src/components/MilkdownEditor.tsx
+++ b/tauri-app/src/components/MilkdownEditor.tsx
@@ -16,6 +16,7 @@ import { buildLanguageSuggestions, ensureLanguageDatalist } from "../lib/languag
 import { exitCodeBlockPlugin } from "../lib/exit-code-block-plugin";
 import { codeBlockViewPlugin } from "../lib/code-block-view-plugin";
 import { codeBlockActivePlugin } from "../lib/code-block-active-plugin";
+import { DIAGRAM_SETTLED_EVENT, hasPendingDiagram } from "../lib/diagram-pending";
 import { createPlaceholderPlugin } from "../lib/placeholder-plugin";
 import { createNoteLinkPlugin } from "../lib/note-link-plugin";
 import type { NoteLinkTarget } from "../lib/note-link-plugin";
@@ -76,15 +77,23 @@ export default function MilkdownEditor(props: MilkdownEditorProps): JSX.Element 
     // 入力はすぐ受け付ける(モバイルはここでキーボードが開き始める)
     created.action((ctx) => ctx.get(editorViewCtx).focus());
     // scrollTop はプレビューを押した瞬間に同じスクロール要素で測ったもの
-    const scroller = ref ? closestScroller(ref) : undefined;
+    const root = ref;
+    const scroller = root ? closestScroller(root) : undefined;
 
     // コードの装飾や図は create の後から伸びてくる。高さが足りないうちに
     // scrollTop を戻すとクランプされ、同じ座標が別の行を指してしまう。
     // 元のスクロール量まで戻せる高さに育ったら景色を戻し、カーソルを置く
     let done = false;
-    const pending: { observer?: ResizeObserver; deadline?: ReturnType<typeof setTimeout> } = {};
+    const pending: {
+      observer?: ResizeObserver;
+      deadline?: ReturnType<typeof setTimeout>;
+      settled?: () => void;
+    } = {};
     const cancel = (): void => {
       pending.observer?.disconnect();
+      if (pending.settled) {
+        root?.removeEventListener(DIAGRAM_SETTLED_EVENT, pending.settled);
+      }
       if (pending.deadline !== undefined) {
         clearTimeout(pending.deadline);
       }
@@ -94,7 +103,11 @@ export default function MilkdownEditor(props: MilkdownEditorProps): JSX.Element 
         return;
       }
       const grown = !scroller || scroller.scrollHeight - scroller.clientHeight >= caret.scrollTop;
-      if (!grown && !force) {
+      // 図は create の時点ではまだソースの高さで場所を取っている。描き終わる
+      // 前に座標を引くと、図より下は丸ごと別のブロックを指す (#168)。
+      // scrollTop 0 では grown が常に真なので、この待ちは別に要る
+      const drawn = !root || !hasPendingDiagram(root);
+      if ((!grown || !drawn) && !force) {
         return;
       }
       done = true;
@@ -116,8 +129,12 @@ export default function MilkdownEditor(props: MilkdownEditorProps): JSX.Element 
     };
     pending.observer = new ResizeObserver(() => apply(false));
     created.action((ctx) => pending.observer?.observe(ctx.get(editorViewCtx).dom));
-    // 図がプレビューより低く終わって高さが届かないこともある。1 秒で
-    // 見切って、そのとき見えている中で一番近い場所に置く
+    // 図の描き終わりは高さを変えないこともある(本文がもう十分に長い、図と
+    // ソースの背丈が同じ)。ResizeObserver だけに頼らず合図も聞く
+    pending.settled = (): void => apply(false);
+    root?.addEventListener(DIAGRAM_SETTLED_EVENT, pending.settled);
+    // 図がプレビューより低く終わって高さが届かないこともある。図が最後まで
+    // 描けないときもここで見切る。1 秒で、そのとき見えている中で一番近い場所に置く
     pending.deadline = setTimeout(() => apply(true), 1000);
     // onCleanup は await 後のここでは owner がいない。外の onCleanup から呼ぶ
     cancelCaret = cancel;

--- a/tauri-app/src/lib/code-block-view-plugin.ts
+++ b/tauri-app/src/lib/code-block-view-plugin.ts
@@ -5,6 +5,7 @@ import copyIcon from "@phosphor-icons/core/assets/regular/copy.svg?raw";
 import checkIcon from "@phosphor-icons/core/assets/regular/check.svg?raw";
 import { t } from "./i18n";
 import { extractCaption } from "./diagram-caption";
+import { setDiagramPending } from "./diagram-pending";
 import { renderDiagrams } from "./mermaid";
 import { isMermaidLanguage, createDebouncedDiagramRenderer } from "./mermaid-preview";
 import { createCopyFeedback } from "./copy-feedback";
@@ -118,6 +119,8 @@ class CodeBlockPreviewView implements NodeView {
   destroy(): void {
     this.renderer.dispose();
     this.copyFeedback.dispose();
+    // 描き終わりは二度と来ない。待っている側を締切まで待たせない
+    setDiagramPending(this.dom, false);
   }
 
   /**
@@ -226,10 +229,19 @@ class CodeBlockPreviewView implements NodeView {
       this.resetPreview();
       return;
     }
+    // ここから図が入るまで、ブロックはソースの高さで場所を取る。高さが確定
+    // していないことを外へ知らせる — 座標から位置を引く側が待てるように (#168)
+    setDiagramPending(this.dom, true);
     this.renderer.request(source, { immediate: initial });
   }
 
   private applyResult(svg: string | null): void {
+    this.showResult(svg);
+    // 描けても描けなくても、この時点で高さは決まっている
+    setDiagramPending(this.dom, false);
+  }
+
+  private showResult(svg: string | null): void {
     if (svg === null) {
       // 打鍵の途中は書きかけの構文になるのが普通。最後に描けた図を残して
       // 落ち着きを保ち、まだ一度も描けていないときだけ控えめに伝える。
@@ -316,6 +328,8 @@ class CodeBlockPreviewView implements NodeView {
     this.preview = undefined;
     this.applyCaption();
     this.dom.classList.remove("has-diagram");
+    // 捨てた描画の結果は届かない。畳んだ姿で高さは決まっている
+    setDiagramPending(this.dom, false);
   }
 }
 

--- a/tauri-app/src/lib/diagram-pending.test.ts
+++ b/tauri-app/src/lib/diagram-pending.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  DIAGRAM_PENDING_CLASS,
+  DIAGRAM_SETTLED_EVENT,
+  hasPendingDiagram,
+  setDiagramPending,
+} from "./diagram-pending";
+
+function block(): { root: HTMLElement; dom: HTMLElement } {
+  const root = document.createElement("div");
+  const dom = document.createElement("div");
+  root.append(dom);
+  return { root, dom };
+}
+
+describe("diagram pending", () => {
+  it("tells the waiting side a diagram has no height yet", () => {
+    const { root, dom } = block();
+
+    expect(hasPendingDiagram(root)).toBe(false);
+
+    setDiagramPending(dom, true);
+
+    expect(hasPendingDiagram(root)).toBe(true);
+    expect(dom.classList.contains(DIAGRAM_PENDING_CLASS)).toBe(true);
+  });
+
+  it("signals the waiting side when the height is settled", () => {
+    const { root, dom } = block();
+    const settled = vi.fn<() => void>();
+    root.addEventListener(DIAGRAM_SETTLED_EVENT, settled);
+
+    setDiagramPending(dom, true);
+    setDiagramPending(dom, false);
+
+    expect(hasPendingDiagram(root)).toBe(false);
+    // 合図はブロックから浮かんでエディタまで届く
+    expect(settled).toHaveBeenCalledTimes(1);
+  });
+
+  // 打鍵のたびに走る sync が、待っていない相手に合図を投げ続けないこと
+  it("stays quiet when nothing was pending", () => {
+    const { root, dom } = block();
+    const settled = vi.fn<() => void>();
+    root.addEventListener(DIAGRAM_SETTLED_EVENT, settled);
+
+    setDiagramPending(dom, false);
+
+    expect(settled).not.toHaveBeenCalled();
+  });
+
+  // 図が 2 つあるノートは、両方が決着するまで「まだ描いている」
+  it("stays pending while any diagram is still drawing", () => {
+    const { root, dom } = block();
+    const other = document.createElement("div");
+    root.append(other);
+
+    setDiagramPending(dom, true);
+    setDiagramPending(other, true);
+    setDiagramPending(dom, false);
+
+    expect(hasPendingDiagram(root)).toBe(true);
+
+    setDiagramPending(other, false);
+
+    expect(hasPendingDiagram(root)).toBe(false);
+  });
+});

--- a/tauri-app/src/lib/diagram-pending.ts
+++ b/tauri-app/src/lib/diagram-pending.ts
@@ -1,0 +1,35 @@
+/**
+ * 図は node view が非同期に描く。描き終わるまでブロックはソース(`pre`)の
+ * 高さで並んでいて、図に置き換わった瞬間に下の本文がまとめて動く。その間に
+ * 座標から文書上の位置を引くと、図より下は別のブロックを指す (#168)。
+ *
+ * 待つ側(カーソル配置)と描く側(node view)を繋ぐのは、このクラスと合図だけ。
+ * クラスにしたのは、待つ側が node view のインスタンスを知らずに DOM への
+ * 問い合わせ 1 回で「まだ描いている図があるか」を答えられるから。合図は
+ * 待ち時間を締切いっぱい使わせないための通知で、状態はクラスが持つ。
+ */
+export const DIAGRAM_PENDING_CLASS = "is-diagram-pending";
+
+/** 図が 1 つ描き終わったときに node view の DOM から浮かぶ(bubbles) */
+export const DIAGRAM_SETTLED_EVENT = "diagram-settled";
+
+/**
+ * ブロックの描画中フラグを立てる/下ろす。下ろすときだけ合図を出す —
+ * 高さが決まった後に呼ぶこと(合図を受けた側はその場で座標を読む)。
+ */
+export function setDiagramPending(dom: HTMLElement, pending: boolean): void {
+  if (pending) {
+    dom.classList.add(DIAGRAM_PENDING_CLASS);
+    return;
+  }
+  if (!dom.classList.contains(DIAGRAM_PENDING_CLASS)) {
+    return;
+  }
+  dom.classList.remove(DIAGRAM_PENDING_CLASS);
+  dom.dispatchEvent(new CustomEvent(DIAGRAM_SETTLED_EVENT, { bubbles: true }));
+}
+
+/** まだ高さの決まっていない図が中にあるか */
+export function hasPendingDiagram(root: ParentNode): boolean {
+  return root.querySelector(`.${DIAGRAM_PENDING_CLASS}`) !== null;
+}


### PR DESCRIPTION
## なぜやるか

Mermaid の図より下をクリックして編集に入ると、カーソルが 1 ブロック上に置かれる (#168)。

エディタが立ち上がった直後、図はまだ描かれておらず、ブロックはソース(`pre`)の高さで場所を
取っている。ソースは描き上がった図より背が高いことが多いので、その状態で `posAtCoords` を
引くと図より下の座標が 1 つ上のブロックを指す。

`placeCaret` には「高さが育つまで待つ」判定が既にあったが、条件は
`scrollHeight - clientHeight >= caret.scrollTop`。`scrollTop` が 0 のとき常に真になるので、
短いノート(=大半のノート)では実質待っていなかった。

Closes #168

## やったこと

- `lib/diagram-pending.ts` を追加。図の高さが未確定なブロックに `is-diagram-pending` を立て、
  決着したときに bubbling する合図を出すだけの小さな置き場。状態はクラスが持つので、待つ側は
  node view のインスタンスを知らずに DOM への問い合わせ 1 回で判断できる
- code block の node view が、描画を頼んだ時点で印を立て、図が入った/描けなかった時点で下ろす
- カーソル配置は、スクロール高さに加えて「描いている図が無いこと」を待つ。合図は
  `ResizeObserver` の隣で聞く(図の描き終わりが高さを変えないこともあるため)
- 待ちは無制限にしない。描けないフェンスも決着として扱い、既存の 1 秒の締切もそのまま残す
- 配置は初回 1 回きり。後から置き直さないので、選択・スクロール・IME の変換を触らない
- テスト
  - `components/MilkdownEditor.test.tsx`: 同じ本文でエディタを 2 回組み、1 回目に測った
    「図の下の段落」の座標を 2 回目のカーソル位置として渡す。修正前は mermaid のソースを
    指して落ちる
  - `lib/diagram-pending.test.ts`: 印と合図の単体テスト(図が 2 つあるときは両方決着するまで待つ)

## やらなかったこと

- プレビュー側は変えていない。`MarkdownPreview` は描画が終わってから 1 度だけ流し込むので、
  途中の高さで見えている時間が無い
- 締切(1 秒)は据え置き。図はプレビューで描画済み = mermaid が温まっているので実際は数十 ms で
  決着する。締切の見直しは実測してからにしたい
- エディタ側の図のテーマ追従・ズームは #183 と同じくプレビューのみのまま

## 資料

- Issue #168
- `sample/plans/12-preview-enhancement.md` の「関連する別件」(この修正の見立ての出所)
- 幾何の固定: `tauri-app/src/styles/workspace.test.ts`(#183 で追加された figcaption の 2 ケース込みで緑)
