### PR TITLE
fix(sync): stop a sync round from fanning out conflicts, stalling, or deleting late edits

### DIFF
--- a/core/src/sync/diff.rs
+++ b/core/src/sync/diff.rs
@@ -70,10 +70,16 @@ pub fn compute(
             }
 
             // Both exist, never synced (first sync with data on both sides)
-            (Some(_), Some(_), None) => {
-                actions.push(SyncAction::Conflict {
-                    key: key.to_string(),
-                });
+            // 中身が同じなら転送するものは何もない。ここを競合にすると、
+            // `.sync-state.json` を消して再同期する復旧手順が、一致している
+            // ファイルまで競合コピーに分裂させてしまう。state はサーバーが
+            // 返す new_state から `save_local_state` が記録し直す
+            (Some(local), Some(remote), None) => {
+                if local.content_hash != remote.content_hash {
+                    actions.push(SyncAction::Conflict {
+                        key: key.to_string(),
+                    });
+                }
             }
 
             // Local only, never synced → upload
@@ -155,10 +161,14 @@ mod tests {
     }
 
     fn remote(key: &str, modified: &str) -> RemoteFile {
+        remote_hashed(key, modified, "remote_hash")
+    }
+
+    fn remote_hashed(key: &str, modified: &str, hash: &str) -> RemoteFile {
         RemoteFile {
             key: key.to_string(),
             last_modified: modified.parse().unwrap(),
-            content_hash: String::new(),
+            content_hash: hash.to_string(),
         }
     }
 
@@ -200,9 +210,13 @@ mod tests {
     }
 
     #[test]
-    fn both_exist_no_state_conflict() {
-        let local_files = vec![local("notes/c.md", "hash_c")];
-        let remote_files = vec![remote("notes/c.md", "2026-04-22T10:00:00Z")];
+    fn both_exist_no_state_different_hash_conflicts() {
+        let local_files = vec![local("notes/c.md", "local_hash")];
+        let remote_files = vec![remote_hashed(
+            "notes/c.md",
+            "2026-04-22T10:00:00Z",
+            "remote_hash",
+        )];
         let actions = compute(&local_files, &remote_files, &SyncState::default());
         assert_eq!(
             actions,
@@ -210,6 +224,20 @@ mod tests {
                 key: "notes/c.md".into()
             }]
         );
+    }
+
+    /// `.sync-state.json` を消して再同期する復旧手順で、中身が一致するファイルまで
+    /// 競合にすると全ノートぶんの `.sync-conflict-*.md` が両側に生まれる
+    #[test]
+    fn both_exist_no_state_same_hash_needs_no_transfer() {
+        let local_files = vec![local("notes/c.md", "same_hash")];
+        let remote_files = vec![remote_hashed(
+            "notes/c.md",
+            "2026-04-22T10:00:00Z",
+            "same_hash",
+        )];
+        let actions = compute(&local_files, &remote_files, &SyncState::default());
+        assert!(actions.is_empty());
     }
 
     #[test]

--- a/core/src/sync/engine.rs
+++ b/core/src/sync/engine.rs
@@ -71,7 +71,7 @@ async fn sync_once(client: &HttpClient, base_dir: &Path) -> Result<SyncResult, S
 
     let bulk_resp = client.bulk(bulk_req).await?;
 
-    let unwritten = apply_response(&bulk_resp, &actions, &data_dir, &mut result);
+    let unwritten = apply_response(&bulk_resp, &actions, &local_files, &data_dir, &mut result);
 
     // サーバーが確定させた状態をそのままローカルにも記録する。
     // ここでローカルを再スキャンして組み直すと、ダウンロード直後の mtime が
@@ -230,6 +230,7 @@ fn decode(file: &DownloadedFile) -> Result<Vec<u8>, String> {
 fn apply_response(
     bulk_resp: &BulkResponse,
     actions: &[SyncAction],
+    local_files: &[LocalFile],
     data_dir: &Path,
     result: &mut SyncResult,
 ) -> HashSet<String> {
@@ -266,22 +267,56 @@ fn apply_response(
                 result.conflicts += 1;
             }
             SyncAction::DeleteLocal { key } => {
-                let path = data_dir.join(key);
-                if path.exists() {
-                    if let Err(e) = fs::remove_file(&path) {
-                        result.errors.push(format!("delete_local {key}: {e}"));
-                    } else {
-                        result.deleted_local += 1;
-                    }
-                } else {
-                    result.deleted_local += 1;
-                }
+                delete_local_file(key, local_files, data_dir, result);
             }
             SyncAction::DownloadNew { .. } | SyncAction::DownloadModified { .. } => {}
         }
     }
 
     unwritten
+}
+
+/// リモートで消されたファイルをローカルからも消す。
+///
+/// scan の判定からここまでにサーバーとの往復が挟まる。その隙に書かれた編集は
+/// まだ誰も知らないので、削除の直前に中身を数え直し、scan 時と違えば残す。
+/// 残ったファイルは次の同期で `UploadModified` として復活する
+fn delete_local_file(
+    key: &str,
+    local_files: &[LocalFile],
+    data_dir: &Path,
+    result: &mut SyncResult,
+) {
+    let path = data_dir.join(key);
+    let content = match fs::read(&path) {
+        Ok(content) => content,
+        // すでに無いなら消す手間が省けただけ
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            result.deleted_local += 1;
+            return;
+        }
+        Err(e) => {
+            result.errors.push(format!("delete_local {key}: {e}"));
+            return;
+        }
+    };
+
+    let scanned = local_files
+        .iter()
+        .find(|f| f.key == key)
+        .map(|f| f.content_hash.as_str());
+    if scanned != Some(scan::compute_hash(&content).as_str()) {
+        result
+            .errors
+            .push(format!("delete_local {key}: changed since scan, kept"));
+        return;
+    }
+
+    if let Err(e) = fs::remove_file(&path) {
+        result.errors.push(format!("delete_local {key}: {e}"));
+    } else {
+        result.deleted_local += 1;
+    }
 }
 
 /// サーバーが確定させた状態を、実際に手元にあるファイルだけに絞って保存する。
