### PR TITLE
fix(core): stop losing notes and snapshots that share a second

### DIFF
--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -183,6 +183,46 @@ mod tests {
         assert!(content.contains("draft body"));
     }
 
+    /// ファイル名は秒までの時刻。同じ秒に 2 本作っても 1 本目を潰さない。
+    /// 2 本目は 1 秒後の名前を取る — 形式(`YYYYMMDD_HHMMSS.md`)は不変。
+    #[test]
+    fn two_notes_created_in_the_same_second_both_survive() {
+        let tmp = TempDir::new().unwrap();
+
+        let first = draft(&tmp, "one", &[]).unwrap();
+        let second = draft(&tmp, "two", &[]).unwrap();
+
+        assert_ne!(first, second);
+        assert_eq!(read_note(&first).unwrap(), "one");
+        assert_eq!(read_note(&second).unwrap(), "two");
+        assert_eq!(list_notes(tmp.path()).unwrap().len(), 2);
+        assert_eq!(
+            stamp_of(&second) - stamp_of(&first),
+            chrono::Duration::seconds(1)
+        );
+    }
+
+    /// ずらした秒はファイル名だけの話ではない。frontmatter の `time` が
+    /// 名前とずれると、一覧(名前順)と表示(`time`)で並びが食い違う。
+    #[test]
+    fn a_shifted_name_carries_the_same_time_in_the_frontmatter() {
+        let tmp = TempDir::new().unwrap();
+        draft(&tmp, "one", &[]).unwrap();
+
+        let second = draft(&tmp, "two", &[]).unwrap();
+
+        let meta = read_note_meta(tmp.path(), &filename_of(&second)).unwrap();
+        assert_eq!(
+            meta.time.naive_local().format("%Y%m%d_%H%M%S").to_string(),
+            second.file_stem().unwrap().to_str().unwrap()
+        );
+    }
+
+    fn stamp_of(path: &Path) -> chrono::NaiveDateTime {
+        let stem = path.file_stem().unwrap().to_str().unwrap();
+        chrono::NaiveDateTime::parse_from_str(stem, "%Y%m%d_%H%M%S").unwrap()
+    }
+
     #[test]
     fn test_update_note_overwrites() {
         let tmp = TempDir::new().unwrap();

--- a/core/src/note/history.rs
+++ b/core/src/note/history.rs
@@ -84,6 +84,16 @@ pub fn snapshot_note(
     }))
 }
 
+/// 並べるための (秒, 枝番) の組。枝番だけは数として比べる — 文字列のままだと
+/// 同じ秒の 2 桁目が来た時点で `-10` が `-2` より前に落ちる。
+///
+/// 枝番はゼロ埋めしない。名前が桁で変わると、既に置かれている控えの id が
+/// 過去のものと今のもので 2 通りになる。並べる側だけを直せば名前は不変。
+fn sort_key(id: &str) -> (&str, u32) {
+    let (stamp, suffix) = id.split_once('-').unwrap_or((id, "1"));
+    (stamp, suffix.parse().unwrap_or(0))
+}
+
 /// 新しいものから順に。
 pub fn list_note_history(
     base_dir: &Path,
@@ -105,7 +115,7 @@ pub fn list_note_history(
         .collect();
     // id は時刻そのものなので、名前順が時刻順。mtime はコピー先の時刻で、
     // 同じ秒の枝番を並べ替える力はない。
-    snapshots.sort_by(|a, b| b.id.cmp(&a.id));
+    snapshots.sort_by(|a, b| sort_key(&b.id).cmp(&sort_key(&a.id)));
     Ok(snapshots)
 }
 
@@ -214,6 +224,34 @@ mod tests {
                 .unwrap()
                 .ends_with("one")
         );
+    }
+
+    /// 枝番が 2 桁に届くと文字列順が時刻順から外れる(`-10` < `-2`)。
+    /// 一覧の先頭は「戻したい直前の 1 つ」なので、そこが入れ替わると
+    /// 復元の既定の候補が 9 個前の控えになる。
+    ///
+    /// 控えは `snapshot_note` を 11 回呼ばずに直に置く。11 回のあいだに
+    /// 秒が変わると枝番が振り直され、並びの前提そのものが消える。
+    #[test]
+    fn eleven_snapshots_in_the_same_second_are_listed_newest_first() {
+        let tmp = TempDir::new().unwrap();
+        let filename = NoteFilename::parse("20260101_000000.md").unwrap();
+        let dir = note_history_dir(tmp.path(), &filename);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("20260101_120000.md"), "x").unwrap();
+        for n in 2..=11 {
+            fs::write(dir.join(format!("20260101_120000-{n}.md")), "x").unwrap();
+        }
+
+        let ids: Vec<String> = list_note_history(tmp.path(), &filename)
+            .unwrap()
+            .into_iter()
+            .map(|s| s.id)
+            .collect();
+
+        assert_eq!(ids[0], "20260101_120000-11");
+        assert_eq!(ids[1], "20260101_120000-10");
+        assert_eq!(ids.last().unwrap(), "20260101_120000");
     }
 
     /// 控えの置き場は同期の走査範囲の外。載せると端末間で控えが往復する。

