### PR TITLE
fix(notes): keep the edit session bound to the note it was typed in

### DIFF
--- a/tauri-app/src/views/Workspace.test.tsx
+++ b/tauri-app/src/views/Workspace.test.tsx
@@ -321,4 +321,49 @@ describe("Workspace › 編集中に選択が差し替わる", () => {
     // 読んだ版で断られるので、相手の行は残る
     expect(disk.get(FILE_A)).toBe(BODY_A_SYNCED);
   });
+
+  // Stale で退避するのは「飛んでいった写し」ではなく、いま画面にある本文。
+  // 往復のあいだに打った字は、まだどこにも残っていない
+  it("backs up the draft as it stands when the save is refused as stale", async () => {
+    await openNoteA();
+    await startEditingBody();
+    typeInEditor?.(`${TEXT_A}\n\n一回目`);
+    disk.set(FILE_A, BODY_A_SYNCED);
+    duringSave = () => {
+      duringSave = undefined;
+      typeInEditor?.(`${TEXT_A}\n\n二回目`);
+    };
+
+    await waitFor(() => expect(screen.getByText("他の端末で足された行")).toBeDefined(), {
+      timeout: 3000,
+    });
+    expect(localStorage.getItem(`note-backup:${FILE_A}`)).toContain("二回目");
+  });
+
+  // 退避して読み直したあとに、その手前で並んだ保存が出てくると、
+  // 読み直した版の指紋で古い draft が通ってしまう
+  it("drops a save that was queued before the stale reload", async () => {
+    await openNoteA();
+    await startEditingBody();
+    typeInEditor?.(`${TEXT_A}\n\n一回目`);
+    disk.set(FILE_A, BODY_A_SYNCED);
+    duringSave = () => {
+      duringSave = undefined;
+      typeInEditor?.(`${TEXT_A}\n\n二回目`);
+      // 飛んでいる保存の後ろに、もう 1 回ぶんの保存を並べる
+      fireEvent.change(titleInput(), { target: { value: TITLE_A } });
+    };
+
+    await waitFor(() => expect(screen.getByText("他の端末で足された行")).toBeDefined(), {
+      timeout: 3000,
+    });
+    // 読み直したあとの保存は通る。それが着く時点までに、並んでいた古い
+    // draft が書かれていないことを見る(書かれていれば 3 回になる)
+    fireEvent.input(titleInput(), { target: { value: "読み直したあとの題" } });
+    await waitFor(() => expect(disk.get(FILE_A)).toContain("読み直したあとの題"), {
+      timeout: 3000,
+    });
+    expect(countOf("update_draft")).toBe(2);
+    expect(disk.get(FILE_A)).toBe("# 読み直したあとの題\n\n他の端末で足された行");
+  });
 });

--- a/tauri-app/src/views/Workspace.test.tsx
+++ b/tauri-app/src/views/Workspace.test.tsx
@@ -241,6 +241,20 @@ describe("Workspace › 外から書き換わったノートの読み直し", ()
       expect(countOf(command)).toBe(0);
     }
   });
+
+  // 自動保存が起きたあとも「保存待ち」のままだと、同期の版が二度と画面に出ない
+  it("reloads the open note after an autosave has already fired", async () => {
+    await openNoteA();
+    fireEvent.input(titleInput(), { target: { value: "会議メモ 改" } });
+    await waitFor(() => expect(countOf("update_draft")).toBe(1), { timeout: 3000 });
+    const readsBefore = countOf("read_note");
+
+    disk.set(FILE_A, BODY_A_SYNCED);
+    shell?.refreshData();
+
+    await waitFor(() => expect(screen.getByText("他の端末で足された行")).toBeDefined());
+    expect(countOf("read_note")).toBe(readsBefore + 1);
+  });
 });
 
 describe("Workspace › 編集中に選択が差し替わる", () => {
@@ -365,5 +379,22 @@ describe("Workspace › 編集中に選択が差し替わる", () => {
     });
     expect(countOf("update_draft")).toBe(2);
     expect(disk.get(FILE_A)).toBe("# 読み直したあとの題\n\n他の端末で足された行");
+  });
+
+  // 復元は入れ替え。戻した直後の「戻る先」を次の保存で押し出すと、
+  // もう一度押しても戻れない
+  it("keeps the reverted body reachable after the next save", async () => {
+    const bodyOld = "# 会議メモ\n\nいちばん最初の本文";
+    localStorage.setItem(`note-backup:${FILE_A}`, bodyOld);
+    await openNoteA();
+
+    fireEvent.click(screen.getByRole("button", { name: "ノート情報" }));
+    fireEvent.click(await screen.findByRole("button", { name: /編集前に戻す/u }));
+    await waitFor(() => expect(disk.get(FILE_A)).toBe(bodyOld));
+    expect(localStorage.getItem(`note-backup:${FILE_A}`)).toBe(BODY_A);
+
+    fireEvent.input(titleInput(), { target: { value: "別の題" } });
+    await waitFor(() => expect(countOf("update_draft")).toBe(2), { timeout: 3000 });
+    expect(localStorage.getItem(`note-backup:${FILE_A}`)).toBe(BODY_A);
   });
 });

