### PR TITLE
feat(preview): hover tools, pan/zoom and SVG/PNG export for diagrams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2697,6 +2697,8 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
+ "tauri-plugin-dialog",
+ "tauri-plugin-fs",
  "tauri-plugin-geolocation",
  "tauri-plugin-opener",
  "tempfile",
@@ -3098,6 +3100,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3968,6 +3971,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5004,6 +5031,48 @@ dependencies = [
  "url",
  "windows-registry",
  "windows-result 0.3.4",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61854a36651aa48381e5e209f69a01273b77f3f9f91f0c430b1b98d33bd47229"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de22eef34fd78c0da050e748710edd50bf127e651d02ea1b2bfada1523cc5c51"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/docs/features.md
+++ b/docs/features.md
@@ -65,7 +65,11 @@ lives in the file, so it follows the note to every device.
 Code blocks are highlighted with Shiki; a ` ```diff ` fence colours its `+`
 and `-` lines instead. ` ```mermaid ` fences render as diagrams, and a leading
 `%% caption: …` comment inside the fence becomes the figure's caption —
-mermaid skips `%%` lines, so the note still draws anywhere else. A per-note
+mermaid skips `%%` lines, so the note still draws anywhere else. Hovering a
+code block or a figure reveals a small toolbar: copy the code, or open the
+diagram full screen and save it as SVG or PNG (the file is named after the
+note and the diagram's position). The full-screen view zooms around the
+cursor with the wheel or a pinch, drags to pan, and closes with Esc. A per-note
 **mindmap view** (frontmatter `view: mindmap`) turns the heading/list
 structure into a markmap. One button in the note's header cycles the three
 views — editor, mindmap, read-only — and shows the icon of whichever comes

--- a/tauri-app/dev/ipc-mock.js
+++ b/tauri-app/dev/ipc-mock.js
@@ -601,6 +601,14 @@
     delete_glyph: ({ name }) => {
       glyphs.delete(name);
     },
+    save_export: ({ suggestedName, dataBase64 }) => {
+      // ブラウザに保存ダイアログは無い。書き出した中身を別タブで開いて、
+      // 目で確かめられるようにする
+      const mime = suggestedName.endsWith(".png") ? "image/png" : "image/svg+xml";
+      const bytes = Uint8Array.from(atob(dataBase64), (c) => c.codePointAt(0));
+      window.open(URL.createObjectURL(new Blob([bytes], { type: mime })), "_blank");
+      return { saved: true };
+    },
     sync_start: () => {},
     sync_status: () => ({}),
     auth_login: () => {},

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -37,6 +37,8 @@ sha2 = "0.11"
 tauri-plugin-opener = "2"
 urlencoding = "2.1.3"
 base64 = "0.23"
+tauri-plugin-dialog = "2"
+tauri-plugin-fs = "2"
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 battery = "0.7"

--- a/tauri-app/src-tauri/src/export.rs
+++ b/tauri-app/src-tauri/src/export.rs
@@ -1,0 +1,85 @@
+//! 図の SVG / PNG を、利用者が選んだ場所に書き出す。
+//!
+//! `WebView` の `<a download>` に任せないのは、macOS の `WKWebView` と Android の
+//! `WebView` がそれを処理しないため。保存ダイアログを出して選ばれた先に
+//! ネイティブ側で書く。
+
+use std::io::Write as _;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as B64;
+use tauri::AppHandle;
+use tauri_plugin_dialog::DialogExt as _;
+use tauri_plugin_fs::{FsExt as _, OpenOptions};
+
+#[derive(serde::Serialize)]
+pub(crate) struct ExportOutcome {
+    /// false はダイアログをキャンセルした。失敗ではない。
+    saved: bool,
+}
+
+/// ファイル名の拡張子。ダイアログのフィルタと、保存先の種類を決める。
+fn extension_of(name: &str) -> Option<&str> {
+    let (_, extension) = name.rsplit_once('.')?;
+    (!extension.is_empty() && !extension.contains('/')).then_some(extension)
+}
+
+/// 保存ダイアログを出し、選ばれた場所に `data_base64` を書く。
+///
+/// ダイアログは非同期版を使い、結果を oneshot で待つ。`blocking_save_file` は
+/// メインスレッドで呼ぶと固まり、同期の Tauri コマンドはメインスレッドで動く。
+/// 書き込みは fs プラグイン越し — Android の保存先は `content://` で、
+/// `std::fs` では開けない。
+#[tauri::command]
+pub(crate) async fn save_export(
+    handle: AppHandle,
+    suggested_name: String,
+    data_base64: String,
+) -> Result<ExportOutcome, String> {
+    let bytes = B64.decode(data_base64).map_err(|e| e.to_string())?;
+    let extension = extension_of(&suggested_name)
+        .ok_or_else(|| format!("export name has no extension: {suggested_name}"))?
+        .to_owned();
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    handle
+        .dialog()
+        .file()
+        .add_filter(extension.to_uppercase(), &[&extension])
+        .set_file_name(&suggested_name)
+        .save_file(move |path| {
+            // 受け手が居なくなっていても、ダイアログ側にできることは無い
+            let _ = tx.send(path);
+        });
+    let Some(path) = rx
+        .await
+        .map_err(|_| "save dialog closed without a result".to_owned())?
+    else {
+        return Ok(ExportOutcome { saved: false });
+    };
+
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    let mut file = handle.fs().open(path, options).map_err(|e| e.to_string())?;
+    file.write_all(&bytes).map_err(|e| e.to_string())?;
+    Ok(ExportOutcome { saved: true })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extension_of;
+
+    #[test]
+    fn extension_is_the_part_after_the_last_dot() {
+        assert_eq!(extension_of("20260903_101010-1.svg"), Some("svg"));
+        assert_eq!(extension_of("a.b.png"), Some("png"));
+    }
+
+    #[test]
+    fn a_name_without_an_extension_has_none() {
+        assert_eq!(extension_of("diagram"), None);
+        assert_eq!(extension_of("diagram."), None);
+        // ディレクトリ名のドットは拡張子ではない
+        assert_eq!(extension_of("v1.0/diagram"), None);
+    }
+}

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@
 mod android_tls;
 mod auth;
 mod device;
+mod export;
 #[cfg(target_os = "macos")]
 mod location;
 mod place;
@@ -422,13 +423,19 @@ fn store_token_from_urls(handle: &AppHandle, urls: &[url::Url]) {
 
 // `mobile_entry_point` fixes the signature to `fn run()`, so a failed startup
 // has nowhere to be returned to — panicking is the only way to report it.
-#[allow(clippy::expect_used)]
+// `generate_context!` embeds every plugin's permission tables in one value;
+// with dialog and fs on board it crosses clippy's stack-frame threshold. It
+// is built once at startup, so the frame size is not a concern.
+#[allow(clippy::expect_used, clippy::large_stack_frames)]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_geolocation::init())
         .plugin(tauri_plugin_opener::init())
+        // 図の書き出し: 保存ダイアログと、Android の content:// への書き込み
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_fs::init())
         .manage(sync::AppSyncState::default())
         .setup(|app| {
             // ブラウザで認証している間に OS がアプリを回収すると、トークンは
@@ -487,6 +494,7 @@ pub fn run() {
             search_all,
             resolve_places,
             delete_note,
+            export::save_export,
             sync::sync_start,
             sync::sync_status,
             auth::auth_login,

--- a/tauri-app/src/components/DiagramZoom.tsx
+++ b/tauri-app/src/components/DiagramZoom.tsx
@@ -1,25 +1,143 @@
-import { onCleanup, onMount } from "solid-js";
+import { createSignal, onCleanup, onMount } from "solid-js";
 import { t } from "../lib/i18n";
+import { fitToViewport, toCss, wheelFactor, zoomAtPoint } from "../lib/zoom-transform";
 import Icon from "./Icon";
+import type { Point, Transform } from "../lib/zoom-transform";
 import type { JSX } from "solid-js";
 
 export interface ZoomedDiagram {
   svg: string;
-  /** 図の原寸。mermaid が SVG の max-width に書き込んだ値をそのまま使う */
-  width: string;
+  /** 図の原寸(px)。viewBox の幅と高さで、mermaid が SVG の max-width に書く値と同じ */
+  width: number;
+  height: number;
 }
 
+/** 右下のボタン 1 回ぶんの倍率。±25% の感覚 */
+const STEP = 1.25;
+
+/** ダブルクリック 1 回ぶんの倍率。ボタンより大きく、一度で「そこを読む」大きさに */
+const DOUBLE_CLICK = 1.6;
+
+function distance(a: Point, b: Point): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+function midpoint(a: Point, b: Point): Point {
+  return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+}
+
+/** ボタンの上ではドラッグもダブルクリック拡大も始めない */
+function isControl(target: EventTarget | null): boolean {
+  return target instanceof Element && target.closest("button") !== null;
+}
+
+/**
+ * 図を全画面で読む。ホイール(トラックパッドのピンチは ctrl+wheel)と 2 本指で
+ * 倍率、ドラッグで位置。開いたときは画面に収まる大きさで真ん中に置く。
+ *
+ * 背景を押しても閉じない — ドラッグの始点と区別が付かない。閉じるのは
+ * Escape か右上の ✕。
+ */
 export default function DiagramZoom(props: {
   diagram: ZoomedDiagram;
   onClose: () => void;
 }): JSX.Element {
-  let ref: HTMLDivElement | undefined;
+  let root: HTMLDivElement | undefined;
+  let canvas: HTMLDivElement | undefined;
+
+  // 倍率と位置は signal にしない。ホイールやドラッグの 1 動作ごとに再描画を
+  // 起こさず、DOM の transform を直接書く。画面に出すのは倍率の数字だけ
+  let current: Transform = { scale: 1, tx: 0, ty: 0 };
+  const [percent, setPercent] = createSignal(100);
+
+  const apply = (next: Transform): void => {
+    current = next;
+    if (canvas) {
+      canvas.style.transform = toCss(next);
+    }
+    setPercent(Math.round(next.scale * 100));
+  };
+
+  const viewport = (): { width: number; height: number } => ({
+    width: root?.clientWidth ?? 0,
+    height: root?.clientHeight ?? 0,
+  });
+
+  const fitToScreen = (): void => {
+    apply(fitToViewport(viewport(), props.diagram));
+  };
+
+  /** 画面座標 → この画面の左上からの座標 */
+  const local = (clientX: number, clientY: number): Point => {
+    const rect = root?.getBoundingClientRect();
+    return { x: clientX - (rect?.left ?? 0), y: clientY - (rect?.top ?? 0) };
+  };
+
+  const zoomAt = (point: Point, factor: number): void => {
+    apply(zoomAtPoint(current, point, factor));
+  };
+
+  const zoomCenter = (factor: number): void => {
+    const { width, height } = viewport();
+    zoomAt({ x: width / 2, y: height / 2 }, factor);
+  };
+
+  // 押されている指(ポインタ)。1 本ならドラッグ、2 本ならピンチ
+  const pointers = new Map<number, Point>();
+
+  const onPointerDown = (e: PointerEvent): void => {
+    if (isControl(e.target)) {
+      return;
+    }
+    root?.setPointerCapture(e.pointerId);
+    pointers.set(e.pointerId, local(e.clientX, e.clientY));
+    root?.classList.add("is-dragging");
+  };
+
+  const onPointerMove = (e: PointerEvent): void => {
+    const previous = pointers.get(e.pointerId);
+    if (!previous) {
+      return;
+    }
+    const point = local(e.clientX, e.clientY);
+    pointers.set(e.pointerId, point);
+
+    if (pointers.size === 1) {
+      apply({
+        ...current,
+        tx: current.tx + point.x - previous.x,
+        ty: current.ty + point.y - previous.y,
+      });
+      return;
+    }
+    // ピンチ: 2 本の間隔の変化が倍率、中点の移動が平行移動
+    const other = [...pointers.entries()].find(([id]) => id !== e.pointerId)?.[1];
+    if (!other) {
+      return;
+    }
+    const before = midpoint(previous, other);
+    const after = midpoint(point, other);
+    const spread = distance(previous, other);
+    const factor = spread > 0 ? distance(point, other) / spread : 1;
+    const zoomed = zoomAtPoint(current, before, factor);
+    apply({ ...zoomed, tx: zoomed.tx + after.x - before.x, ty: zoomed.ty + after.y - before.y });
+  };
+
+  const onPointerEnd = (e: PointerEvent): void => {
+    pointers.delete(e.pointerId);
+    if (pointers.size === 0) {
+      root?.classList.remove("is-dragging");
+    }
+  };
+
+  const onDblClick = (e: MouseEvent): void => {
+    if (!isControl(e.target)) {
+      zoomAt(local(e.clientX, e.clientY), DOUBLE_CLICK);
+    }
+  };
 
   onMount(() => {
-    // 画面より広い図は、端ではなく真ん中から見せる
-    if (ref) {
-      ref.scrollLeft = (ref.scrollWidth - ref.clientWidth) / 2;
-    }
+    fitToScreen();
 
     const onKeyDown = (e: KeyboardEvent): void => {
       if (e.key === "Escape") {
@@ -28,13 +146,32 @@ export default function DiagramZoom(props: {
     };
     globalThis.addEventListener("keydown", onKeyDown);
     onCleanup(() => globalThis.removeEventListener("keydown", onKeyDown));
+
+    // passive にしない。preventDefault できないと、ピンチ(ctrl+wheel)が
+    // ページ全体のズームとして OS に取られる
+    const onWheel = (e: WheelEvent): void => {
+      e.preventDefault();
+      zoomAt(local(e.clientX, e.clientY), wheelFactor(e.deltaY, e.ctrlKey));
+    };
+    root?.addEventListener("wheel", onWheel, { passive: false });
+    onCleanup(() => root?.removeEventListener("wheel", onWheel));
   });
 
   return (
-    <div ref={ref} class="mermaid-zoom" onClick={() => props.onClose()} role="presentation">
+    <div
+      ref={root}
+      class="mermaid-zoom"
+      role="presentation"
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerEnd}
+      onPointerCancel={onPointerEnd}
+      onDblClick={onDblClick}
+    >
       <div
+        ref={canvas}
         class="mermaid-zoom-canvas"
-        style={{ width: props.diagram.width }}
+        style={{ width: `${props.diagram.width}px` }}
         innerHTML={props.diagram.svg}
       />
       <button
@@ -46,6 +183,37 @@ export default function DiagramZoom(props: {
       >
         <Icon name="x" size={18} />
       </button>
+      <div class="mermaid-zoom-controls">
+        <button
+          type="button"
+          class="icon-button"
+          title={t().preview.zoomOut}
+          aria-label={t().preview.zoomOut}
+          onClick={() => zoomCenter(1 / STEP)}
+        >
+          <Icon name="magnifying-glass-minus" size={16} />
+        </button>
+        <span class="mermaid-zoom-percent">{percent()}%</span>
+        <button
+          type="button"
+          class="icon-button"
+          title={t().preview.zoomIn}
+          aria-label={t().preview.zoomIn}
+          onClick={() => zoomCenter(STEP)}
+        >
+          <Icon name="magnifying-glass-plus" size={16} />
+        </button>
+        <button
+          type="button"
+          class="icon-button"
+          title={t().preview.fit}
+          aria-label={t().preview.fit}
+          onClick={fitToScreen}
+        >
+          <Icon name="corners-in" size={16} />
+        </button>
+      </div>
+      <p class="mermaid-zoom-hint">{t().preview.zoomHint}</p>
     </div>
   );
 }

--- a/tauri-app/src/components/MarkdownPreview.test.tsx
+++ b/tauri-app/src/components/MarkdownPreview.test.tsx
@@ -1,9 +1,15 @@
 import { render, cleanup } from "@solidjs/testing-library";
 import { page, userEvent } from "vitest/browser";
+import type { Locator } from "vitest/browser";
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import MarkdownPreview from "./MarkdownPreview";
 
 const FLOWCHART = ["```mermaid", "flowchart TD", "  A[Start] --> B[End]", "```"].join("\n");
+
+/** 右下の倍率表示を数で読む */
+function percentOf(locator: Locator): number {
+  return Number.parseInt(locator.element().textContent ?? "", 10);
+}
 
 describe("MarkdownPreview", () => {
   afterEach(() => cleanup());
@@ -36,6 +42,58 @@ describe("MarkdownPreview", () => {
     await userEvent.keyboard("{Escape}");
 
     await expect.element(screen.locator(".mermaid-zoom")).not.toBeInTheDocument();
+  });
+
+  it("fits the diagram to the screen when it opens and zooms in from the controls", async () => {
+    const { baseElement } = render(() => <MarkdownPreview source={FLOWCHART} />);
+    const screen = page.elementLocator(baseElement);
+
+    await expect.element(screen.locator(".mermaid-figure svg")).toBeInTheDocument();
+    await userEvent.click(screen.locator(".mermaid-block"));
+    const canvas = screen.locator(".mermaid-zoom-canvas");
+    await expect.element(canvas).toBeInTheDocument();
+
+    // 開いた直後から transform が付いている(fit)。原寸の 2 倍まで
+    const before = (canvas.element() as HTMLElement).style.transform;
+    expect(before).toMatch(/^translate\(.+\) scale\(.+\)$/u);
+    const percent = screen.locator(".mermaid-zoom-percent");
+    const fitted = percentOf(percent);
+    expect(fitted).toBeGreaterThan(0);
+    expect(fitted).toBeLessThanOrEqual(200);
+
+    await userEvent.click(screen.getByRole("button", { name: "大きく" }));
+
+    await expect.element(percent).toHaveTextContent(`${Math.round(fitted * 1.25)}%`);
+    expect((canvas.element() as HTMLElement).style.transform).not.toBe(before);
+  });
+
+  it("zooms toward the wheel without closing", async () => {
+    const { baseElement } = render(() => <MarkdownPreview source={FLOWCHART} />);
+    const screen = page.elementLocator(baseElement);
+
+    await expect.element(screen.locator(".mermaid-figure svg")).toBeInTheDocument();
+    await userEvent.click(screen.locator('[data-action="zoom"]'));
+    const zoom = screen.locator(".mermaid-zoom");
+    await expect.element(zoom).toBeInTheDocument();
+    const percent = screen.locator(".mermaid-zoom-percent");
+    const fitted = percentOf(percent);
+
+    const wheel = new WheelEvent("wheel", {
+      deltaY: -300,
+      clientX: 10,
+      clientY: 10,
+      bubbles: true,
+      cancelable: true,
+    });
+    zoom.element().dispatchEvent(wheel);
+
+    // preventDefault されていれば、ページのスクロールやブラウザのズームには渡らない
+    expect(wheel.defaultPrevented).toBe(true);
+    const zoomed = percentOf(percent);
+    expect(zoomed).toBeGreaterThan(fitted);
+    // 背景を押しても閉じない — ドラッグの始点と区別が付かないので
+    await userEvent.click(zoom);
+    await expect.element(zoom).toBeInTheDocument();
   });
 
   it("leaves prose alone", async () => {

--- a/tauri-app/src/components/MarkdownPreview.test.tsx
+++ b/tauri-app/src/components/MarkdownPreview.test.tsx
@@ -1,6 +1,6 @@
 import { render, cleanup } from "@solidjs/testing-library";
 import { page, userEvent } from "vitest/browser";
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import MarkdownPreview from "./MarkdownPreview";
 
 const FLOWCHART = ["```mermaid", "flowchart TD", "  A[Start] --> B[End]", "```"].join("\n");
@@ -12,14 +12,14 @@ describe("MarkdownPreview", () => {
     const { baseElement } = render(() => <MarkdownPreview source={FLOWCHART} />);
     const screen = page.elementLocator(baseElement);
 
-    await expect.element(screen.locator(".mermaid-block svg")).toBeInTheDocument();
+    await expect.element(screen.locator(".mermaid-figure svg")).toBeInTheDocument();
   });
 
   it("opens the diagram full screen when it is tapped", async () => {
     const { baseElement } = render(() => <MarkdownPreview source={FLOWCHART} />);
     const screen = page.elementLocator(baseElement);
 
-    await expect.element(screen.locator(".mermaid-block svg")).toBeInTheDocument();
+    await expect.element(screen.locator(".mermaid-figure svg")).toBeInTheDocument();
     await userEvent.click(screen.locator(".mermaid-block"));
 
     await expect.element(screen.locator(".mermaid-zoom-canvas svg")).toBeInTheDocument();
@@ -29,7 +29,7 @@ describe("MarkdownPreview", () => {
     const { baseElement } = render(() => <MarkdownPreview source={FLOWCHART} />);
     const screen = page.elementLocator(baseElement);
 
-    await expect.element(screen.locator(".mermaid-block svg")).toBeInTheDocument();
+    await expect.element(screen.locator(".mermaid-figure svg")).toBeInTheDocument();
     await userEvent.click(screen.locator(".mermaid-block"));
     await expect.element(screen.locator(".mermaid-zoom")).toBeInTheDocument();
 
@@ -44,5 +44,60 @@ describe("MarkdownPreview", () => {
 
     await expect.element(screen.locator(".markdown-preview h1")).toBeInTheDocument();
     expect(baseElement.querySelector(".mermaid-block")).toBeNull();
+  });
+
+  it("opens the diagram from its zoom tool", async () => {
+    const { baseElement } = render(() => <MarkdownPreview source={FLOWCHART} />);
+    const screen = page.elementLocator(baseElement);
+
+    await expect.element(screen.locator(".mermaid-figure svg")).toBeInTheDocument();
+    await userEvent.click(screen.locator('[data-action="zoom"]'));
+
+    await expect.element(screen.locator(".mermaid-zoom-canvas svg")).toBeInTheDocument();
+  });
+
+  describe("copy tool", () => {
+    const written: string[] = [];
+    const clipboard = Object.getOwnPropertyDescriptor(Navigator.prototype, "clipboard");
+
+    beforeEach(() => {
+      written.length = 0;
+      // ヘッドレスの Chromium はクリップボードへの書き込みを許可しない。
+      // 見たいのは「押したブロックの生ソースが渡ること」だけ
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: {
+          writeText: (text: string) => {
+            written.push(text);
+            return Promise.resolve();
+          },
+        },
+      });
+    });
+
+    afterEach(() => {
+      if (clipboard) {
+        Object.defineProperty(Navigator.prototype, "clipboard", clipboard);
+      }
+      // インスタンス側に置いた上書きを外し、プロトタイプの本物に戻す
+      Reflect.deleteProperty(navigator, "clipboard");
+    });
+
+    it("copies the fence source of the block it sits in", async () => {
+      const source = ["```ts", "const a = 1;", "```", "", "```ts", "const b = 2;", "```"].join(
+        "\n",
+      );
+      const { baseElement } = render(() => <MarkdownPreview source={source} />);
+      const screen = page.elementLocator(baseElement);
+
+      await expect.element(screen.locator("pre").nth(1)).toBeInTheDocument();
+      await userEvent.click(screen.locator('[data-action="copy"]').nth(1));
+
+      await expect.poll(() => written).toStrictEqual(["const b = 2;\n"]);
+      await expect.element(screen.locator('[data-action="copy"]').nth(1)).toHaveClass("is-copied");
+      await expect
+        .element(screen.locator('[data-action="copy"]').nth(0))
+        .not.toHaveClass("is-copied");
+    });
   });
 });

--- a/tauri-app/src/components/MarkdownPreview.test.tsx
+++ b/tauri-app/src/components/MarkdownPreview.test.tsx
@@ -2,9 +2,22 @@ import { render, cleanup } from "@solidjs/testing-library";
 import { page, userEvent } from "vitest/browser";
 import type { Locator } from "vitest/browser";
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { mockIPC, clearMocks } from "@tauri-apps/api/mocks";
 import MarkdownPreview from "./MarkdownPreview";
 
 const FLOWCHART = ["```mermaid", "flowchart TD", "  A[Start] --> B[End]", "```"].join("\n");
+
+/** コマンドに渡った base64 を文字列に戻す */
+function decodeBase64(base64: string): string {
+  return new TextDecoder().decode(
+    Uint8Array.from(atob(base64), (char) => char.codePointAt(0) ?? 0),
+  );
+}
+
+/** SVG の開始タグだけ。mermaid の <style> の中の max-width は図の体裁で、見たいのはルートの属性 */
+function openingTagOf(svg: string): string {
+  return svg.match(/^<svg[^>]*>/u)?.[0] ?? "";
+}
 
 /** 右下の倍率表示を数で読む */
 function percentOf(locator: Locator): number {
@@ -112,6 +125,65 @@ describe("MarkdownPreview", () => {
     await userEvent.click(screen.locator('[data-action="zoom"]'));
 
     await expect.element(screen.locator(".mermaid-zoom-canvas svg")).toBeInTheDocument();
+  });
+
+  describe("export tools", () => {
+    const calls: { cmd: string; args: Record<string, unknown> }[] = [];
+
+    beforeEach(() => {
+      calls.length = 0;
+      mockIPC((cmd, args) => {
+        calls.push({ cmd, args: (args ?? {}) as Record<string, unknown> });
+        return { saved: true };
+      });
+    });
+
+    afterEach(() => clearMocks());
+
+    it("hands the sized svg to the save command, named after the note", async () => {
+      const { baseElement } = render(() => (
+        <MarkdownPreview source={FLOWCHART} exportStem="20260903_101010" />
+      ));
+      const screen = page.elementLocator(baseElement);
+
+      await expect.element(screen.locator(".mermaid-figure svg")).toBeInTheDocument();
+      await userEvent.click(screen.locator('[data-action="svg"]'));
+
+      await expect.poll(() => calls.map((call) => call.cmd)).toStrictEqual(["save_export"]);
+      expect(calls[0].args.suggestedName).toBe("20260903_101010-1.svg");
+      const opening = openingTagOf(decodeBase64(calls[0].args.dataBase64 as string));
+      expect(opening).toContain('xmlns="http://www.w3.org/2000/svg"');
+      expect(opening).not.toContain("max-width");
+    });
+
+    it("hands a png to the save command", async () => {
+      const { baseElement } = render(() => <MarkdownPreview source={FLOWCHART} />);
+      const screen = page.elementLocator(baseElement);
+
+      await expect.element(screen.locator(".mermaid-figure svg")).toBeInTheDocument();
+      await userEvent.click(screen.locator('[data-action="png"]'));
+
+      await expect.poll(() => calls.map((call) => call.cmd)).toStrictEqual(["save_export"]);
+      expect(calls[0].args.suggestedName).toBe("diagram-1.png");
+      // PNG の先頭 8 バイト (\x89PNG\r\n\x1a\n) の base64
+      expect(calls[0].args.dataBase64).toMatch(/^iVBORw0KGgo/u);
+    });
+
+    it("reports a failed save instead of staying silent", async () => {
+      mockIPC(() => {
+        throw new Error("disk full");
+      });
+      const errors: string[] = [];
+      const { baseElement } = render(() => (
+        <MarkdownPreview source={FLOWCHART} onError={(message) => errors.push(message)} />
+      ));
+      const screen = page.elementLocator(baseElement);
+
+      await expect.element(screen.locator(".mermaid-figure svg")).toBeInTheDocument();
+      await userEvent.click(screen.locator('[data-action="svg"]'));
+
+      await expect.poll(() => errors).toStrictEqual(["図を保存できませんでした"]);
+    });
   });
 
   describe("copy tool", () => {

--- a/tauri-app/src/components/MarkdownPreview.tsx
+++ b/tauri-app/src/components/MarkdownPreview.tsx
@@ -82,9 +82,18 @@ export default function MarkdownPreview(props: MarkdownPreviewProps): JSX.Elemen
   // 押されたときだけ原寸で開く
   const openZoom = (from: Element): void => {
     const svg = from.closest(".mermaid-block")?.querySelector("svg");
-    if (svg) {
-      setZoomed({ svg: svg.outerHTML, width: svg.style.maxWidth });
+    if (!svg) {
+      return;
     }
+    // 原寸は viewBox。mermaid が max-width に書く値と同じだが、数値で欲しい。
+    // viewBox を持たない SVG は縮めて描いている今の大きさを原寸とみなす
+    const box = svg.viewBox.baseVal;
+    const rect = svg.getBoundingClientRect();
+    setZoomed({
+      svg: svg.outerHTML,
+      width: box.width > 0 ? box.width : rect.width,
+      height: box.height > 0 ? box.height : rect.height,
+    });
   };
 
   /** 道具は描画結果の中に静的な HTML で居るので、押されたものをここで 1 か所で受ける */

--- a/tauri-app/src/components/MarkdownPreview.tsx
+++ b/tauri-app/src/components/MarkdownPreview.tsx
@@ -1,12 +1,15 @@
 import { createSignal, createEffect, on, onCleanup, Show } from "solid-js";
 import copyIcon from "@phosphor-icons/core/assets/regular/copy.svg?raw";
 import checkIcon from "@phosphor-icons/core/assets/regular/check.svg?raw";
+import { typedInvoke } from "../lib/commands";
 import { createCopyFeedback } from "../lib/copy-feedback";
+import { exportName, rasterize, sizedSvg, textToBase64 } from "../lib/diagram-export";
 import { t } from "../lib/i18n";
 import { renderMarkdown } from "../lib/markdown";
 import { resolvedTheme } from "../lib/theme";
 import DiagramZoom from "./DiagramZoom";
 import "../styles/markdown-preview.css";
+import type { ExportFormat } from "../lib/diagram-export";
 import type { ZoomedDiagram } from "./DiagramZoom";
 import type { JSX } from "solid-js";
 
@@ -16,15 +19,33 @@ interface MarkdownPreviewProps {
   noteTitles?: ReadonlyMap<string, string>;
   /** `:name:` を画像で描くための登録表。無ければ保存形のまま出る。 */
   glyphs?: ReadonlyMap<string, string>;
+  /** 図を書き出すときのファイル名の頭。ノートの stem。無ければ generic な名前 */
+  exportStem?: string;
+  /** 書き出しに失敗したとき、利用者に見せる文。無ければ黙って失敗する */
+  onError?: (message: string) => void;
 }
 
 /** コピー後にチェック表示を戻すまでの時間。エディタの node view と同じ */
 const COPY_RESET_MS = 1500;
 
+/** 押された道具が属する図。道具のアイコンも svg なので、図の入れ物で絞る */
+function diagramOf(from: Element): { figure: Element; svg: SVGSVGElement } | undefined {
+  const figure = from.closest(".mermaid-block");
+  const svg = figure?.querySelector<SVGSVGElement>(".mermaid-figure svg");
+  return figure && svg ? { figure, svg } : undefined;
+}
+
+/** PNG の下地。透明のままだと暗い背景のビューアで線が消える */
+function surfaceColor(): string {
+  const color = getComputedStyle(document.documentElement).getPropertyValue("--app-surface");
+  return color.trim() || "#ffffff";
+}
+
 export default function MarkdownPreview(props: MarkdownPreviewProps): JSX.Element {
   const [html, setHtml] = createSignal("");
   const [zoomed, setZoomed] = createSignal<ZoomedDiagram | undefined>();
 
+  let root: HTMLDivElement | undefined;
   let renderVersion = 0;
 
   createEffect(
@@ -81,12 +102,13 @@ export default function MarkdownPreview(props: MarkdownPreviewProps): JSX.Elemen
   // 図は本文と違って折り返せない。狭い画面では幅に合わせて縮めておき、
   // 押されたときだけ原寸で開く
   const openZoom = (from: Element): void => {
-    const svg = from.closest(".mermaid-block")?.querySelector("svg");
-    if (!svg) {
+    const diagram = diagramOf(from);
+    if (!diagram) {
       return;
     }
     // 原寸は viewBox。mermaid が max-width に書く値と同じだが、数値で欲しい。
     // viewBox を持たない SVG は縮めて描いている今の大きさを原寸とみなす
+    const { svg } = diagram;
     const box = svg.viewBox.baseVal;
     const rect = svg.getBoundingClientRect();
     setZoomed({
@@ -94,6 +116,27 @@ export default function MarkdownPreview(props: MarkdownPreviewProps): JSX.Elemen
       width: box.width > 0 ? box.width : rect.width,
       height: box.height > 0 ? box.height : rect.height,
     });
+  };
+
+  /** ネイティブの保存ダイアログへ。キャンセルは失敗ではないので何も言わない */
+  const exportDiagram = async (from: Element, format: ExportFormat): Promise<void> => {
+    const diagram = diagramOf(from);
+    if (!diagram) {
+      return;
+    }
+    const figures = [...(root?.querySelectorAll(".mermaid-block") ?? [])];
+    const index = figures.indexOf(diagram.figure) + 1;
+    try {
+      const source = diagram.svg.outerHTML;
+      const dataBase64 =
+        format === "svg" ? textToBase64(sizedSvg(source)) : await rasterize(source, surfaceColor());
+      await typedInvoke("save_export", {
+        suggestedName: exportName(props.exportStem, index, format),
+        dataBase64,
+      });
+    } catch {
+      props.onError?.(t().preview.exportFailed);
+    }
   };
 
   /** 道具は描画結果の中に静的な HTML で居るので、押されたものをここで 1 か所で受ける */
@@ -118,6 +161,11 @@ export default function MarkdownPreview(props: MarkdownPreviewProps): JSX.Elemen
         openZoom(tool);
         break;
       }
+      case "svg":
+      case "png": {
+        void exportDiagram(tool, tool.dataset.action);
+        break;
+      }
       default: {
         break;
       }
@@ -126,7 +174,13 @@ export default function MarkdownPreview(props: MarkdownPreviewProps): JSX.Elemen
 
   return (
     <>
-      <div class="markdown-preview" innerHTML={html()} onClick={onClick} role="presentation" />
+      <div
+        ref={root}
+        class="markdown-preview"
+        innerHTML={html()}
+        onClick={onClick}
+        role="presentation"
+      />
 
       <Show when={zoomed()}>
         {(diagram) => <DiagramZoom diagram={diagram()} onClose={() => setZoomed(undefined)} />}

--- a/tauri-app/src/components/MarkdownPreview.tsx
+++ b/tauri-app/src/components/MarkdownPreview.tsx
@@ -1,4 +1,8 @@
-import { createSignal, createEffect, on, Show } from "solid-js";
+import { createSignal, createEffect, on, onCleanup, Show } from "solid-js";
+import copyIcon from "@phosphor-icons/core/assets/regular/copy.svg?raw";
+import checkIcon from "@phosphor-icons/core/assets/regular/check.svg?raw";
+import { createCopyFeedback } from "../lib/copy-feedback";
+import { t } from "../lib/i18n";
 import { renderMarkdown } from "../lib/markdown";
 import { resolvedTheme } from "../lib/theme";
 import DiagramZoom from "./DiagramZoom";
@@ -14,6 +18,9 @@ interface MarkdownPreviewProps {
   glyphs?: ReadonlyMap<string, string>;
 }
 
+/** コピー後にチェック表示を戻すまでの時間。エディタの node view と同じ */
+const COPY_RESET_MS = 1500;
+
 export default function MarkdownPreview(props: MarkdownPreviewProps): JSX.Element {
   const [html, setHtml] = createSignal("");
   const [zoomed, setZoomed] = createSignal<ZoomedDiagram | undefined>();
@@ -22,8 +29,9 @@ export default function MarkdownPreview(props: MarkdownPreviewProps): JSX.Elemen
 
   createEffect(
     on(
-      // mermaid はテーマの色を SVG に焼き込むので、切り替えたら描き直すしかない
-      () => [props.source, resolvedTheme(), props.noteTitles, props.glyphs] as const,
+      // mermaid はテーマの色を SVG に焼き込むので、切り替えたら描き直すしかない。
+      // 道具のラベルも描画結果に焼き込まれるので、言語が変わっても描き直す
+      () => [props.source, resolvedTheme(), props.noteTitles, props.glyphs, t()] as const,
       async ([source, , noteTitles, glyphs]) => {
         const currentVersion = ++renderVersion;
         if (!source) {
@@ -38,19 +46,78 @@ export default function MarkdownPreview(props: MarkdownPreviewProps): JSX.Elemen
     ),
   );
 
+  // 「コピー済み」を出しているボタン。道具は innerHTML の中にあるので signal では
+  // 持てず、押されたボタンそのものに印を付ける。描き直しで外れても構わない
+  let copiedButton: HTMLElement | undefined;
+
+  const applyCopyState = (copied: boolean): void => {
+    if (!copiedButton) {
+      return;
+    }
+    copiedButton.classList.toggle("is-copied", copied);
+    copiedButton.innerHTML = copied ? checkIcon : copyIcon;
+  };
+
+  const copyFeedback = createCopyFeedback(
+    (text) => navigator.clipboard.writeText(text),
+    applyCopyState,
+    COPY_RESET_MS,
+  );
+  onCleanup(() => copyFeedback.dispose());
+
+  const copyBlock = (button: HTMLElement): void => {
+    const source = button.closest("pre")?.dataset.source;
+    if (source === undefined) {
+      return;
+    }
+    // 別のブロックへ移ったら前の印は下ろす。戻すタイマーは最後の 1 回分しか無い
+    if (copiedButton !== button) {
+      applyCopyState(false);
+      copiedButton = button;
+    }
+    copyFeedback.copy(source);
+  };
+
   // 図は本文と違って折り返せない。狭い画面では幅に合わせて縮めておき、
   // 押されたときだけ原寸で開く
-  const openZoom = (e: MouseEvent): void => {
-    const target = e.target instanceof Element ? e.target : null;
-    const svg = target?.closest(".mermaid-block")?.querySelector("svg");
+  const openZoom = (from: Element): void => {
+    const svg = from.closest(".mermaid-block")?.querySelector("svg");
     if (svg) {
       setZoomed({ svg: svg.outerHTML, width: svg.style.maxWidth });
     }
   };
 
+  /** 道具は描画結果の中に静的な HTML で居るので、押されたものをここで 1 か所で受ける */
+  const onClick = (e: MouseEvent): void => {
+    const target = e.target instanceof Element ? e.target : null;
+    if (!target) {
+      return;
+    }
+    const tool = target.closest<HTMLElement>("[data-action]");
+    if (!tool) {
+      if (target.closest(".mermaid-block")) {
+        openZoom(target);
+      }
+      return;
+    }
+    switch (tool.dataset.action) {
+      case "copy": {
+        copyBlock(tool);
+        break;
+      }
+      case "zoom": {
+        openZoom(tool);
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+  };
+
   return (
     <>
-      <div class="markdown-preview" innerHTML={html()} onClick={openZoom} role="presentation" />
+      <div class="markdown-preview" innerHTML={html()} onClick={onClick} role="presentation" />
 
       <Show when={zoomed()}>
         {(diagram) => <DiagramZoom diagram={diagram()} onClose={() => setZoomed(undefined)} />}

--- a/tauri-app/src/lib/commands.ts
+++ b/tauri-app/src/lib/commands.ts
@@ -193,6 +193,11 @@ interface CommandMap {
   get_sync_config: { args: void; result: SyncConfig };
   save_sync_config: { args: { config: SyncConfig }; result: void };
   is_sync_config_editable: { args: void; result: boolean };
+  /**
+   * 図の書き出し。保存ダイアログを出し、選ばれた場所に書く。ノートには
+   * 触れないので MUTATING には入れない。`saved: false` はキャンセル。
+   */
+  save_export: { args: { suggestedName: string; dataBase64: string }; result: { saved: boolean } };
 }
 
 export type CommandName = keyof CommandMap;

--- a/tauri-app/src/lib/diagram-export.test.ts
+++ b/tauri-app/src/lib/diagram-export.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { exportName, naturalSize, rasterize, sizedSvg, textToBase64 } from "./diagram-export";
+
+/** mermaid が返す形。width 100% と max-width で本文幅に収まるようにしてある */
+const MERMAID_SVG =
+  '<svg id="mermaid-1" width="100%" viewBox="0 0 320.5 120" ' +
+  'style="max-width: 320.5px;" role="graphics-document">' +
+  '<rect x="0" y="0" width="320" height="120" fill="#fff"></rect>' +
+  "<text>A&nbsp;B</text></svg>";
+
+function bytesOf(base64: string): Uint8Array {
+  return Uint8Array.from(atob(base64), (char) => char.codePointAt(0) ?? 0);
+}
+
+describe("naturalSize", () => {
+  it("reads the viewBox", () => {
+    expect(naturalSize(MERMAID_SVG)).toStrictEqual({ width: 320.5, height: 120 });
+  });
+
+  it("has no answer for an svg without a viewBox", () => {
+    expect(naturalSize("<svg></svg>")).toBeUndefined();
+  });
+});
+
+describe("sizedSvg", () => {
+  it("pins width and height to the viewBox and drops the max-width", () => {
+    const sized = sizedSvg(MERMAID_SVG);
+
+    expect(sized).toContain('width="321"');
+    expect(sized).toContain('height="120"');
+    expect(sized).not.toContain("max-width");
+    expect(sized).not.toContain("style=");
+  });
+
+  it("writes a standalone svg document", () => {
+    const sized = sizedSvg(MERMAID_SVG);
+
+    // 名前空間が無いと、単体のファイルとして開いたビューアは画像と認識しない
+    expect(sized).toMatch(/^<svg[^>]* xmlns="http:\/\/www\.w3\.org\/2000\/svg"/u);
+    // HTML の実体は文字(U+00A0)に直っている。XML の中で &nbsp; は未定義
+    expect(sized).not.toContain("&nbsp;");
+    expect(sized).toContain("A\u00A0B");
+  });
+
+  it("refuses anything that is not an svg", () => {
+    expect(() => sizedSvg("<p>no</p>")).toThrow("not an svg");
+  });
+});
+
+describe("rasterize", () => {
+  it("draws a png at twice the natural size", async () => {
+    const base64 = await rasterize(MERMAID_SVG, "#ffffff");
+
+    // PNG の先頭 8 バイト (\x89PNG\r\n\x1a\n)
+    expect(base64).toMatch(/^iVBORw0KGgo/u);
+    const bitmap = await createImageBitmap(new Blob([bytesOf(base64)], { type: "image/png" }));
+    expect([bitmap.width, bitmap.height]).toStrictEqual([641, 240]);
+  });
+});
+
+describe("exportName", () => {
+  it("names the file after the note and the diagram's position", () => {
+    expect(exportName("20260903_101010", 2, "svg")).toBe("20260903_101010-2.svg");
+  });
+
+  it("falls back to a generic name when there is no note", () => {
+    expect(exportName(undefined, 1, "png")).toBe("diagram-1.png");
+  });
+});
+
+describe("textToBase64", () => {
+  it("encodes text as utf-8 bytes", () => {
+    expect(textToBase64("図")).toBe("5Zuz");
+  });
+
+  it("copes with a payload larger than a call's argument limit", () => {
+    const big = "<svg>".padEnd(300_000, "x");
+
+    expect(new TextDecoder().decode(bytesOf(textToBase64(big)))).toBe(big);
+  });
+});

--- a/tauri-app/src/lib/diagram-export.ts
+++ b/tauri-app/src/lib/diagram-export.ts
@@ -1,0 +1,109 @@
+/**
+ * 描画済みの図(mermaid の SVG)をファイルにできる形に整える。保存そのものは
+ * `save_export` コマンド(ネイティブの保存ダイアログ)に渡すので、ここから
+ * 出るのはコマンドに渡す base64 まで。
+ */
+
+export interface Size {
+  width: number;
+  height: number;
+}
+
+export type ExportFormat = "svg" | "png";
+
+/** PNG の解像度。原寸のままだと Retina で文字がにじむ */
+const PNG_SCALE = 2;
+
+/**
+ * mermaid の出力は HTML としてシリアライズされているので、XML として読むと
+ * `&nbsp;` などで壊れることがある。HTML として読み、書き出すときに XML に
+ * 直す — XMLSerializer が名前空間を補うので、単体の .svg として開ける
+ */
+function parseSvg(svg: string): SVGSVGElement | undefined {
+  const doc = new DOMParser().parseFromString(svg, "text/html");
+  return doc.querySelector("svg") ?? undefined;
+}
+
+/** 原寸。mermaid は viewBox にも style の max-width にも同じ値を書く */
+export function naturalSize(svg: string): Size | undefined {
+  const box = parseSvg(svg)?.viewBox.baseVal;
+  if (!box || box.width <= 0 || box.height <= 0) {
+    return undefined;
+  }
+  return { width: box.width, height: box.height };
+}
+
+/**
+ * 単体のファイルとして開いたときに原寸で出るよう、viewBox の実寸を
+ * width / height に入れ、mermaid が本文用に付けた `max-width` を外す。
+ * 外さないとビューアによっては幅 100% で開いて縦横比が崩れる
+ */
+export function sizedSvg(svg: string): string {
+  const element = parseSvg(svg);
+  if (!element) {
+    throw new Error("not an svg");
+  }
+  const size = naturalSize(svg);
+  if (size) {
+    element.setAttribute("width", String(Math.round(size.width)));
+    element.setAttribute("height", String(Math.round(size.height)));
+  }
+  element.style.maxWidth = "";
+  if (element.getAttribute("style") === "") {
+    element.removeAttribute("style");
+  }
+  return new XMLSerializer().serializeToString(element);
+}
+
+/**
+ * 文字列を UTF-8 のバイト列として base64 に。`btoa` は Latin-1 しか受けないので
+ * 一度バイトにする。spread で一気に渡さないのは、大きな図で引数の数が
+ * 呼び出しの上限を超えるため
+ */
+export function textToBase64(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCodePoint(byte);
+  }
+  return btoa(binary);
+}
+
+/**
+ * SVG を PNG に描き、base64 で返す。`background` で塗るのは、透明のままだと
+ * 暗い背景のビューアで線が消えるため。画像は data URL で読む — Blob URL でも
+ * 描けるが、同一生成元の扱いが環境で揺れ、canvas が汚染されると書き出せない
+ */
+export async function rasterize(svg: string, background: string): Promise<string> {
+  const sized = sizedSvg(svg);
+  const size = naturalSize(sized);
+  if (!size) {
+    throw new Error("svg has no size");
+  }
+  const image = new Image();
+  image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(sized)}`;
+  await image.decode();
+
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.round(size.width * PNG_SCALE);
+  canvas.height = Math.round(size.height * PNG_SCALE);
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new Error("canvas is unavailable");
+  }
+  context.fillStyle = background;
+  context.fillRect(0, 0, canvas.width, canvas.height);
+  context.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+  // toBlob と違って同期で、結果はそのまま base64。汚染されていれば例外
+  const dataUrl = canvas.toDataURL("image/png");
+  return dataUrl.slice(dataUrl.indexOf(",") + 1);
+}
+
+/**
+ * 保存ダイアログに出す名前。ノートの stem と何番目の図かで決める —
+ * 固定名だと 1 つのノートの 2 枚目で上書きを聞かれる
+ */
+export function exportName(stem: string | undefined, index: number, format: ExportFormat): string {
+  return `${stem ?? "diagram"}-${index}.${format}`;
+}

--- a/tauri-app/src/lib/i18n.ts
+++ b/tauri-app/src/lib/i18n.ts
@@ -236,6 +236,10 @@ const ja = {
   },
   preview: {
     zoom: "拡大",
+    zoomIn: "大きく",
+    zoomOut: "小さく",
+    fit: "全体表示",
+    zoomHint: "ホイールでズーム / ドラッグで移動 / Esc で閉じる",
   },
   firstRun: {
     title: "同期はあとからでも設定できます",
@@ -504,6 +508,10 @@ const en: Messages = {
   },
   preview: {
     zoom: "Zoom",
+    zoomIn: "Zoom in",
+    zoomOut: "Zoom out",
+    fit: "Fit",
+    zoomHint: "Scroll to zoom / drag to pan / Esc to close",
   },
   firstRun: {
     title: "You can set up sync later",

--- a/tauri-app/src/lib/i18n.ts
+++ b/tauri-app/src/lib/i18n.ts
@@ -234,6 +234,9 @@ const ja = {
     exitBlock: "ブロックから抜ける",
     deleteBlock: "ブロックを削除",
   },
+  preview: {
+    zoom: "拡大",
+  },
   firstRun: {
     title: "同期はあとからでも設定できます",
     body: "設定しなければ、書いたものはこの端末の中だけに残ります。それで困らないなら、このまま使い始めて構いません。",
@@ -498,6 +501,9 @@ const en: Messages = {
     diagramFailed: "Cannot draw this diagram",
     exitBlock: "Leave the block",
     deleteBlock: "Delete the block",
+  },
+  preview: {
+    zoom: "Zoom",
   },
   firstRun: {
     title: "You can set up sync later",

--- a/tauri-app/src/lib/i18n.ts
+++ b/tauri-app/src/lib/i18n.ts
@@ -240,6 +240,9 @@ const ja = {
     zoomOut: "小さく",
     fit: "全体表示",
     zoomHint: "ホイールでズーム / ドラッグで移動 / Esc で閉じる",
+    saveSvg: "SVG で保存",
+    savePng: "PNG で保存",
+    exportFailed: "図を保存できませんでした",
   },
   firstRun: {
     title: "同期はあとからでも設定できます",
@@ -512,6 +515,9 @@ const en: Messages = {
     zoomOut: "Zoom out",
     fit: "Fit",
     zoomHint: "Scroll to zoom / drag to pan / Esc to close",
+    saveSvg: "Save as SVG",
+    savePng: "Save as PNG",
+    exportFailed: "Could not save the diagram",
   },
   firstRun: {
     title: "You can set up sync later",

--- a/tauri-app/src/lib/markdown.test.ts
+++ b/tauri-app/src/lib/markdown.test.ts
@@ -128,6 +128,37 @@ describe("renderMarkdown", () => {
     expect(html).toContain('class="diff-line diff-add"');
   });
 
+  // コピーは innerHTML の中の 1 つのハンドラが拾う。押されたブロックの
+  // 生ソースは DOM から引けないと、描画結果から逆算することになる
+  it("hangs a copy tool and the fence source on a highlighted block", async () => {
+    const source = ["```ts", 'const a = "<b>";', "```"].join("\n");
+
+    const html = await renderMarkdown(source);
+
+    expect(html).toMatch(
+      /<pre class="shiki[^>]* data-source="const a = &quot;&lt;b&gt;&quot;;\n"/u,
+    );
+    expect(html).toContain('data-action="copy"');
+    expect(html).toContain('<span class="preview-tools-lang">ts</span>');
+    // 道具はブロックの中に置く。外に置くと pre の位置決めの基準にならない
+    expect(html.indexOf('data-action="copy"')).toBeLessThan(html.lastIndexOf("</pre>"));
+  });
+
+  it("hangs the same copy tool on a diff fence", async () => {
+    const source = ["```diff", "+new", "```"].join("\n");
+
+    const html = await renderMarkdown(source);
+
+    expect(html).toContain('<pre data-source="+new\n"><code>');
+    expect(html).toContain('data-action="copy"');
+  });
+
+  it("names the copy tool in the current language", async () => {
+    const html = await renderMarkdown(["```ts", "1", "```"].join("\n"));
+
+    expect(html).toContain('aria-label="コードをコピー"');
+  });
+
   // 種類ごとに別の配列へ振り分けて描くので、戻すときの番号がずれやすい
   it("keeps a diff fence in source order next to a highlighted one", async () => {
     const source = ["```diff", "+added", "```", "", "```ts", "const a = 1;", "```"].join("\n");
@@ -156,7 +187,7 @@ describe("renderMarkdown with mermaid", () => {
 
     const html = await renderMarkdown(source);
 
-    expect(html).not.toContain("<svg");
+    expect(html).not.toContain('class="mermaid-block"');
     expect(html).toContain("これは図ではない");
   });
 
@@ -191,6 +222,13 @@ describe("renderMarkdown with mermaid", () => {
     const html = await renderMarkdown(FLOWCHART);
 
     expect(html).not.toContain("<figcaption");
+  });
+
+  it("puts the zoom tool inside the figure", async () => {
+    const html = await renderMarkdown(FLOWCHART);
+
+    expect(html.indexOf('data-action="zoom"')).toBeGreaterThan(html.indexOf("<figure"));
+    expect(html.indexOf('data-action="zoom"')).toBeLessThan(html.indexOf("</figure>"));
   });
 
   it("keeps diagrams and code blocks in source order", async () => {

--- a/tauri-app/src/lib/markdown.test.ts
+++ b/tauri-app/src/lib/markdown.test.ts
@@ -224,11 +224,14 @@ describe("renderMarkdown with mermaid", () => {
     expect(html).not.toContain("<figcaption");
   });
 
-  it("puts the zoom tool inside the figure", async () => {
+  it("puts the zoom and export tools inside the figure", async () => {
     const html = await renderMarkdown(FLOWCHART);
 
-    expect(html.indexOf('data-action="zoom"')).toBeGreaterThan(html.indexOf("<figure"));
-    expect(html.indexOf('data-action="zoom"')).toBeLessThan(html.indexOf("</figure>"));
+    for (const action of ["zoom", "svg", "png"]) {
+      const at = html.indexOf(`data-action="${action}"`);
+      expect(at).toBeGreaterThan(html.indexOf("<figure"));
+      expect(at).toBeLessThan(html.indexOf("</figure>"));
+    }
   });
 
   it("keeps diagrams and code blocks in source order", async () => {

--- a/tauri-app/src/lib/markdown.ts
+++ b/tauri-app/src/lib/markdown.ts
@@ -120,7 +120,11 @@ function codeBlock(pre: string, block: FenceBlock): string {
 }
 
 function diagramTools(): string {
-  return `<div class="preview-tools">${toolButton("zoom", t().preview.zoom, cornersOutIcon)}</div>`;
+  const { preview } = t();
+  return (
+    `<div class="preview-tools">${toolButton("zoom", preview.zoom, cornersOutIcon)}` +
+    `${toolButton("svg", preview.saveSvg, "SVG")}${toolButton("png", preview.savePng, "PNG")}</div>`
+  );
 }
 
 fenceMd.renderer.rules.fence = (tokens, idx, _options, renderEnv) => {

--- a/tauri-app/src/lib/markdown.ts
+++ b/tauri-app/src/lib/markdown.ts
@@ -1,8 +1,11 @@
 import MarkdownIt from "markdown-it";
 import type { Env, MarkdownIt as MarkdownItInstance } from "markdown-it";
+import copyIcon from "@phosphor-icons/core/assets/regular/copy.svg?raw";
+import cornersOutIcon from "@phosphor-icons/core/assets/regular/corners-out.svg?raw";
 import { extractCaption } from "./diagram-caption";
 import { renderDiffBlock } from "./diff-block";
 import { glyphPlugin } from "./glyph-markdown";
+import { t } from "./i18n";
 import { renderDiagrams } from "./mermaid";
 import { noteLinkPlugin } from "./note-link-markdown";
 import { isPreservedEmptyLine } from "./preserved-empty-line";
@@ -81,6 +84,45 @@ function plainBlock(code: string): string {
   return `<pre><code>${fenceMd.utils.escapeHtml(code)}</code></pre>`;
 }
 
+/**
+ * ホバーで現れる操作。描画結果は innerHTML に流すので SolidJS の部品は置けず、
+ * node view (code-block-view-plugin.ts) と同じく raw の SVG 文字列を埋める。
+ * 押されたときの処理は MarkdownPreview が data-action で受ける。
+ */
+function toolButton(action: string, label: string, content: string): string {
+  const escaped = fenceMd.utils.escapeHtml(label);
+  return (
+    `<button type="button" class="preview-tool" data-action="${action}" ` +
+    `title="${escaped}" aria-label="${escaped}">${content}</button>`
+  );
+}
+
+/**
+ * コードブロックにコピーの道具と生ソースを付ける。ソースを DOM に持たせるのは、
+ * 押されたブロックの中身を描画結果から逆算しないため — diff の行は改行を
+ * 持たない div なので textContent では戻らない。
+ * 道具は pre の中に置く(node view と同じ構造)。外に包むと、閲覧とエディタで
+ * ブロック直下の要素が変わり、幾何を突き合わせる前提が崩れる。
+ */
+function codeBlock(pre: string, block: FenceBlock): string {
+  const openEnd = pre.indexOf(">");
+  const end = pre.lastIndexOf("</pre>");
+  if (!pre.startsWith("<pre") || openEnd === -1 || end === -1) {
+    return pre;
+  }
+  const lang = block.lang
+    ? `<span class="preview-tools-lang">${fenceMd.utils.escapeHtml(block.lang)}</span>`
+    : "";
+  const tools = `<div class="preview-tools">${lang}${toolButton("copy", t().editor.copyCode, copyIcon)}</div>`;
+  // Shiki の付けた class を先頭に残す。後ろに足せば `<pre class="shiki` で数えられる
+  const source = fenceMd.utils.escapeHtml(block.code);
+  return `${pre.slice(0, openEnd)} data-source="${source}"${pre.slice(openEnd, end)}${tools}${pre.slice(end)}`;
+}
+
+function diagramTools(): string {
+  return `<div class="preview-tools">${toolButton("zoom", t().preview.zoom, cornersOutIcon)}</div>`;
+}
+
 fenceMd.renderer.rules.fence = (tokens, idx, _options, renderEnv) => {
   const token = tokens[idx];
   // `render()` は env を必ず渡すが、型の上では省略できることになっている。
@@ -134,7 +176,10 @@ function diagramBlock(svg: string, source: string): string {
   const figcaption = caption
     ? `<figcaption class="mermaid-caption">${fenceMd.utils.escapeHtml(caption)}</figcaption>`
     : "";
-  return `<figure class="mermaid-block"><div class="mermaid-figure">${svg}</div>${figcaption}</figure>`;
+  return (
+    `<figure class="mermaid-block"><div class="mermaid-figure">${svg}</div>` +
+    `${figcaption}${diagramTools()}</figure>`
+  );
 }
 
 type FenceKind = "diagram" | "diff" | "code";
@@ -168,14 +213,15 @@ async function renderFences(blocks: FenceBlock[]): Promise<string[]> {
   return blocks.map((block, index) => {
     switch (kinds[index]) {
       case "diff": {
-        return renderDiffBlock(block.code);
+        return codeBlock(renderDiffBlock(block.code), block);
       }
       case "code": {
-        return highlighted[codeIndex++];
+        return codeBlock(highlighted[codeIndex++], block);
       }
       default: {
         const svg = svgs[diagramIndex++];
-        return svg ? diagramBlock(svg, block.code) : plainBlock(block.code);
+        // 描けなかった図はソースを読ませる。読めるなら写せてもよい
+        return svg ? diagramBlock(svg, block.code) : codeBlock(plainBlock(block.code), block);
       }
     }
   });

--- a/tauri-app/src/lib/mermaid.ts
+++ b/tauri-app/src/lib/mermaid.ts
@@ -96,6 +96,10 @@ export async function renderDiagrams(sources: string[]): Promise<(string | null)
     startOnLoad: false,
     // ノートは同期先から降ってくることもある。ラベルの HTML は DOMPurify に通す
     securityLevel: "strict",
+    // ラベルを foreignObject(HTML)ではなく SVG の text で描く。foreignObject が
+    // あると PNG に描くときに canvas が汚染されて書き出せない。ラベル内の
+    // <br/> や太字の見え方は変わる
+    flowchart: { htmlLabels: false },
     ...themeConfig(),
   });
 

--- a/tauri-app/src/lib/zoom-transform.test.ts
+++ b/tauri-app/src/lib/zoom-transform.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import {
+  MAX_SCALE,
+  MIN_SCALE,
+  fitToViewport,
+  toCss,
+  wheelFactor,
+  zoomAtPoint,
+} from "./zoom-transform";
+import type { Transform } from "./zoom-transform";
+
+const VIEWPORT = { width: 1000, height: 800 };
+
+/** 画面上の点 → 図の座標。ズームの前後でこれが動かなければ、その点を軸に拡大している */
+function diagramPoint(transform: Transform, x: number, y: number): [number, number] {
+  return [(x - transform.tx) / transform.scale, (y - transform.ty) / transform.scale];
+}
+
+describe("fitToViewport", () => {
+  it("shrinks a wide diagram until it sits inside the padded viewport", () => {
+    const transform = fitToViewport(VIEWPORT, { width: 2000, height: 400 });
+
+    // (1000 - 96) / 2000
+    expect(transform.scale).toBeCloseTo(0.452);
+    expect(transform.tx).toBeCloseTo((1000 - 2000 * 0.452) / 2);
+    expect(transform.ty).toBeCloseTo((800 - 400 * 0.452) / 2);
+  });
+
+  it("does not blow a small diagram up past twice its size", () => {
+    const transform = fitToViewport(VIEWPORT, { width: 100, height: 100 });
+
+    expect(transform.scale).toBe(2);
+    expect(transform.tx).toBe(400);
+    expect(transform.ty).toBe(300);
+  });
+
+  it("never goes below the minimum on a viewport smaller than the padding", () => {
+    const transform = fitToViewport({ width: 50, height: 50 }, { width: 100, height: 100 });
+
+    expect(transform.scale).toBe(MIN_SCALE);
+  });
+});
+
+describe("zoomAtPoint", () => {
+  const start: Transform = { scale: 1, tx: 100, ty: 50 };
+
+  it("keeps the point under the cursor where it is", () => {
+    const before = diagramPoint(start, 300, 200);
+
+    const zoomed = zoomAtPoint(start, { x: 300, y: 200 }, 1.6);
+
+    expect(zoomed.scale).toBeCloseTo(1.6);
+    const after = diagramPoint(zoomed, 300, 200);
+    expect(after[0]).toBeCloseTo(before[0]);
+    expect(after[1]).toBeCloseTo(before[1]);
+  });
+
+  it("stops at the maximum scale", () => {
+    const zoomed = zoomAtPoint(start, { x: 0, y: 0 }, 1000);
+
+    expect(zoomed.scale).toBe(MAX_SCALE);
+  });
+
+  it("stops at the minimum scale", () => {
+    const zoomed = zoomAtPoint(start, { x: 0, y: 0 }, 0.0001);
+
+    expect(zoomed.scale).toBe(MIN_SCALE);
+  });
+
+  it("leaves the transform alone when clamping changes nothing", () => {
+    const atMax: Transform = { scale: MAX_SCALE, tx: -10, ty: -20 };
+
+    expect(zoomAtPoint(atMax, { x: 5, y: 5 }, 2)).toStrictEqual(atMax);
+  });
+});
+
+describe("wheelFactor", () => {
+  it("zooms in when the wheel rolls away from the user", () => {
+    expect(wheelFactor(-100, false)).toBeGreaterThan(1);
+    expect(wheelFactor(100, false)).toBeLessThan(1);
+  });
+
+  it("moves faster for a trackpad pinch (ctrl + wheel)", () => {
+    expect(wheelFactor(-100, true)).toBeGreaterThan(wheelFactor(-100, false));
+  });
+});
+
+describe("toCss", () => {
+  it("translates before it scales, so tx/ty stay in screen pixels", () => {
+    expect(toCss({ scale: 1.5, tx: 10, ty: -20 })).toBe("translate(10px, -20px) scale(1.5)");
+  });
+});

--- a/tauri-app/src/lib/zoom-transform.ts
+++ b/tauri-app/src/lib/zoom-transform.ts
@@ -1,0 +1,82 @@
+/**
+ * 図のズーム画面の座標計算。DOM を触らない純関数なので、ホイール・ピンチ・
+ * ボタンのどれから来ても同じ式で動き、テストは数値だけで書ける。
+ *
+ * 変換は `translate(tx, ty) scale(s)`。tx/ty は画面のピクセル、図の左上が
+ * どこに来るか。倍率を変えるときは「カーソルの下の点が動かない」ように
+ * 平行移動を合わせて直す — そうしないと拡大のたびに図が逃げていく。
+ */
+
+export interface Size {
+  width: number;
+  height: number;
+}
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface Transform {
+  scale: number;
+  tx: number;
+  ty: number;
+}
+
+export const MIN_SCALE = 0.15;
+export const MAX_SCALE = 8;
+
+/** 開いたときに原寸の何倍まで広げるか。小さい図を画面いっぱいにするとぼやけるだけ */
+const FIT_MAX_SCALE = 2;
+
+/** 開いたときに図の周りに残す余白(px)。閉じるボタンやコントロールが図に被らない */
+const FIT_PADDING = 96;
+
+function clamp(value: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, value));
+}
+
+/** 画面の真ん中に、余白を残して収まる大きさで置く */
+export function fitToViewport(viewport: Size, diagram: Size): Transform {
+  const scale = clamp(
+    Math.min(
+      (viewport.width - FIT_PADDING) / diagram.width,
+      (viewport.height - FIT_PADDING) / diagram.height,
+      FIT_MAX_SCALE,
+    ),
+    MIN_SCALE,
+    MAX_SCALE,
+  );
+  return {
+    scale,
+    tx: (viewport.width - diagram.width * scale) / 2,
+    ty: (viewport.height - diagram.height * scale) / 2,
+  };
+}
+
+/** `point`(画面座標)の下にある図の点を動かさずに倍率を `factor` 倍する */
+export function zoomAtPoint(current: Transform, point: Point, factor: number): Transform {
+  const scale = clamp(current.scale * factor, MIN_SCALE, MAX_SCALE);
+  if (scale === current.scale) {
+    return current;
+  }
+  const k = scale / current.scale;
+  return {
+    scale,
+    tx: point.x - (point.x - current.tx) * k,
+    ty: point.y - (point.y - current.ty) * k,
+  };
+}
+
+/**
+ * ホイール 1 回ぶんの倍率。指数にするのは、上に 100 回して下に 100 戻せば
+ * ちょうど元に戻るため。トラックパッドのピンチはブラウザが ctrl+wheel で
+ * 届けてくる。1 回の delta が小さいので、係数を上げて指の動きに追いつかせる
+ */
+export function wheelFactor(deltaY: number, pinch: boolean): number {
+  return Math.exp(-deltaY * (pinch ? 0.01 : 0.0022));
+}
+
+export function toCss(transform: Transform): string {
+  return `translate(${transform.tx}px, ${transform.ty}px) scale(${transform.scale})`;
+}

--- a/tauri-app/src/styles/markdown-preview.css
+++ b/tauri-app/src/styles/markdown-preview.css
@@ -129,41 +129,91 @@
   height: auto;
 }
 
-/* 縮んだ図を原寸で読むための全画面。はみ出した分はスクロールで追う */
+/* ---- 図のズーム画面: transform で倍率と位置を持つ。はみ出しは隠し、
+   ホイール・ピンチ・ドラッグで動かす (DiagramZoom.tsx) ---- */
 .mermaid-zoom {
   position: fixed;
   inset: 0;
   z-index: 200;
-  display: flex;
-  overflow: auto;
-  /* 端まで来たときに背後のノートが動き出さないようにする */
-  overscroll-behavior: contain;
+  overflow: hidden;
   background: var(--app-surface);
-  padding: calc(env(safe-area-inset-top, 0px) + var(--size-3)) var(--size-3)
-    calc(env(safe-area-inset-bottom, 0px) + var(--size-3));
+  cursor: grab;
+  /* ブラウザのスクロールやピンチに取られず、pointer events で全部受ける */
+  touch-action: none;
+  overscroll-behavior: contain;
+  user-select: none;
 }
 
-/* 幅は原寸を JS から受け取る。flex + margin auto なら、はみ出しても
-   左上が切り落とされない */
+.mermaid-zoom.is-dragging {
+  cursor: grabbing;
+}
+
+/* 幅は原寸を JS から受け取り、倍率と位置は JS が transform に直接書く */
 .mermaid-zoom-canvas {
-  margin: auto;
-  flex: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform-origin: 0 0;
+  will-change: transform;
 }
 
 .mermaid-zoom-canvas svg {
+  display: block;
   width: 100%;
   max-width: none;
   height: auto;
+  /* ドラッグは画面全体で受ける。図形やラベルにヒットテストを食わせない */
+  pointer-events: none;
 }
 
-/* 図をスクロールしても流れていかないよう、絶対配置ではなく画面に固定する */
 .mermaid-zoom-close {
-  position: fixed;
-  top: calc(env(safe-area-inset-top, 0px) + var(--size-2));
+  position: absolute;
+  top: calc(var(--safe-top) + var(--size-2));
   right: var(--size-2);
-  background: var(--app-surface);
+  background: var(--app-input-bg);
   border: 1px solid var(--app-border);
   color: var(--app-text-muted);
+}
+
+/* 右下: 倍率のボタンと数字。ホイールの無い端末でもここから動かせる */
+.mermaid-zoom-controls {
+  position: absolute;
+  right: var(--size-3);
+  bottom: calc(var(--safe-bottom) + var(--size-3));
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: var(--size-1);
+  background: var(--app-input-bg);
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-2);
+  box-shadow: 0 8px 24px -12px rgb(20 20 25 / 25%);
+  color: var(--app-text-muted);
+  cursor: default;
+}
+
+.mermaid-zoom-percent {
+  min-width: 44px;
+  text-align: center;
+  font-size: var(--font-size-0);
+  font-variant-numeric: tabular-nums;
+}
+
+/* 左下: 操作の手引き。触れば分かる操作なので薄く。タッチ端末には当てはまらない */
+.mermaid-zoom-hint {
+  position: absolute;
+  left: var(--size-3);
+  bottom: calc(var(--safe-bottom) + var(--size-3));
+  margin: 0;
+  font-size: var(--font-size-0);
+  color: var(--app-text-faint);
+  pointer-events: none;
+}
+
+@media (hover: none) {
+  .mermaid-zoom-hint {
+    display: none;
+  }
 }
 
 /* ---- ホバーツール: 図とコードブロックの右上に、触れている間だけ出る操作。

--- a/tauri-app/src/styles/markdown-preview.css
+++ b/tauri-app/src/styles/markdown-preview.css
@@ -34,6 +34,8 @@
 }
 
 .markdown-preview pre {
+  /* ホバーツールの位置決めの基準(editor.css の pre と同じ) */
+  position: relative;
   /* normalize の max-content フィットを解除して本文幅に(editor.css と同じ理由)。
      padding も editor.css の pre と同じ。違うと編集に入るときにコードブロックの
      高さが変わり、その下の本文がずれる */
@@ -114,6 +116,7 @@
    ブロックに戻す(normalize の gap はエディタ側の div には効かない) */
 .markdown-preview .mermaid-block {
   display: block;
+  position: relative;
   cursor: zoom-in;
 }
 
@@ -161,6 +164,85 @@
   background: var(--app-surface);
   border: 1px solid var(--app-border);
   color: var(--app-text-muted);
+}
+
+/* ---- ホバーツール: 図とコードブロックの右上に、触れている間だけ出る操作。
+   絶対配置なので紙面の高さは変えない — 閲覧とエディタで図やコードの高さが
+   食い違うと、その下の本文がずれる (#168)。 ---- */
+
+.markdown-preview .preview-tools {
+  position: absolute;
+  top: var(--size-2);
+  right: var(--size-2);
+  display: flex;
+  align-items: center;
+  gap: var(--size-1);
+  padding: 2px var(--size-1);
+  background: var(--app-input-bg);
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-2);
+  box-shadow: 0 4px 12px -6px rgb(20 20 25 / 20%);
+  /* pre の中に置くので mono と white-space: pre を継承する。道具は本文ではない */
+  font-family: var(--font-sans);
+  line-height: 1;
+  white-space: nowrap;
+  cursor: default;
+  opacity: 0;
+  /* 透明なままだと見えない道具が図やコードへのクリックを吸う */
+  pointer-events: none;
+  transition: opacity 0.15s;
+}
+
+.markdown-preview pre:hover .preview-tools,
+.markdown-preview .mermaid-block:hover .preview-tools,
+.markdown-preview .preview-tools:focus-within {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* タッチ端末に hover は無い(あっても押した後に残る)。薄く出しっぱなしにする */
+@media (hover: none) {
+  .markdown-preview .preview-tools {
+    opacity: 0.75;
+    pointer-events: auto;
+  }
+}
+
+.markdown-preview .preview-tools-lang {
+  padding-inline: var(--size-1);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-0);
+  color: var(--app-text-faint);
+}
+
+.markdown-preview .preview-tool {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--size-1);
+  border: none;
+  border-radius: var(--radius-1);
+  background: none;
+  color: var(--app-text-muted);
+  font-size: var(--font-size-0);
+  font-weight: var(--font-weight-6);
+  cursor: pointer;
+}
+
+.markdown-preview .preview-tool:hover {
+  color: var(--app-text);
+  background: var(--app-surface-2);
+}
+
+.markdown-preview .preview-tool svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+}
+
+/* コピー直後のチェック表示。押した実感のための最小の変化 */
+.markdown-preview .preview-tool.is-copied {
+  color: var(--app-ok);
 }
 
 /* Shiki dual theme: data-theme に応じて CSS 変数で配色を切り替える。

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -858,6 +858,8 @@ export default function Workspace(): JSX.Element {
                             source={noteBody()}
                             noteTitles={noteTitles()}
                             glyphs={glyphs()}
+                            exportStem={selected()?.filename.replace(/\.md$/u, "")}
+                            onError={(message) => shell.showToast(message)}
                           />
                           {/* このノートを指している記録。畳んだ 1 行以上の場所は取らない */}
                           <Show when={(backlinks() ?? []).length > 0}>

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -452,9 +452,9 @@ export default function Workspace(): JSX.Element {
       setDetailOpen(true);
       return;
     }
-    // リンクは踏める・図はズームのまま・バックリンク欄は一覧のまま。
-    // 編集に化けさせない
-    if (target?.closest("a, button, .mermaid-block, .mermaid-zoom, .backlinks")) {
+    // リンクは踏める・図はズームのまま・道具は道具のまま・バックリンク欄は
+    // 一覧のまま。編集に化けさせない
+    if (target?.closest("a, button, .mermaid-block, .mermaid-zoom, .preview-tools, .backlinks")) {
       return;
     }
     // 書けるのはエディタ表示のときだけ。ここから下は編集を始める話になる


### PR DESCRIPTION
## なぜやるか

閲覧プレビューでは、コードを写すには編集に入るしかなく、図は原寸で開いてスクロールするだけで、外に持ち出す手段もなかった。
`view: preview` で読むだけのノートを置けるようになったので、読む側の道具を揃える。#183 に続く Phase 12 の残り。

## やったこと

図とコードの右上に出るツールバーから、コピー・ズーム・書き出しへ分岐する。緑が新しい部分。

```mermaid
flowchart LR
  md["レンダラ (markdown.ts)"] -->|"data-action 付きの静的 HTML"| tools["ホバーツールバー"]
  tools -->|copy| clip["クリップボード"]
  tools -->|zoom| zoom["全画面ズーム (DiagramZoom)"]
  tools -->|"svg / png"| exp["書き出し整形 (diagram-export.ts)"]
  exp -->|base64| cmd["save_export (Rust)"]
  cmd --> dlg["保存ダイアログ (plugin-dialog)"]
  dlg -->|"content:// も可"| fs["書き込み (plugin-fs)"]

  classDef added stroke:#3fb950,stroke-width:3px
  class tools,exp,cmd,dlg,fs added
```

- ツールバーはホバー中だけ出て、紙面の高さは変えない
  - コピーはフェンスの生ソースを写す。diff の行は改行を持たないので DOM から復元せず属性に持たせた
  - タッチ端末では薄く出しっぱなし
- 全画面ズームは開いたとき画面に収め、ホイール・ピンチ・ドラッグ・右下のボタンで動かせる
  - 背景クリックで閉じる挙動はドラッグの始点と区別できないので廃止した
- 書き出しは保存ダイアログを経てネイティブ側が書く。WKWebView と Android WebView は `<a download>` を処理しない
  - PNG のために mermaid を `htmlLabels: false` で初期化した。ラベル内の `<br/>` や太字の見え方が変わる

## やらなかったこと

- macOS 実機での PNG 保存と Android の SAF ピッカーの動作確認。確かめたのは Chromium での描画まで
- `htmlLabels: false` で既存ノートの図がどう変わるかの目視
- 計画にあった `dialog:allow-save` の capability 追加。プラグインは Rust からしか呼ばず、WebView に出す必要がない

## 資料

- 計画: `sample/plans/12-preview-enhancement.md`(gitignore)
- 先行: #183