--- a/core/src/note/repository.rs
+++ b/core/src/note/repository.rs
@@ -1,4 +1,5 @@
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use chrono::Local;
@@ -27,6 +28,21 @@ impl Notes {
         notes_dir(&self.base_dir)
     }
 
+    /// ノートを 1 本作る。返るのは書いたファイルのパス。
+    ///
+    /// ファイル名は秒までの時刻で、それがそのままノートの ID になる
+    /// (形式は不変)。同じ秒に 2 本作られたときは空いている秒まで
+    /// 1 秒ずつ進める — 名前を変えるのではなく、まだ誰も使っていない
+    /// 名前を選び直すだけ。frontmatter の `time` も進めたあとの時刻に
+    /// 揃える。名前(一覧の並び)と `time`(表示)がずれると、同じ一覧の
+    /// 中で並びと日時が食い違う。
+    ///
+    /// 予約は `create_new` に任せる。`exists()` で見てから書くと、その
+    /// あいだに別スレッド・別プロセスが同じ名前を取れてしまう。
+    /// 作成は `write_atomic`(tmp → rename)を通さない: rename は既存の
+    /// ファイルを黙って置き換えるので、衝突回避と両立しない。ここで
+    /// 書き途中に落ちても失うのは書きかけの新規ノートだけで、
+    /// 既存の記録は壊れない。
     pub(crate) fn create(
         &self,
         body: &str,
@@ -34,13 +50,28 @@ impl Notes {
         context: &Context,
         provenance: Provenance<'_>,
     ) -> Result<PathBuf, CoreError> {
-        let now = Local::now();
-        let file_path = note_file_path(&self.base_dir, now);
+        let mut now = Local::now();
+        let mut file_path = note_file_path(&self.base_dir, now);
         ensure_dir(&file_path)?;
 
-        let markdown = format_note_markdown(body, tags, now, context, provenance)?;
-        write_atomic(&file_path, markdown)?;
-        Ok(file_path)
+        loop {
+            match OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&file_path)
+            {
+                Ok(mut file) => {
+                    let markdown = format_note_markdown(body, tags, now, context, provenance)?;
+                    file.write_all(markdown.as_bytes())?;
+                    return Ok(file_path);
+                }
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                    now += chrono::Duration::seconds(1);
+                    file_path = note_file_path(&self.base_dir, now);
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
     }
 
     pub(crate) fn list(&self) -> Result<Vec<NoteSummary>, CoreError> {

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -598,7 +598,7 @@ mod tests {
     fn a_tag_scope_keeps_only_notes_carrying_the_tag() {
         let tmp = TempDir::new().unwrap();
         draft(&tmp, "リトライ設計", &["sync".to_string()]).unwrap();
-        write_second_note(tmp.path(), "20200101_000000.md", "リトライの雑記 #misc");
+        draft(&tmp, "リトライの雑記 #misc", &[]).unwrap();
 
         let hits = search_all(tmp.path(), "リトライ", &scope(&["sync"])).unwrap();
 
@@ -694,22 +694,6 @@ mod tests {
         path.file_stem().unwrap().to_str().unwrap().to_string()
     }
 
-    /// 2 件目のノートを固定名で直接書く。`create_draft_note` を同じ秒に
-    /// 2 回呼ぶとファイル名が衝突し、1 件目を上書きしてしまう。
-    fn write_second_note(base: &Path, filename: &str, body: &str) {
-        use crate::utils::frontmatter::{self, NoteFrontmatter};
-        use chrono::TimeZone;
-        let fm = NoteFrontmatter::new(
-            chrono::FixedOffset::east_opt(9 * 3600)
-                .unwrap()
-                .with_ymd_and_hms(2020, 1, 1, 0, 0, 0)
-                .unwrap(),
-        );
-        let path = crate::utils::paths::notes_dir(base).join(filename);
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(&path, frontmatter::render(&fm, body).unwrap()).unwrap();
-    }
-
     #[test]
     fn a_timeline_entry_that_links_a_note_is_a_backlink() {
         let tmp = TempDir::new().unwrap();
@@ -731,7 +715,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let target = draft(&tmp, "指される側", &[]).unwrap();
         let body = format!("{}\n[[{}]]", "あ".repeat(300), stem_of(&target));
-        write_second_note(tmp.path(), "20200101_000000.md", &body);
+        draft(&tmp, &body, &[]).unwrap();
 
         let hits = find_backlinks(tmp.path(), &filename_of(&target)).unwrap();
 
@@ -761,7 +745,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let target = draft(&tmp, "指される側", &[]).unwrap();
         let body = format!("詳しくは [[{}|前の話]] を見る", stem_of(&target));
-        write_second_note(tmp.path(), "20200101_000000.md", &body);
+        draft(&tmp, &body, &[]).unwrap();
 
         let hits = find_backlinks(tmp.path(), &filename_of(&target)).unwrap();
 
@@ -778,7 +762,7 @@ mod tests {
     fn no_links_means_no_backlinks() {
         let tmp = TempDir::new().unwrap();
         let target = draft(&tmp, "誰も指していない", &[]).unwrap();
-        write_second_note(tmp.path(), "20200101_000000.md", "無関係なノート");
+        draft(&tmp, "無関係なノート", &[]).unwrap();
         save_timeline_entry(tmp.path(), "無関係なエントリ", &context(), Source::App).unwrap();
 
         assert!(

--- a/core/src/template.rs
+++ b/core/src/template.rs
@@ -186,8 +186,9 @@ mod tests {
         .unwrap();
     }
 
-    /// 作成日時を指定してノートを直に書く。`create_note_from_template` を
-    /// 同じ秒に 2 回呼ぶとファイル名が衝突して 1 件目を上書きしてしまう。
+    /// 過去の日付のノートを直に書く。`{{prev}}` も「今日のぶんはもう在るか」も
+    /// 日付で判定するので、`create_note_from_template`(作成時刻は今)では
+    /// 昨日以前のノートを用意できない。
     fn seed_note(tmp: &TempDir, filename: &str, template: &str, days_ago: i64) {
         let time = (Local::now() - chrono::Duration::days(days_ago)).fixed_offset();
         let fm = NoteFrontmatter {

--- a/tauri-app/dev/ipc-mock.js
+++ b/tauri-app/dev/ipc-mock.js
@@ -333,6 +333,20 @@
 
   const placeKey = (lat, lon) => `${lat.toFixed(2)},${lon.toFixed(2)}`;
 
+  const stampOf = (date) =>
+    `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}_${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
+
+  // まだ使われていない名前と、その名前が名乗る時刻。core の `Notes::create`
+  // と同じく、同じ秒に 2 本作られたら空いている秒まで 1 秒ずつ進める。
+  // ここで潰すと、「+ 新規」を続けて押したときだけモックが実物と違う挙動を見せる
+  const freeNoteName = () => {
+    const time = new Date();
+    while (notes.has(`${stampOf(time)}.md`)) {
+      time.setSeconds(time.getSeconds() + 1);
+    }
+    return { filename: `${stampOf(time)}.md`, time };
+  };
+
   const commands = {
     list_timeline_dates: () => [...timeline.keys()].toSorted().toReversed(),
     read_timeline_by_date: ({ date }) => timeline.get(date) ?? [],
@@ -508,11 +522,9 @@
       notes.delete(filename);
     },
     create_draft: ({ body, tags, origin }) => {
-      const now = new Date();
-      const stamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}_${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
-      const filename = `${stamp}.md`;
+      const { filename, time } = freeNoteName();
       notes.set(filename, {
-        time: now.toISOString(),
+        time: time.toISOString(),
         tags: tags ?? [],
         view: null,
         // 画面から作ったノートはアプリが名乗る。実装(`create_draft`)と
@@ -562,12 +574,10 @@
         throw new Error("template not found");
       }
       const name = filename.replace(/\.md$/, "");
-      const now = new Date();
-      const stamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}_${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
 
       // 同じテンプレの今日のぶんが既にあれば作らない。日付はファイル名の
       // 先頭 8 桁で見る — 保存している time は UTC で、日をまたぐと食い違う
-      const today = stamp.slice(0, 8);
+      const today = stampOf(new Date()).slice(0, 8);
       const existing = [...notes.entries()].find(
         ([fname, note]) => note.template === name && fname.slice(0, 8) === today,
       );
@@ -580,9 +590,9 @@
         .toSorted(([a], [b]) => b.localeCompare(a))[0];
       const prev = previous ? `[[${previous[0].replace(/\.md$/, "")}]]` : null;
 
-      const created = `${stamp}.md`;
+      const { filename: created, time } = freeNoteName();
       notes.set(created, {
-        time: now.toISOString(),
+        time: time.toISOString(),
         tags: template.tags
           .map((tag) => resolveVars(tag, prev, locale))
           .filter((tag) => tag.trim()),


### PR DESCRIPTION
## なぜやるか

マージ後監査(Batch B)の指摘 2 件。ノートのファイル名は秒までの時刻で、それがそのまま ID になる。同じ秒に 2 本作ると 2 本目が rename で 1 本目を置き換え、エラーも痕跡も残さずノートが消えていた。控えの一覧は id を文字列で並べるので、同じ秒に 10 個を超えると先頭が 9 個前の控えになる。

## やったこと

- 新規ノートは空いている秒を `create_new` で予約して作る。frontmatter の `time` も取れた秒に合わせる(ID 形式は不変)
  - ブラウザ用の IPC モックも同じ上書きをしていたので揃えた
- 控えの一覧は枝番を数として並べる。既存の控えの名前は変えていない
- 検索のテストが本物の作成経路を通る。固定名で frontmatter を手書きするヘルパを削った

## やらなかったこと

- 枝番のゼロ埋め。既存の控えと新しい控えで id が 2 通りになるので、並べる側だけを直した
- `Notes::create` のループ上限。秒は単調に進むので終わるが、未来の秒が埋まっている場合のガードは無い
- `template.rs` の固定名ヘルパ。あのテストは昨日以前の日付のノートが要るので、作成経路では用意できない

## 資料

- 計画: `sample/plans/13-post-merge-audit-fixes.md` の Batch B(指摘 B-1 / B-2)
- Red を確認したテスト: `two_notes_created_in_the_same_second_both_survive` / `eleven_snapshots_in_the_same_second_are_listed_newest_first`