--- a/tauri-app/src/views/Workspace.test.tsx
+++ b/tauri-app/src/views/Workspace.test.tsx
@@ -1,17 +1,23 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, fireEvent, cleanup, waitFor } from "@solidjs/testing-library";
 import { mockIPC, mockWindows, clearMocks } from "@tauri-apps/api/mocks";
-import { MemoryRouter, Route } from "@solidjs/router";
+import { page } from "vitest/browser";
+import { MemoryRouter, Route, useNavigate } from "@solidjs/router";
 import type { JSX } from "solid-js";
 import { ShellProvider, useShell } from "../lib/shell";
 import type { Shell } from "../lib/shell";
 import Workspace from "./Workspace";
 
 // 本物の Milkdown は ProseMirror 一式を連れてくる。ここで見たいのは
-// 「編集中に本文を読み直さない」という判断だけなので、開いているという
-// 事実だけを持つ板に差し替える
+// 「どのノートに何を書くか」という判断だけなので、開いているという事実と
+// 打鍵の入り口だけを持つ板に差し替える
+let typeInEditor: ((markdown: string) => void) | undefined;
 vi.mock(import("../components/MilkdownEditor"), () => ({
-  default: (props: { defaultValue?: string }): JSX.Element => {
+  default: (props: {
+    defaultValue?: string;
+    onChange?: (markdown: string) => void;
+  }): JSX.Element => {
+    typeInEditor = props.onChange;
     const el = document.createElement("div");
     el.dataset.testid = "editor-body";
     el.textContent = props.defaultValue ?? "";
@@ -19,88 +25,194 @@ vi.mock(import("../components/MilkdownEditor"), () => ({
   },
 }));
 
-const FILENAME = "20260903_120000.md";
-const BODY_BEFORE = "# 会議メモ\n\nここまで書いた";
-const BODY_AFTER = "# 会議メモ (同期後)\n\n他の端末で足された行";
+const FILE_A = "20260903_120000.md";
+const FILE_B = "20260903_130000.md";
+const TITLE_A = "会議メモ";
+const TEXT_A = "ここまで書いた";
+const BODY_A = `# ${TITLE_A}\n\n${TEXT_A}`;
+/** 他の端末が書いた版。同期で降ってきたことにする。 */
+const BODY_A_SYNCED = "# 会議メモ (同期後)\n\n他の端末で足された行";
+const TITLE_B = "買い物";
+const BODY_B = `# ${TITLE_B}\n\n牛乳`;
 
-/** ディスクの中身。テストの途中で外から書き換わったことにする。 */
-let diskBody: string;
-/** 呼ばれた Tauri コマンドの記録。読み直し経路が何も書かないことを見る。 */
-let calls: string[];
+/** ディスクの中身(filename → 全文)。テストの途中で外から書き換わったことにする。 */
+let disk: Map<string, string>;
+/** 呼ばれたコマンドと引数。どのノートに何が書かれたかをこれで見る。 */
+let calls: { cmd: string; args: Record<string, unknown> }[];
+/** read_note を止めておく関門。応答が届く前の操作を再現する。 */
+let readGate: Promise<void> | undefined;
+let openGate: (() => void) | undefined;
+/** update_draft が飛んでいる間に起きること。往復の途中の打鍵を再現する。 */
+let duringSave: (() => void) | undefined;
+
+/** 本文の指紋。core と同じ「読んだ版で書く」照合をテストでも同じ形で行う。 */
+const revisionOf = (body: string): string => `rev:${body}`;
+
+const countOf = (command: string): number => calls.filter((c) => c.cmd === command).length;
+
+/** そのノートへの書き込みだけを取り出す。隣のノートへ着地していないかを見る。 */
+const writesTo = (filename: string): Record<string, unknown>[] =>
+  calls
+    .filter((c) => c.cmd === "update_draft" && String(c.args.filePath).endsWith(filename))
+    .map((c) => c.args);
+
+/** 一覧の 1 行。時刻はファイル名(= ID)から導く。 */
+const summaryOf = (filename: string): Record<string, unknown> => ({
+  path: `/data/notes/${filename}`,
+  filename,
+  time:
+    `${filename.slice(0, 4)}-${filename.slice(4, 6)}-${filename.slice(6, 8)}` +
+    `T${filename.slice(9, 11)}:${filename.slice(11, 13)}:${filename.slice(13, 15)}+09:00`,
+  tags: [],
+  preview: disk.get(filename) ?? "",
+});
 
 const WRITE_COMMANDS = ["update_draft", "create_draft", "set_note_view", "delete_note"];
 
-const countOf = (command: string): number => calls.filter((c) => c === command).length;
+/** Tauri から返る SaveError の形。フロントが見るのは `kind` だけ。 */
+const saveError = (kind: string, message: string): Error =>
+  Object.assign(new Error(message), { kind });
 
-const HANDLERS: Record<string, () => unknown> = {
-  list_notes: () => [
-    {
-      path: `/data/notes/${FILENAME}`,
-      filename: FILENAME,
-      time: "2026-09-03T12:00:00+09:00",
-      tags: [],
-      preview: diskBody,
-    },
-  ],
+const HANDLERS: Record<string, (args: Record<string, unknown>) => unknown> = {
+  list_notes: () => [...disk.keys()].map((filename) => summaryOf(filename)),
   list_templates: () => [],
   find_backlinks: () => [],
-  read_note: () => ({ body: diskBody, revision: `rev-${diskBody.length}` }),
-  read_note_meta: () => ({}),
+  read_note: async ({ filename }) => {
+    await readGate;
+    const body = disk.get(String(filename));
+    if (body === undefined) {
+      throw new Error(`note not found: ${String(filename)}`);
+    }
+    return { body, revision: revisionOf(body) };
+  },
+  read_note_meta: ({ filename }) => ({
+    time: summaryOf(String(filename)).time,
+    tags: [],
+  }),
+  create_draft: () => {
+    disk.set(FILE_B, "");
+    return `/data/notes/${FILE_B}`;
+  },
+  update_draft: ({ filePath, body, revision }) => {
+    duringSave?.();
+    const filename = String(filePath).split("/").at(-1) ?? "";
+    const current = disk.get(filename);
+    if (current === undefined) {
+      throw saveError("other", `note not found: ${filename}`);
+    }
+    // core と同じ照合。読んでから誰かが書き換えていれば、その上に書かない
+    if (typeof revision === "string" && revision !== revisionOf(current)) {
+      throw saveError("stale", `Stale: ${filename} changed since it was read`);
+    }
+    disk.set(filename, String(body));
+    return revisionOf(String(body));
+  },
+  delete_note: ({ filename }) => {
+    disk.delete(String(filename));
+  },
+  set_note_view: () => null,
 };
 
 let shell: Shell | undefined;
+let navigateTo: ((to: string) => void) | undefined;
 
 function CaptureShell(): JSX.Element {
   shell = useShell();
   return null;
 }
 
-/** ノートを 1 件開いた状態まで進める。狭い画面では詳細を開くまで本文が出ない。 */
-async function renderWorkspace(): Promise<void> {
+/** ウィジェットの `?file=` を流し込めるように、ルータの中から navigate を借りる。 */
+function WorkspaceRoute(): JSX.Element {
+  const navigate = useNavigate();
+  navigateTo = (to) => navigate(to);
+  return <Workspace />;
+}
+
+/** ノート A を 1 件開いた状態まで進める。狭い画面では詳細を開くまで本文が出ない。 */
+async function openNoteA(): Promise<void> {
   render(() => (
     <ShellProvider>
       <CaptureShell />
       <MemoryRouter>
-        <Route path="/" component={Workspace} />
+        <Route path="/" component={WorkspaceRoute} />
       </MemoryRouter>
     </ShellProvider>
   ));
-  fireEvent.click(await screen.findByRole("button", { name: /会議メモ/u }));
-  await waitFor(() => expect(screen.getByText("ここまで書いた")).toBeDefined());
+  fireEvent.click(await screen.findByRole("button", { name: new RegExp(TITLE_A, "u") }));
+  await waitFor(() => expect(screen.getByText(TEXT_A)).toBeDefined());
 }
 
 function titleInput(): HTMLInputElement {
   return screen.getByPlaceholderText<HTMLInputElement>("タイトル");
 }
 
-describe("Workspace › 外から書き換わったノートの読み直し", () => {
-  beforeEach(() => {
-    diskBody = BODY_BEFORE;
-    calls = [];
-    shell = undefined;
-    mockWindows("main");
-    mockIPC((cmd) => {
-      calls.push(cmd);
-      const handler = HANDLERS[cmd];
-      if (!handler) {
-        throw new Error(`unexpected command ${cmd}`);
-      }
-      return handler();
-    });
-  });
+/** タイトル欄の Enter が編集の入り口。エディタは lazy なので届くまで待つ。 */
+async function startEditingBody(): Promise<void> {
+  fireEvent.keyDown(titleInput(), { key: "Enter" });
+  await waitFor(() => expect(screen.getByTestId("editor-body")).toBeDefined());
+}
 
-  afterEach(() => {
-    cleanup();
-    clearMocks();
-    document.body.innerHTML = "";
+/** 「新規」→「空のノート」。テンプレのシートを経由するのは本物と同じ順序。 */
+async function createEmptyNote(): Promise<void> {
+  fireEvent.click(screen.getByRole("button", { name: /新規/u }));
+  fireEvent.click(await screen.findByRole("menuitem", { name: /空のノート/u }));
+}
+
+const blockReads = (): void => {
+  const gate = Promise.withResolvers<void>();
+  readGate = gate.promise;
+  openGate = gate.resolve;
+};
+
+const releaseReads = (): void => {
+  openGate?.();
+  readGate = undefined;
+  openGate = undefined;
+};
+
+/** ディスク・IPC・画面の幅を、テスト 1 本ぶんの初期状態に戻す。 */
+async function setupWorkspace(): Promise<void> {
+  // 一覧と詳細が並ぶ幅。編集中に「+ 新規」を押せるのはこの形のときだけで、
+  // 携帯の幅では一覧ペインごと隠れている
+  await page.viewport(1280, 800);
+  disk = new Map([[FILE_A, BODY_A]]);
+  calls = [];
+  shell = undefined;
+  navigateTo = undefined;
+  typeInEditor = undefined;
+  duringSave = undefined;
+  releaseReads();
+  localStorage.clear();
+  mockWindows("main");
+  mockIPC((cmd, args) => {
+    const payload = (args ?? {}) as Record<string, unknown>;
+    calls.push({ cmd, args: payload });
+    const handler = HANDLERS[cmd];
+    if (!handler) {
+      throw new Error(`unexpected command ${cmd}`);
+    }
+    return handler(payload);
   });
+}
+
+function teardownWorkspace(): void {
+  // 止めたままの読みを解いてから畳む。待ち続ける promise を残さない
+  releaseReads();
+  cleanup();
+  clearMocks();
+  document.body.innerHTML = "";
+}
+
+describe("Workspace › 外から書き換わったノートの読み直し", () => {
+  beforeEach(setupWorkspace);
+  afterEach(teardownWorkspace);
 
   // 同期でダウンロードされた変更が、開いたままのノートに届く
   it("reloads the open note when dataVersion increases", async () => {
-    await renderWorkspace();
-    expect(titleInput().value).toBe("会議メモ");
+    await openNoteA();
+    expect(titleInput().value).toBe(TITLE_A);
 
-    diskBody = BODY_AFTER;
+    disk.set(FILE_A, BODY_A_SYNCED);
     shell?.refreshData();
 
     await waitFor(() => expect(screen.getByText("他の端末で足された行")).toBeDefined());
@@ -114,20 +226,80 @@ describe("Workspace › 外から書き換わったノートの読み直し", ()
 
   // エディタを開いたまま本文を差し替えると、カーソル・選択・IME が消える
   it("leaves the body alone while the editor is open", async () => {
-    await renderWorkspace();
-    fireEvent.keyDown(titleInput(), { key: "Enter" });
-    await waitFor(() => expect(screen.getByTestId("editor-body")).toBeDefined());
+    await openNoteA();
+    await startEditingBody();
     const readsBefore = countOf("read_note");
 
-    diskBody = BODY_AFTER;
+    disk.set(FILE_A, BODY_A_SYNCED);
     shell?.refreshData();
 
     // 一覧の読み直しが届くまで待つ。そのうえで本文だけが読み直されないことを見る
     await screen.findByText("会議メモ (同期後)");
     expect(countOf("read_note")).toBe(readsBefore);
-    expect(screen.getByTestId("editor-body").textContent).toBe("ここまで書いた");
+    expect(screen.getByTestId("editor-body").textContent).toBe(TEXT_A);
     for (const command of WRITE_COMMANDS) {
       expect(countOf(command)).toBe(0);
     }
+  });
+});
+
+describe("Workspace › 編集中に選択が差し替わる", () => {
+  beforeEach(setupWorkspace);
+  afterEach(teardownWorkspace);
+
+  // 「+ 新規」は編集中でも押せる。押した瞬間に選択だけが移ると、
+  // 次の保存が新しいノートに前のノートの本文を書く
+  it("keeps the typed body in its own note when a new note takes the selection", async () => {
+    await openNoteA();
+    await startEditingBody();
+    typeInEditor?.(`${TEXT_A}\n\nもう一行`);
+
+    await createEmptyNote();
+    await waitFor(() => expect(titleInput().value).toBe(""));
+
+    // 画面を離れると、待っている保存は出しきられる
+    cleanup();
+    await waitFor(() => expect(countOf("update_draft")).toBe(1));
+    expect(writesTo(FILE_B)).toStrictEqual([]);
+    expect(disk.get(FILE_A)).toContain("もう一行");
+    expect(disk.get(FILE_B)).toBe("");
+  });
+
+  // ウィジェットの行から `?file=` で別のノートが開く経路も同じ
+  it("keeps the typed body in its own note when ?file= opens another note", async () => {
+    disk.set(FILE_B, BODY_B);
+    await openNoteA();
+    await startEditingBody();
+    typeInEditor?.(`${TEXT_A}\n\nもう一行`);
+
+    navigateTo?.(`/?file=${FILE_B}`);
+    await waitFor(() => expect(titleInput().value).toBe(TITLE_B));
+
+    cleanup();
+    await waitFor(() => expect(countOf("update_draft")).toBe(1));
+    expect(writesTo(FILE_B)).toStrictEqual([]);
+    expect(disk.get(FILE_A)).toContain("もう一行");
+    expect(disk.get(FILE_B)).toBe(BODY_B);
+  });
+
+  // 削除は隣のノートを選ぶ。待っている保存はそれでも「打った本人」に着地する
+  it("keeps the typed body in its own note when a delete moves the selection", async () => {
+    disk.set(FILE_B, BODY_B);
+    await openNoteA();
+    await startEditingBody();
+    typeInEditor?.(`${TEXT_A}\n\nもう一行`);
+
+    // 隣のノートの本文が届く前にタイトル欄を離れる = 待っている保存を出しきる
+    blockReads();
+    fireEvent.click(screen.getByRole("button", { name: "削除" }));
+    fireEvent.change(titleInput(), { target: { value: TITLE_A } });
+
+    // 打った字は消すノートに着地する。隣のノートには何も書かない
+    await waitFor(() => expect(disk.get(FILE_A)).toContain("もう一行"), { timeout: 3000 });
+    expect(writesTo(FILE_B)).toStrictEqual([]);
+
+    // 5 秒後の本削除はテストの外まで生き残る。UI の「元に戻す」と同じ道で畳む
+    await waitFor(() => expect(shell?.toast()?.undo).toBeInstanceOf(Function));
+    shell?.toast()?.undo?.();
   });
 });

--- a/tauri-app/src/views/Workspace.test.tsx
+++ b/tauri-app/src/views/Workspace.test.tsx
@@ -302,4 +302,23 @@ describe("Workspace › 編集中に選択が差し替わる", () => {
     await waitFor(() => expect(shell?.toast()?.undo).toBeInstanceOf(Function));
     shell?.toast()?.undo?.();
   });
+
+  // フォーカス復帰の読み直しが飛んでいる間にタップして書き始めると、
+  // 画面に出ているのは読む前の本文。保存に添える版もそれに揃っていないと、
+  // 相手の版を「読んだつもり」で潰す
+  it("saves with the revision it actually read when a refresh lands mid-edit", async () => {
+    await openNoteA();
+
+    blockReads();
+    disk.set(FILE_A, BODY_A_SYNCED);
+    shell?.refreshData();
+    await startEditingBody();
+    typeInEditor?.(`${TEXT_A}\n\nこの端末で足した行`);
+    releaseReads();
+
+    await waitFor(() => expect(countOf("update_draft")).toBe(1), { timeout: 3000 });
+    expect(writesTo(FILE_A)[0]?.revision).toBe(revisionOf(BODY_A));
+    // 読んだ版で断られるので、相手の行は残る
+    expect(disk.get(FILE_A)).toBe(BODY_A_SYNCED);
+  });
 });

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -278,11 +278,22 @@ export default function Workspace(): JSX.Element {
     item: NoteItem;
     body: string;
     session: EditSession;
+    /** 写しを取った時点の世代。読み直しをまたいだ写しは書かない。 */
+    generation: number;
   }
+
+  /**
+   * 保存の世代。外からの書き換えに譲って読み直すたびに 1 つ進める。
+   * 譲るより前に `saveChain` に並んだ写しは、読み直した版を知らないまま
+   * 順番が来る。そのまま書くと、いま画面に出ている相手の本文を古い draft で
+   * 潰す — 読み直しで `revisions` が新しくなっているので core も止められない。
+   * `session.lastSavedBody` を合わせるだけでは「同じ本文の写し」しか止まらない。
+   */
+  let saveGeneration = 0;
 
   const snapshotSave = (): PendingSave | undefined => {
     const item = selected();
-    return item ? { item, body: fullBody(), session } : undefined;
+    return item ? { item, body: fullBody(), session, generation: saveGeneration } : undefined;
   };
 
   /**
@@ -292,7 +303,11 @@ export default function Workspace(): JSX.Element {
    * 相手の版がバックアップに回るので、どちらも失わない。
    */
   const yieldToOutsideEdit = async (pending: PendingSave): Promise<void> => {
-    writeBackup(localStorage, pending.item.filename, pending.body);
+    // 退避するのは飛んでいった写しではなく、いま画面にある本文。Stale が
+    // 返るまでの往復のあいだに打った字は、まだファイルにもここにも無い
+    const typed = selected()?.id === pending.item.id ? fullBody() : pending.body;
+    writeBackup(localStorage, pending.item.filename, typed);
+    saveGeneration += 1;
     if (saveTimer) {
       clearTimeout(saveTimer);
       saveTimer = undefined;
@@ -310,8 +325,13 @@ export default function Workspace(): JSX.Element {
     saveChain = (async () => {
       await previous;
       // 触っていない誤タップのセッションを書き込みに変えない。書いても
-      // 内容が変わらないなら、ファイルの mtime を動かして同期を起こすだけ
-      if (!pending || !shouldSave(pending.session, pending.body)) {
+      // 内容が変わらないなら、ファイルの mtime を動かして同期を起こすだけ。
+      // 読み直しをまたいだ写しも書かない(世代が置いていかれている)
+      if (
+        !pending ||
+        pending.generation !== saveGeneration ||
+        !shouldSave(pending.session, pending.body)
+      ) {
         return;
       }
       setSaveStatus("saving");

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -388,25 +388,35 @@ export default function Workspace(): JSX.Element {
   };
 
   /**
+   * 開いている編集を畳んでから戻る。選択を動かす手前で必ず通す道。
+   * 畳まずに移ると `fullBody()` が「次のノートの題 + 前のノートの本文」に
+   * なり、次の保存がその混ぜ物を隣のノートへ書き込む。読み直しが
+   * `revisions` を更新済みなので Stale でも止まらない。
+   * 編集していないときに `stopEditing` を呼ばないのは、あれが `draft()` を
+   * 本文に据えるから — 開いていない draft は前のノートのものだ。
+   */
+  const settleEdit = (): Promise<void> => (editing() ? stopEditing() : Promise.resolve());
+
+  /**
    * 選択を差し替える唯一の入口。一覧のタップ・ウィジェットの `?file=`・
    * 新規作成・テンプレ・バックリンクは全部ここを通る。入口ごとに
    * 「編集中だったらどうするか」を書くと、書き忘れた入口だけが前のノートの
    * 本文を次のノートへ持ち込む — 入口が増えても書く場所は 1 つにしておく。
    */
-  function switchTo(id: string): void {
+  async function switchTo(id: string): Promise<void> {
+    await settleEdit();
     setSelectedId(id);
     setDetailOpen(true);
   }
 
   const select = (item: NoteItem): void => {
     shell.closePopovers();
-    setEditing(false);
-    switchTo(item.id);
+    void switchTo(item.id);
   };
 
   const openBacklink = (hit: SearchHit): void => {
     if (hit.kind === "note" && hit.filename) {
-      switchTo(hit.filename);
+      void switchTo(hit.filename);
     } else {
       navigate(`${ROUTES.TIMELINE}?day=${hit.date}`);
     }
@@ -419,7 +429,7 @@ export default function Workspace(): JSX.Element {
       () => searchParams.file,
       (file) => {
         if (typeof file === "string" && file) {
-          switchTo(file);
+          void switchTo(file);
         }
       },
     ),
@@ -471,7 +481,7 @@ export default function Workspace(): JSX.Element {
     // 書き始める操作ではないから — マインドマップでも踏める
     const noteLink = target?.closest("a.note-link");
     if (noteLink instanceof HTMLElement && noteLink.dataset.file) {
-      switchTo(noteLink.dataset.file);
+      void switchTo(noteLink.dataset.file);
       return;
     }
     // リンクは踏める・図はズームのまま・道具は道具のまま・バックリンク欄は
@@ -603,7 +613,10 @@ export default function Workspace(): JSX.Element {
   let newNotePointer = "mouse";
 
   // ---- 削除 + Undo（5秒は tombstone、経過後に本削除）----
-  const remove = (item: NoteItem): void => {
+  const remove = async (item: NoteItem): Promise<void> => {
+    // 隣を選ぶ前に編集を畳む。switchTo と同じ理屈だが、削除は詳細ペインを
+    // 開かない(狭い端末では隣を開いたままにする)ので switchTo は通さない
+    await settleEdit();
     // 隠す前に隣を決める。selected は一覧から消えた id を先頭へ倒すので、
     // 何もしないと削除のたびに最上段へ飛ばされる。隣なら目線は動かない。
     // detailOpen は触らない — 今まで通り、端末が狭ければ隣を開いたままにする
@@ -795,7 +808,9 @@ export default function Workspace(): JSX.Element {
                     class="icon-button"
                     title={t().common.delete}
                     aria-label={t().common.delete}
-                    onClick={() => remove(item())}
+                    onClick={() => {
+                      void remove(item());
+                    }}
                   >
                     <Icon name="trash" size={17} />
                   </button>

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -365,6 +365,9 @@ export default function Workspace(): JSX.Element {
       clearTimeout(saveTimer);
     }
     saveTimer = setTimeout(() => {
+      // 起きたタイマーは終わったタイマー。掃除しないと「保存待ちがある」が
+      // 立ったままになり、フォーカス復帰の読み直しが二度と通らない
+      saveTimer = undefined;
       void flushSave(pending);
     }, SAVE_DEBOUNCE_MS);
   };
@@ -552,6 +555,13 @@ export default function Workspace(): JSX.Element {
       return;
     }
     writeBackup(localStorage, item.filename, current);
+    // 入れ替えたので、いまの「戻る先」はこの控え。控えを取り終えた
+    // セッションとして開き直す — 開き直さないと、次に題や本文を触った
+    // ときに新しいセッションが立ち上がり、その最初の保存が復元直前の本文を
+    // 控えに書いて、もう一度押しても戻れなくなる
+    session = beginEditSession(backup);
+    session.committed = true;
+    sessionFile = item.filename;
     const titled = splitTitle(backup);
     batch(() => {
       setNoteTitle(titled.title);

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -129,6 +129,11 @@ export default function Workspace(): JSX.Element {
    * のは、保存が遅れて届く頃には別のノートが選ばれていることがあるから。
    */
   const revisions = new Map<string, string>();
+  /**
+   * 走っている自動保存のタイマー。「まだディスクに無い本文がある」の合図で、
+   * 読み直しを抑える判断がこれを読む。他の編集セッションの状態と一緒に置く。
+   */
+  let saveTimer: ReturnType<typeof setTimeout> | undefined;
 
   const visibleItems = createMemo<NoteItem[]>(() => {
     const dropped = new Set(hidden());
@@ -192,12 +197,16 @@ export default function Workspace(): JSX.Element {
         () => typedInvoke("read_note", { filename: item.filename }),
         () => typedInvoke("read_note_meta", { filename: item.filename }),
       );
-      revisions.set(item.filename, content.revision);
       // 一覧を素早くたどると、遅い読みが速い読みを追い越して届く。
-      // いま選ばれているノートへの答えだけを画面に出す
-      if (selected()?.id !== item.id) {
+      // いま選ばれているノートへの答えだけを画面に出す。読み始める前に
+      // 確かめた「編集中でも保存待ちでもない」も、届いた時点でもう一度見る —
+      // 応答を待つあいだにタップして書き始められる。
+      // revision まで見送るのは、画面に出していない版で保存に行くと、
+      // 読んでいない相手の本文の上に書けてしまうから
+      if (selected()?.id !== item.id || editing() || saveTimer) {
         return;
       }
+      revisions.set(item.filename, content.revision);
       // 本文とモードは対で出す。バラすと一瞬だけ違うモードで描かれる
       const titled = splitTitle(content.body);
       batch(() => {
@@ -258,7 +267,6 @@ export default function Workspace(): JSX.Element {
   };
 
   // ---- 編集（自動保存: 1秒 debounce + 直列化）----
-  let saveTimer: ReturnType<typeof setTimeout> | undefined;
   let saveChain: Promise<void> = Promise.resolve();
 
   /**

--- a/tauri-app/src/views/Workspace.tsx
+++ b/tauri-app/src/views/Workspace.tsx
@@ -185,29 +185,6 @@ export default function Workspace(): JSX.Element {
     (filename) => typedInvoke("find_backlinks", { filename }),
   );
 
-  const openBacklink = (hit: SearchHit): void => {
-    if (hit.kind === "note" && hit.filename) {
-      setSelectedId(hit.filename);
-      setDetailOpen(true);
-    } else {
-      navigate(`${ROUTES.TIMELINE}?day=${hit.date}`);
-    }
-  };
-
-  // ウィジェットの行から `?file=` 付きで来たときだけ、その 1 件を開く。
-  // 一覧が届く前に来ることがあるが、id はファイル名そのものなので先に置ける
-  createEffect(
-    on(
-      () => searchParams.file,
-      (file) => {
-        if (typeof file === "string" && file) {
-          setSelectedId(file);
-          setDetailOpen(true);
-        }
-      },
-    ),
-  );
-
   /** ディスクから読み直して画面に出す。選択の切り替えと、外からの書き換えの後に。 */
   const loadNote = async (item: NoteItem): Promise<void> => {
     try {
@@ -278,13 +255,6 @@ export default function Workspace(): JSX.Element {
     } catch {
       setNoteView(previous);
     }
-  };
-
-  const select = (item: NoteItem): void => {
-    shell.closePopovers();
-    setSelectedId(item.id);
-    setEditing(false);
-    setDetailOpen(true);
   };
 
   // ---- 編集（自動保存: 1秒 debounce + 直列化）----
@@ -402,6 +372,59 @@ export default function Workspace(): JSX.Element {
     ),
   );
 
+  const stopEditing = async (): Promise<void> => {
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = undefined;
+    }
+    await flushSave();
+    // 書き終えた本文が真実。読み直しを待ってからプレビューを出すと
+    // 一瞬だけ編集前の本文が見える
+    setNoteBody(draft());
+    setEditing(false);
+    // 次に書き始めるときは新しいセッション。戻る先が 1 段ずつ進む
+    sessionFile = null;
+    await refetchNotes();
+  };
+
+  /**
+   * 選択を差し替える唯一の入口。一覧のタップ・ウィジェットの `?file=`・
+   * 新規作成・テンプレ・バックリンクは全部ここを通る。入口ごとに
+   * 「編集中だったらどうするか」を書くと、書き忘れた入口だけが前のノートの
+   * 本文を次のノートへ持ち込む — 入口が増えても書く場所は 1 つにしておく。
+   */
+  function switchTo(id: string): void {
+    setSelectedId(id);
+    setDetailOpen(true);
+  }
+
+  const select = (item: NoteItem): void => {
+    shell.closePopovers();
+    setEditing(false);
+    switchTo(item.id);
+  };
+
+  const openBacklink = (hit: SearchHit): void => {
+    if (hit.kind === "note" && hit.filename) {
+      switchTo(hit.filename);
+    } else {
+      navigate(`${ROUTES.TIMELINE}?day=${hit.date}`);
+    }
+  };
+
+  // ウィジェットの行から `?file=` 付きで来たときだけ、その 1 件を開く。
+  // 一覧が届く前に来ることがあるが、id はファイル名そのものなので先に置ける
+  createEffect(
+    on(
+      () => searchParams.file,
+      (file) => {
+        if (typeof file === "string" && file) {
+          switchTo(file);
+        }
+      },
+    ),
+  );
+
   const startEditing = (point?: CaretPoint): void => {
     if (!selected()) {
       return;
@@ -448,8 +471,7 @@ export default function Workspace(): JSX.Element {
     // 書き始める操作ではないから — マインドマップでも踏める
     const noteLink = target?.closest("a.note-link");
     if (noteLink instanceof HTMLElement && noteLink.dataset.file) {
-      setSelectedId(noteLink.dataset.file);
-      setDetailOpen(true);
+      switchTo(noteLink.dataset.file);
       return;
     }
     // リンクは踏める・図はズームのまま・道具は道具のまま・バックリンク欄は
@@ -532,21 +554,6 @@ export default function Workspace(): JSX.Element {
     return backup !== null && backup !== fullBody();
   });
 
-  const stopEditing = async (): Promise<void> => {
-    if (saveTimer) {
-      clearTimeout(saveTimer);
-      saveTimer = undefined;
-    }
-    await flushSave();
-    // 書き終えた本文が真実。読み直しを待ってからプレビューを出すと
-    // 一瞬だけ編集前の本文が見える
-    setNoteBody(draft());
-    setEditing(false);
-    // 次に書き始めるときは新しいセッション。戻る先が 1 段ずつ進む
-    sessionFile = null;
-    await refetchNotes();
-  };
-
   const createNote = async (): Promise<void> => {
     const path = await typedInvoke("create_draft", {
       body: "",
@@ -558,9 +565,8 @@ export default function Workspace(): JSX.Element {
     // 前に開いていたノートの題を書き換えることになる
     const filename = path.split("/").at(-1);
     if (filename) {
-      setSelectedId(filename);
+      await switchTo(filename);
     }
-    setDetailOpen(true);
   };
 
   /**
@@ -579,9 +585,8 @@ export default function Workspace(): JSX.Element {
       await refetchNotes();
       const filename = created.path.split("/").at(-1);
       if (filename) {
-        setSelectedId(filename);
+        await switchTo(filename);
       }
-      setDetailOpen(true);
       if (created.reused) {
         shell.showToast(t().templates.reused(template.name));
       }


### PR DESCRIPTION
## なぜやるか

編集中に別のノートを開く(新規、テンプレ、ウィジェットの `?file=`、バックリンク、削除後の隣)と、エディタが前のノートの本文を持ったまま選択だけが移り、次の自動保存が「新しい題 + 前の本文」を新しいノートに書いていた。読み直しが revision を更新済みなので Stale では止まらず、控えも上書きされて戻せない。

同じずれから来る穴が他に 3 つあった。マージ後監査 Batch A の 4 件。

## やったこと

選択を動かす入口を 1 つに寄せ、そこで編集を畳んでから選択を移す(緑が今回入った部分)。

```mermaid
flowchart LR
  list["一覧のタップ"] --> sw
  link["?file= / バックリンク / プレビュー内リンク"] --> sw
  create["新規 / テンプレ"] --> sw
  del["削除後に隣へ"] --> settle
  sw["switchTo"] --> settle["編集を畳む(保存を流す)"]
  settle --> sel["選択を移す"]

  classDef added stroke:#3fb950,stroke-width:3px
  class sw,settle added
```

- 選択が動く前に、打った本文はそのノートへ書き終わる
- 画面に出していない版で保存に行かない
  - フォーカス復帰の読み直しは、応答が届いた時点でも編集中・保存待ちを確かめる
  - Stale で控えに取るのは飛んだ写しではなく画面の本文。読み直しをまたいだ保存待ちは世代で捨てる
- 復元は「控えを取り終えたセッション」として開き直し、もう一度押しても戻れる
  - 自動保存のタイマーを発火時に片付ける。残ると読み直しが二度と通らなかった

## やらなかったこと

- 読み失敗(catch 側)の編集中ガード。観測できる害がなく Red が書けない → #195
- `onCleanup` / `commitTitle` が写しを取り直す形。到達する経路が今は無い → #194

## 資料

- 計画: `sample/plans/13-post-merge-audit-fixes.md` の Batch A
- #181 フォーカス復帰の読み直し