@@ -470,7 +505,7 @@ mod tests {
         };
 
         let mut result = SyncResult::default();
-        apply_response(&resp, &[], dir.path(), &mut result);
+        apply_response(&resp, &[], &[], dir.path(), &mut result);
 
         assert_eq!(
             fs::read_to_string(dir.path().join("notes/a.md")).unwrap(),
@@ -511,7 +546,7 @@ mod tests {
         };
 
         let mut result = SyncResult::default();
-        let unwritten = apply_response(&resp, &[], dir.path(), &mut result);
+        let unwritten = apply_response(&resp, &[], &[], dir.path(), &mut result);
 
         assert_eq!(
             fs::read_to_string(dir.path().join("notes/good.md")).unwrap(),
@@ -535,6 +570,63 @@ mod tests {
         SyncAction::DeleteLocal {
             key: key.to_string(),
         }
+    }
+
+    fn no_response() -> BulkResponse {
+        BulkResponse {
+            downloads: Vec::new(),
+            conflict_downloads: Vec::new(),
+            new_state: server_state(&[]),
+        }
+    }
+
+    #[test]
+    fn a_local_delete_removes_the_file_it_was_computed_from() {
+        let dir = tempfile::tempdir().unwrap();
+        seed(dir.path(), "notes/a.md", "untouched");
+        let locals = vec![local_file("notes/a.md", &scan::compute_hash(b"untouched"))];
+
+        let mut result = SyncResult::default();
+        apply_response(
+            &no_response(),
+            &[delete_local("notes/a.md")],
+            &locals,
+            dir.path(),
+            &mut result,
+        );
+
+        assert!(!dir.path().join("notes/a.md").exists());
+        assert_eq!(result.deleted_local, 1);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    }
+
+    /// scan と削除のあいだにはネットワーク往復が挟まる。その隙に書かれた
+    /// 編集まで消さないよう、削除の直前に中身を見直す
+    #[test]
+    fn a_local_delete_is_skipped_when_the_file_changed_after_the_scan() {
+        let dir = tempfile::tempdir().unwrap();
+        seed(
+            dir.path(),
+            "notes/a.md",
+            "edited while the sync was in flight",
+        );
+        let locals = vec![local_file("notes/a.md", &scan::compute_hash(b"as scanned"))];
+
+        let mut result = SyncResult::default();
+        apply_response(
+            &no_response(),
+            &[delete_local("notes/a.md")],
+            &locals,
+            dir.path(),
+            &mut result,
+        );
+
+        assert_eq!(
+            fs::read_to_string(dir.path().join("notes/a.md")).unwrap(),
+            "edited while the sync was in flight"
+        );
+        assert_eq!(result.deleted_local, 0);
+        assert_eq!(result.errors.len(), 1, "errors: {:?}", result.errors);
     }
 
     /// サーバーの同期状態が壊れて空になったときに、それを「全部削除された」と
@@ -605,7 +697,7 @@ mod tests {
         };
 
         let mut result = SyncResult::default();
-        let unwritten = apply_response(&resp, &[], dir.path(), &mut result);
+        let unwritten = apply_response(&resp, &[], &[], dir.path(), &mut result);
 
         assert!(!dir.path().parent().unwrap().join("escaped.md").exists());
         assert_eq!(result.downloaded, 0);

--- a/core/src/sync/engine.rs
+++ b/core/src/sync/engine.rs
@@ -4,7 +4,7 @@
 //! 再スキャンで state を組み直さない、全消しを拒否する）はコメントでしか
 //! 守られていない。2 本目を書くと必ずドリフトするので分岐させない。
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 
@@ -71,13 +71,14 @@ async fn sync_once(client: &HttpClient, base_dir: &Path) -> Result<SyncResult, S
 
     let bulk_resp = client.bulk(bulk_req).await?;
 
-    apply_response(&bulk_resp, &actions, &data_dir, &mut result).map_err(SyncError::other)?;
+    let unwritten = apply_response(&bulk_resp, &actions, &data_dir, &mut result);
 
     // サーバーが確定させた状態をそのままローカルにも記録する。
     // ここでローカルを再スキャンして組み直すと、ダウンロード直後の mtime が
     // サーバーの版と食い違い、同じファイルを永久に再取得し続ける
 
-    save_local_state(base_dir, &bulk_resp.new_state, &data_dir).map_err(SyncError::other)?;
+    save_local_state(base_dir, &bulk_resp.new_state, &data_dir, &unwritten)
+        .map_err(SyncError::other)?;
 
     Ok(result)
 }
@@ -221,21 +222,36 @@ fn decode(file: &DownloadedFile) -> Result<Vec<u8>, String> {
         .map_err(|e| format!("base64 decode {}: {e}", file.key))
 }
 
+/// サーバーの返事をローカルに反映する。書けなかったキーを返す。
+///
+/// 1 件の失敗でここを抜けると `save_local_state` に届かず、壊れたキーが
+/// 毎回同じ所で同期を止める。失敗は `result.errors` に積んで先へ進み、
+/// 書けなかったキーは「同期済み」として記録させない。
 fn apply_response(
     bulk_resp: &BulkResponse,
     actions: &[SyncAction],
     data_dir: &Path,
     result: &mut SyncResult,
-) -> Result<(), String> {
+) -> HashSet<String> {
+    let mut unwritten = HashSet::new();
+
     for d in &bulk_resp.downloads {
-        write_under(data_dir, &d.key, &decode(d)?)?;
-        result.downloaded += 1;
+        match decode(d).and_then(|content| write_under(data_dir, &d.key, &content)) {
+            Ok(()) => result.downloaded += 1,
+            Err(e) => {
+                result.errors.push(e);
+                unwritten.insert(d.key.clone());
+            }
+        }
     }
 
     // 競合で負けたリモート側。`.sync-conflict-` はスキャン対象外なので、
     // ローカルに置いても同期ループにはならない
     for d in &bulk_resp.conflict_downloads {
-        write_under(data_dir, &d.key, &decode(d)?)?;
+        if let Err(e) = decode(d).and_then(|content| write_under(data_dir, &d.key, &content)) {
+            result.errors.push(e);
+            unwritten.insert(d.key.clone());
+        }
     }
 
     for action in actions {
@@ -265,12 +281,18 @@ fn apply_response(
         }
     }
 
-    Ok(())
+    unwritten
 }
 
 /// サーバーが確定させた状態を、実際に手元にあるファイルだけに絞って保存する。
 /// 手元に無いものを「同期済み」と記録すると、次の同期でリモート側を消してしまう。
-fn to_local_state(server_state: &ServerSyncState, data_dir: &Path) -> SyncState {
+/// `unwritten` は取得に失敗したキー: ファイル自体は古い版のまま残っているので、
+/// 存在チェックだけでは除けない。
+fn to_local_state(
+    server_state: &ServerSyncState,
+    data_dir: &Path,
+    unwritten: &HashSet<String>,
+) -> SyncState {
     let mut state = SyncState {
         last_sync: Some(Utc::now()),
         ..Default::default()
@@ -279,7 +301,7 @@ fn to_local_state(server_state: &ServerSyncState, data_dir: &Path) -> SyncState 
         let Ok(last_synced_modified) = record.last_modified.parse() else {
             continue;
         };
-        if !is_safe_key(key) || !data_dir.join(key).exists() {
+        if !is_safe_key(key) || unwritten.contains(key) || !data_dir.join(key).exists() {
             continue;
         }
         state.files.insert(
@@ -297,8 +319,9 @@ fn save_local_state(
     base_dir: &Path,
     server_state: &ServerSyncState,
     data_dir: &Path,
+    unwritten: &HashSet<String>,
 ) -> Result<(), String> {
-    to_local_state(server_state, data_dir)
+    to_local_state(server_state, data_dir, unwritten)
         .save(base_dir)
         .map_err(|e| e.to_string())
 }
@@ -395,7 +418,7 @@ mod tests {
         seed(dir.path(), "notes/a.md", "content");
         let state = server_state(&[("notes/a.md", "hash-a", "2026-08-05T00:00:00Z")]);
 
-        let local = to_local_state(&state, dir.path());
+        let local = to_local_state(&state, dir.path(), &HashSet::new());
 
         let record = &local.files["notes/a.md"];
         assert_eq!(record.content_hash, "hash-a");
@@ -412,7 +435,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let state = server_state(&[("notes/missing.md", "hash-a", "2026-08-05T00:00:00Z")]);
 
-        assert!(to_local_state(&state, dir.path()).files.is_empty());
+        assert!(
+            to_local_state(&state, dir.path(), &HashSet::new())
+                .files
+                .is_empty()
+        );
     }
 
     #[test]
@@ -420,7 +447,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let state = server_state(&[("../escape.md", "hash-a", "2026-08-05T00:00:00Z")]);
 
-        assert!(to_local_state(&state, dir.path()).files.is_empty());
+        assert!(
+            to_local_state(&state, dir.path(), &HashSet::new())
+                .files
+                .is_empty()
+        );
     }
 
     #[test]
@@ -439,7 +470,7 @@ mod tests {
         };
 
         let mut result = SyncResult::default();
-        apply_response(&resp, &[], dir.path(), &mut result).unwrap();
+        apply_response(&resp, &[], dir.path(), &mut result);
 
         assert_eq!(
             fs::read_to_string(dir.path().join("notes/a.md")).unwrap(),
@@ -451,6 +482,53 @@ mod tests {
             "other device"
         );
         assert_eq!(result.downloaded, 1);
+    }
+
+    /// bulk が通ったあとの書き込みで 1 件こけたら、そこで抜けずに残りを書く。
+    /// 抜けると `save_local_state` に届かず、壊れた 1 キーが毎回同じ所で
+    /// 同期を止め、次の同期は state 無しで全件 Conflict になる
+    #[test]
+    fn a_failed_download_leaves_the_others_written_and_the_state_saved() {
+        let dir = tempfile::tempdir().unwrap();
+        // 更新版の取得に失敗したので、手元には古い版が残ったまま
+        seed(dir.path(), "notes/bad.md", "stale local copy");
+        let resp = BulkResponse {
+            downloads: vec![
+                DownloadedFile {
+                    key: "notes/bad.md".to_string(),
+                    content_base64: "not base64!!".to_string(),
+                },
+                DownloadedFile {
+                    key: "notes/good.md".to_string(),
+                    content_base64: B64.encode(b"remote"),
+                },
+            ],
+            conflict_downloads: Vec::new(),
+            new_state: server_state(&[
+                ("notes/bad.md", "hash-bad", "2026-08-05T00:00:00Z"),
+                ("notes/good.md", "hash-good", "2026-08-05T00:00:00Z"),
+            ]),
+        };
+
+        let mut result = SyncResult::default();
+        let unwritten = apply_response(&resp, &[], dir.path(), &mut result);
+
+        assert_eq!(
+            fs::read_to_string(dir.path().join("notes/good.md")).unwrap(),
+            "remote"
+        );
+        assert_eq!(
+            fs::read_to_string(dir.path().join("notes/bad.md")).unwrap(),
+            "stale local copy"
+        );
+        assert_eq!(result.downloaded, 1);
+        assert_eq!(result.errors.len(), 1, "errors: {:?}", result.errors);
+
+        // 取れなかったキーを「同期済み」と記録すると、手元の古い版が
+        // 新しいハッシュで確定してしまう
+        let state = to_local_state(&resp.new_state, dir.path(), &unwritten);
+        assert!(state.files.contains_key("notes/good.md"));
+        assert!(!state.files.contains_key("notes/bad.md"));
     }
 
     fn delete_local(key: &str) -> SyncAction {
@@ -527,6 +605,11 @@ mod tests {
         };
 
         let mut result = SyncResult::default();
-        assert!(apply_response(&resp, &[], dir.path(), &mut result).is_err());
+        let unwritten = apply_response(&resp, &[], dir.path(), &mut result);
+
+        assert!(!dir.path().parent().unwrap().join("escaped.md").exists());
+        assert_eq!(result.downloaded, 0);
+        assert_eq!(result.errors.len(), 1, "errors: {:?}", result.errors);
+        assert!(unwritten.contains("../escaped.md"));
     }
 }

--- a/core/src/sync/scan.rs
+++ b/core/src/sync/scan.rs
@@ -182,7 +182,9 @@ fn is_excluded(file_name: &str) -> bool {
         || file_name.starts_with(".sync-tmp-")
 }
 
-fn compute_hash(content: &[u8]) -> String {
+/// 同期のハッシュはここでしか作らない。engine が削除の直前に計算し直すぶんも
+/// 同じ関数を通す — 定義が 2 つに割れると、片方の版が「変更あり」に見え続ける
+pub(crate) fn compute_hash(content: &[u8]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
 
     let mut hasher = Sha256::new();


### PR DESCRIPTION
## なぜやるか

同期 1 回のなかに、ノートを失うか同期を止める穴が 3 つあった。差分計算がリモートのハッシュを見ないので、`.sync-state.json` を消して再同期する案内どおりに操作すると、中身の同じノートまで競合コピーに分裂する。往復のあとの書き込みは 1 件失敗するとその場で抜け、同期状態が保存されないまま次回は全件が競合になる。ローカル削除は走査時の判定のまま往復を挟んで実行され、そのあいだの編集が消える。

マージ後監査 (`sample/plans/13-post-merge-audit-fixes.md` の Batch E) の 3 件。

## やったこと

- 中身が一致するファイルは競合にしない。差分計算がリモートのハッシュを見るようになった
- 1 件の書き込み失敗で同期を止めない。残りを書いて同期状態は必ず保存し、書けなかったキーだけ「同期済み」から外す — 古い版が残るので存在だけでは判別できない
- 削除の直前にハッシュを数え直す。走査からのあいだに書かれた編集は残り、次の同期でアップロードとして復活する

## やらなかったこと

- 計画にあった `RecordOnly` という action は足していない。すべての分岐が無視するだけの種別になり、記録はサーバーが返す一覧で足りるため
- `sync-storage` スキルの同期表に「状態なし・同ハッシュ」の行を足していない。同じファイルを Batch F が触るのでそちらへ
- 削除を見送ったときのエラー文言は英語のまま。同期結果のエラーは他も英語で、i18n を通していない
