### PR TITLE
chore(dev): hold the browser IPC mock to the same checks as src

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,13 @@ jobs:
               - 'rust/justfile'
             frontend:
               - 'tauri-app/src/**'
+              - 'tauri-app/dev/**'
               - '.oxlintrc.json'
               - 'tauri-app/.oxlintrc.json'
               - 'tauri-app/package.json'
               - 'tauri-app/pnpm-lock.yaml'
               - 'tauri-app/tsconfig.json'
+              - 'tauri-app/tsconfig.dev.json'
               - 'tauri-app/vite.config.ts'
               - 'tauri-app/vitest.config.ts'
               - 'tauri-app/justfile'

--- a/tauri-app/dev/ipc-mock.js
+++ b/tauri-app/dev/ipc-mock.js
@@ -5,9 +5,74 @@
  * インライン注入する。モジュールグラフより先に実行される普通の <script> なので、
  * `@tauri-apps/api` が `window.__TAURI_INTERNALS__` を読む頃には必ず居る。
  * プロダクションビルドには一切含まれない。
+ *
+ * 作り物の状態(タイムライン・ノート・テンプレ)は IIFE の中に閉じる。外に出て
+ * いるのは、その状態を何も見ない純粋なヘルパだけ。
  */
+
+const pad = (n) => String(n).padStart(2, "0");
+
+/** core の `format_stamp` と同じトークン。strftime には渡さない。 */
+const formatStamp = (date, pattern) =>
+  pattern
+    .replaceAll("YYYY", String(date.getFullYear()))
+    .replaceAll("MM", pad(date.getMonth() + 1))
+    .replaceAll("DD", pad(date.getDate()))
+    .replaceAll("HH", pad(date.getHours()))
+    .replaceAll("mm", pad(date.getMinutes()))
+    .replaceAll("ss", pad(date.getSeconds()));
+
+/** ノートのファイル名になる `YYYYMMDD_HHMMSS`。 */
+const stampOf = (date) =>
+  `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}_${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
+
+const templateSummary = (filename, template) => ({
+  filename,
+  name: filename.replace(/\.md$/u, ""),
+  tags: template.tags,
+  preview: (template.body.split("\n").find((line) => line.trim()) ?? "")
+    .replace(/^#+\s*/u, "")
+    .trim(),
+});
+
+/** 本物は data:image/svg+xml;base64 で返す。ここも同じ形にしておく。 */
+const svgDataUrl = (svg) => `data:image/svg+xml;base64,${btoa(svg)}`;
+
+const glyphSvg = (label, fill) =>
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="${fill}"/><text x="16" y="21" font-size="12" font-family="sans-serif" font-weight="700" text-anchor="middle" fill="#fff">${label}</text></svg>`;
+
+const delay = (ms) =>
+  // oxlint-disable-next-line promise/avoid-new
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+// core の Revision の代わり。本文が同じなら同じ値、違えば違う値になれば足りる
+const revisionOf = (body) => {
+  let hash = 5381;
+  for (const ch of body) {
+    hash = ((hash * 33) ^ ch.codePointAt(0)) >>> 0;
+  }
+  return hash.toString(16);
+};
+
+const placeKey = (lat, lon) => `${lat.toFixed(2)},${lon.toFixed(2)}`;
+
+/** 本流(core)の utils::tags と同じ規則: ASCII の大小は見ない。 */
+const lowerTag = (tag) => tag.replaceAll(/[A-Z]/gu, (c) => c.toLowerCase());
+
+/** core が返す一致位置と同じ数え方。UTF-16 の要素数ではなく文字数で数える。 */
+const charCount = (text) => [...text].length;
+
+/**
+ * `update_draft` の失敗。本物は Rust 側の JSON がそのまま届くので `kind` を持つ
+ * ただのオブジェクトだが、Error に同じキーを生やしても `isStaleSave` の見る形は
+ * 変わらない(`typeof` が object で `kind` を持つ)。
+ */
+const saveError = (kind, message) => Object.assign(new Error(message), { kind });
+
 (() => {
-  if (window.__TAURI_INTERNALS__) {
+  if (globalThis.__TAURI_INTERNALS__) {
     return;
   }
 
@@ -31,8 +96,6 @@
     "読書メモ: 設計の背景を残すことについて",
     "ウィジェットからの起動導線を確認した",
   ];
-
-  const pad = (n) => String(n).padStart(2, "0");
 
   /** 書いた入り口の固定語彙。`undefined` は名乗る前に書かれた記録。 */
   const SOURCES = ["app", "widget", "cli", "mcp", undefined];
@@ -216,15 +279,23 @@
   const noteList = () =>
     [...notes.entries()]
       .toSorted(([a], [b]) => b.localeCompare(a))
-      .map(([filename, note]) => ({
-        path: `/mock/data/${filename}`,
-        filename,
-        time: note.time,
-        tags: note.tags,
-        preview: note.body.slice(0, 120),
-        ...(note.origin ? { origin: note.origin } : {}),
-        ...(note.template ? { template: note.template } : {}),
-      }));
+      .map(([filename, note]) => {
+        const summary = {
+          path: `/mock/data/${filename}`,
+          filename,
+          time: note.time,
+          tags: note.tags,
+          preview: note.body.slice(0, 120),
+        };
+        // core が `skip_serializing_if` で落とすのと同じく、無いキーは生やさない
+        if (note.origin) {
+          summary.origin = note.origin;
+        }
+        if (note.template) {
+          summary.template = note.template;
+        }
+        return summary;
+      });
 
   // ---- テンプレートのつくりもの ----
 
@@ -258,17 +329,7 @@
     en: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
   };
 
-  /** core の `format_stamp` と同じトークン。strftime には渡さない。 */
-  const formatStamp = (date, pattern) =>
-    pattern
-      .replaceAll("YYYY", String(date.getFullYear()))
-      .replaceAll("MM", pad(date.getMonth() + 1))
-      .replaceAll("DD", pad(date.getDate()))
-      .replaceAll("HH", pad(date.getHours()))
-      .replaceAll("mm", pad(date.getMinutes()))
-      .replaceAll("ss", pad(date.getSeconds()));
-
-  const PREV_LINE = /\{\{\s*prev\s*(:[^}]*)?\}\}/;
+  const PREV_LINE = /\{\{\s*prev\s*(?::[^}]*)?\}\}/u;
 
   /**
    * core の `resolve_vars` と同じ規則で解く。ハーネスだけ違う結果を返すと、
@@ -280,37 +341,30 @@
       // 前回が無いときは、その行を丸ごと落とす(「前回: 」だけを残さない)
       .filter((line) => prev !== null || !PREV_LINE.test(line))
       .map((line) =>
-        line.replaceAll(/\{\{([^}]*)\}\}/g, (raw, inner) => {
+        line.replaceAll(/\{\{(?<inner>[^}]*)\}\}/gu, (raw, inner) => {
           const at = inner.indexOf(":");
           const name = (at === -1 ? inner : inner.slice(0, at)).trim();
           const arg = at === -1 ? undefined : inner.slice(at + 1).trim();
           const now = new Date();
-          if (name === "date") return formatStamp(now, arg || "YYYY-MM-DD");
-          if (name === "time") return formatStamp(now, arg || "HH:mm");
-          if (name === "weekday") return (WEEKDAYS[locale] ?? WEEKDAYS.en)[now.getDay()];
-          if (name === "prev") return prev ?? "";
+          if (name === "date") {
+            return formatStamp(now, arg || "YYYY-MM-DD");
+          }
+          if (name === "time") {
+            return formatStamp(now, arg || "HH:mm");
+          }
+          if (name === "weekday") {
+            return (WEEKDAYS[locale] ?? WEEKDAYS.en)[now.getDay()];
+          }
+          if (name === "prev") {
+            return prev ?? "";
+          }
           // 知らない変数は書いたまま残す
           return raw;
         }),
       )
       .join("\n");
 
-  const templateSummary = (filename, template) => ({
-    filename,
-    name: filename.replace(/\.md$/, ""),
-    tags: template.tags,
-    preview: (template.body.split("\n").find((line) => line.trim()) ?? "")
-      .replace(/^#+\s*/, "")
-      .trim(),
-  });
-
   // ---- グリフのつくりもの ----
-
-  /** 本物は data:image/svg+xml;base64 で返す。ここも同じ形にしておく。 */
-  const svgDataUrl = (svg) => `data:image/svg+xml;base64,${btoa(svg)}`;
-
-  const glyphSvg = (label, fill) =>
-    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="${fill}"/><text x="16" y="21" font-size="12" font-family="sans-serif" font-weight="700" text-anchor="middle" fill="#fff">${label}</text></svg>`;
 
   /** name -> { format, url }。 */
   const glyphs = new Map([
@@ -319,22 +373,6 @@
   ]);
 
   // ---- コマンド実装 ----
-
-  const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-  // core の Revision の代わり。本文が同じなら同じ値、違えば違う値になれば足りる
-  const revisionOf = (body) => {
-    let hash = 5381;
-    for (const ch of body) {
-      hash = ((hash * 33) ^ ch.codePointAt(0)) >>> 0;
-    }
-    return hash.toString(16);
-  };
-
-  const placeKey = (lat, lon) => `${lat.toFixed(2)},${lon.toFixed(2)}`;
-
-  const stampOf = (date) =>
-    `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}_${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
 
   // まだ使われていない名前と、その名前が名乗る時刻。core の `Notes::create`
   // と同じく、同じ秒に 2 本作られたら空いている秒まで 1 秒ずつ進める。
@@ -375,16 +413,17 @@
     search_all: ({ query, tags }) => {
       const needle = query.trim().toLowerCase();
       // 本流(core)の utils::tags と同じ規則: `#` の有無と ASCII の大小は見ない
-      const lower = (tag) => tag.replaceAll(/[A-Z]/g, (c) => c.toLowerCase());
       const scope = tags
-        .map((tag) => lower(tag.trim().replace(/^#/, "")))
+        .map((tag) => lowerTag(tag.trim().replace(/^#/u, "")))
         .filter((tag) => tag.length > 0);
       if (!needle && scope.length === 0) {
         return [];
       }
       // lib/tags.ts の TAG と同じ。ここは 1 行しか読まないのでコードは切り分けない
-      const TAG = /(?<![\p{L}\p{N}_-])#([\p{L}\p{N}_-]+)/gu;
-      const parseTags = (text) => [...new Set([...text.matchAll(TAG)].map((m) => lower(m[1])))];
+      const TAG = /(?<![\p{L}\p{N}_-])#(?<tag>[\p{L}\p{N}_-]+)/gu;
+      const parseTags = (text) => [
+        ...new Set([...text.matchAll(TAG)].map((m) => lowerTag(m.groups.tag))),
+      ];
       const inScope = (own) => scope.every((tag) => own.includes(tag));
       /** 本流(core)と同じ形: 一致の前後を含む抜粋と、文字数の一致位置。 */
       const excerpt = (text) => {
@@ -399,14 +438,14 @@
         const snippet = lead + flat.slice(start, at + needle.length + 40);
         return {
           snippet,
-          match_start: [...(lead + flat.slice(start, at))].length,
-          match_len: [...flat.slice(at, at + needle.length)].length,
+          match_start: charCount(lead + flat.slice(start, at)),
+          match_len: charCount(flat.slice(at, at + needle.length)),
         };
       };
       const hits = [];
       for (const [iso, lines] of timeline) {
         lines.forEach((raw, index) => {
-          const text = raw.replace(/^- \[\d\d:\d\d:\d\d\] /, "").replace(/ \{.*\}$/, "");
+          const text = raw.replace(/^- \[\d\d:\d\d:\d\d\] /u, "").replace(/ \{.*\}$/u, "");
           const own = parseTags(text);
           if (!text.toLowerCase().includes(needle) || !inScope(own)) {
             return;
@@ -423,28 +462,27 @@
         });
       }
       for (const [filename, note] of notes) {
-        if (!note.body.toLowerCase().includes(needle) || !inScope(note.tags)) {
-          continue;
+        if (note.body.toLowerCase().includes(needle) && inScope(note.tags)) {
+          hits.push({
+            kind: "note",
+            title: note.body.split("\n")[0].replace(/^#+\s*/u, ""),
+            date: note.time.slice(0, 10),
+            filename,
+            index: null,
+            tags: note.tags,
+            ...excerpt(note.body),
+          });
         }
-        hits.push({
-          kind: "note",
-          title: note.body.split("\n")[0].replace(/^#+\s*/, ""),
-          date: note.time.slice(0, 10),
-          filename,
-          index: null,
-          tags: note.tags,
-          ...excerpt(note.body),
-        });
       }
       return hits.toSorted((a, b) => b.date.localeCompare(a.date)).slice(0, 100);
     },
     list_notes: () => noteList(),
     find_backlinks: ({ filename }) => {
-      const needle = `[[${filename.replace(/\.md$/, "")}]]`;
+      const needle = `[[${filename.replace(/\.md$/u, "")}]]`;
       const hits = [];
       for (const [iso, lines] of timeline) {
         lines.forEach((raw, index) => {
-          const text = raw.replace(/^- \[\d\d:\d\d:\d\d\] /, "").replace(/ \{.*\}$/, "");
+          const text = raw.replace(/^- \[\d\d:\d\d:\d\d\] /u, "").replace(/ \{.*\}$/u, "");
           if (text.includes(needle)) {
             hits.push({
               kind: "timeline",
@@ -461,20 +499,19 @@
         });
       }
       for (const [name, note] of notes) {
-        if (name === filename || !note.body.includes(needle)) {
-          continue;
+        if (name !== filename && note.body.includes(needle)) {
+          hits.push({
+            kind: "note",
+            title: note.body.split("\n")[0].replace(/^#+\s*/u, ""),
+            snippet: note.body.slice(0, 90),
+            date: note.time.slice(0, 10),
+            filename: name,
+            index: null,
+            tags: note.tags,
+            match_start: null,
+            match_len: null,
+          });
         }
-        hits.push({
-          kind: "note",
-          title: note.body.split("\n")[0].replace(/^#+\s*/, ""),
-          snippet: note.body.slice(0, 90),
-          date: note.time.slice(0, 10),
-          filename: name,
-          index: null,
-          tags: note.tags,
-          match_start: null,
-          match_len: null,
-        });
       }
       return hits.toSorted((a, b) => b.date.localeCompare(a.date));
     },
@@ -539,11 +576,12 @@
       const filename = filePath.split("/").at(-1);
       const note = notes.get(filename);
       if (!note) {
-        throw { kind: "other", message: `note not found: ${filename}` };
+        throw saveError("other", `note not found: ${filename}`);
       }
       // core と同じ照合。読んでから誰かが書き換えていれば、その上に書かない
-      if (revision != null && revision !== revisionOf(note.body)) {
-        throw { kind: "stale", message: `Stale: ${filename} changed since it was read` };
+      const expected = revision ?? null;
+      if (expected !== null && expected !== revisionOf(note.body)) {
+        throw saveError("stale", `Stale: ${filename} changed since it was read`);
       }
       note.body = body;
       // core と同じく、本文の保存だけが更新日時を打つ
@@ -573,22 +611,22 @@
       if (!template) {
         throw new Error("template not found");
       }
-      const name = filename.replace(/\.md$/, "");
+      const name = filename.replace(/\.md$/u, "");
 
       // 同じテンプレの今日のぶんが既にあれば作らない。日付はファイル名の
       // 先頭 8 桁で見る — 保存している time は UTC で、日をまたぐと食い違う
-      const today = stampOf(new Date()).slice(0, 8);
+      const todayStamp = stampOf(new Date()).slice(0, 8);
       const existing = [...notes.entries()].find(
-        ([fname, note]) => note.template === name && fname.slice(0, 8) === today,
+        ([fname, note]) => note.template === name && fname.slice(0, 8) === todayStamp,
       );
       if (existing) {
         return { path: `/mock/data/${existing[0]}`, reused: true };
       }
 
-      const previous = [...notes.entries()]
+      const [previous] = [...notes.entries()]
         .filter(([, note]) => note.template === name)
-        .toSorted(([a], [b]) => b.localeCompare(a))[0];
-      const prev = previous ? `[[${previous[0].replace(/\.md$/, "")}]]` : null;
+        .toSorted(([a], [b]) => b.localeCompare(a));
+      const prev = previous ? `[[${previous[0].replace(/\.md$/u, "")}]]` : null;
 
       const { filename: created, time } = freeNoteName();
       notes.set(created, {
@@ -619,7 +657,7 @@
         .toSorted((a, b) => a.name.localeCompare(b.name)),
     save_glyph: ({ name, format, dataBase64 }) => {
       // core と同じ規則。通らない名前は本物でも保存できない
-      if (!/^[a-z0-9][a-z0-9_+-]{0,31}$/.test(name)) {
+      if (!/^[a-z0-9][a-z0-9_+-]{0,31}$/u.test(name)) {
         throw new Error(`Invalid path: ${name}`);
       }
       if (format !== "png" && format !== "svg") {
@@ -661,13 +699,14 @@
 
   let callbackId = 0;
 
-  window.__TAURI_INTERNALS__ = {
+  globalThis.__TAURI_INTERNALS__ = {
     invoke: async (cmd, args) => {
       const handler = commands[cmd];
       if (!handler) {
         throw new Error(`mock: unknown command ${cmd}`);
       }
-      return handler(args ?? {});
+      // await して返す。ハンドラが同期に投げても、本物と同じく reject で届く
+      return await handler(args ?? {});
     },
     transformCallback: () => {
       callbackId += 1;

--- a/tauri-app/dev/ipc-mock.js
+++ b/tauri-app/dev/ipc-mock.js
@@ -8,11 +8,70 @@
  *
  * 作り物の状態(タイムライン・ノート・テンプレ)は IIFE の中に閉じる。外に出て
  * いるのは、その状態を何も見ない純粋なヘルパだけ。
+ *
+ * TS 化はしない(インライン注入される素の <script> なので)。型は JSDoc で書き、
+ * `tsconfig.dev.json` の checkJs が見る。
  */
 
+/**
+ * ノート 1 件の作り物。省略可能なキーは、本物の frontmatter で
+ * `skip_serializing_if` が落とすものと同じ。
+ * @typedef {object} MockNote
+ * @property {string} time
+ * @property {string[]} tags
+ * @property {string | null} [view]
+ * @property {string} body
+ * @property {string} [updated]
+ * @property {string} [source]
+ * @property {string} [origin]
+ * @property {string} [template]
+ */
+
+/**
+ * 一覧が返す 1 件。commands.ts の `Note` と同じ形。
+ * @typedef {object} NoteSummary
+ * @property {string} path
+ * @property {string} filename
+ * @property {string} time
+ * @property {string[]} tags
+ * @property {string} preview
+ * @property {string} [origin]
+ * @property {string} [template]
+ */
+
+/**
+ * @typedef {object} MockTemplate
+ * @property {string[]} tags
+ * @property {string} body
+ */
+
+/**
+ * @typedef {object} MockGlyph
+ * @property {string} format
+ * @property {string} url
+ */
+
+/**
+ * 行末 JSON の中身。実ファイルと同じく、空のものはキーごと無い。
+ * @typedef {object} MockContext
+ * @property {number} battery
+ * @property {boolean} is_charging
+ * @property {string} network_type
+ * @property {string} os
+ * @property {string} os_version
+ * @property {string} arch
+ * @property {{ latitude: number, longitude: number }} [location]
+ * @property {string} [s]
+ */
+
+/** @param {number} n */
 const pad = (n) => String(n).padStart(2, "0");
 
-/** core の `format_stamp` と同じトークン。strftime には渡さない。 */
+/**
+ * core の `format_stamp` と同じトークン。strftime には渡さない。
+ * @param {Date} date
+ * @param {string} pattern
+ */
 const formatStamp = (date, pattern) =>
   pattern
     .replaceAll("YYYY", String(date.getFullYear()))
@@ -22,10 +81,17 @@ const formatStamp = (date, pattern) =>
     .replaceAll("mm", pad(date.getMinutes()))
     .replaceAll("ss", pad(date.getSeconds()));
 
-/** ノートのファイル名になる `YYYYMMDD_HHMMSS`。 */
+/**
+ * ノートのファイル名になる `YYYYMMDD_HHMMSS`。
+ * @param {Date} date
+ */
 const stampOf = (date) =>
   `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}_${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
 
+/**
+ * @param {string} filename
+ * @param {MockTemplate} template
+ */
 const templateSummary = (filename, template) => ({
   filename,
   name: filename.replace(/\.md$/u, ""),
@@ -35,39 +101,62 @@ const templateSummary = (filename, template) => ({
     .trim(),
 });
 
-/** 本物は data:image/svg+xml;base64 で返す。ここも同じ形にしておく。 */
+/**
+ * 本物は data:image/svg+xml;base64 で返す。ここも同じ形にしておく。
+ * @param {string} svg
+ */
 const svgDataUrl = (svg) => `data:image/svg+xml;base64,${btoa(svg)}`;
 
+/**
+ * @param {string} label
+ * @param {string} fill
+ */
 const glyphSvg = (label, fill) =>
   `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="${fill}"/><text x="16" y="21" font-size="12" font-family="sans-serif" font-weight="700" text-anchor="middle" fill="#fff">${label}</text></svg>`;
 
+/** @param {number} ms */
 const delay = (ms) =>
   // oxlint-disable-next-line promise/avoid-new
   new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
 
-// core の Revision の代わり。本文が同じなら同じ値、違えば違う値になれば足りる
+/**
+ * core の Revision の代わり。本文が同じなら同じ値、違えば違う値になれば足りる。
+ * @param {string} body
+ */
 const revisionOf = (body) => {
   let hash = 5381;
   for (const ch of body) {
-    hash = ((hash * 33) ^ ch.codePointAt(0)) >>> 0;
+    hash = ((hash * 33) ^ (ch.codePointAt(0) ?? 0)) >>> 0;
   }
   return hash.toString(16);
 };
 
+/**
+ * @param {number} lat
+ * @param {number} lon
+ */
 const placeKey = (lat, lon) => `${lat.toFixed(2)},${lon.toFixed(2)}`;
 
-/** 本流(core)の utils::tags と同じ規則: ASCII の大小は見ない。 */
+/**
+ * 本流(core)の utils::tags と同じ規則: ASCII の大小は見ない。
+ * @param {string} tag
+ */
 const lowerTag = (tag) => tag.replaceAll(/[A-Z]/gu, (c) => c.toLowerCase());
 
-/** core が返す一致位置と同じ数え方。UTF-16 の要素数ではなく文字数で数える。 */
+/**
+ * core が返す一致位置と同じ数え方。UTF-16 の要素数ではなく文字数で数える。
+ * @param {string} text
+ */
 const charCount = (text) => [...text].length;
 
 /**
  * `update_draft` の失敗。本物は Rust 側の JSON がそのまま届くので `kind` を持つ
  * ただのオブジェクトだが、Error に同じキーを生やしても `isStaleSave` の見る形は
  * 変わらない(`typeof` が object で `kind` を持つ)。
+ * @param {"stale" | "other"} kind
+ * @param {string} message
  */
 const saveError = (kind, message) => Object.assign(new Error(message), { kind });
 
@@ -100,10 +189,15 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
   /** 書いた入り口の固定語彙。`undefined` は名乗る前に書かれた記録。 */
   const SOURCES = ["app", "widget", "cli", "mcp", undefined];
 
+  /**
+   * @param {number} dayIndex
+   * @param {number} entryIndex
+   */
   function contextFor(dayIndex, entryIndex) {
     if ((dayIndex + entryIndex) % 3 === 2) {
       return null;
     }
+    /** @type {MockContext} */
     const ctx = {
       battery: 20 + ((dayIndex * 13 + entryIndex * 29) % 80),
       is_charging: entryIndex % 4 === 0,
@@ -128,7 +222,10 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
     return ctx;
   }
 
-  /** date(ISO) -> raw 行の配列(古い順)。 */
+  /**
+   * date(ISO) -> raw 行の配列(古い順)。
+   * @type {Map<string, string[]>}
+   */
   const timeline = new Map();
   const today = new Date();
   for (let d = 0; d < 20; d += 1) {
@@ -147,7 +244,10 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
 
   // ---- ノートのつくりもの ----
 
-  /** タイムラインは実時刻基準で作られるので、origin も同じ基準で合わせる。 */
+  /**
+   * タイムラインは実時刻基準で作られるので、origin も同じ基準で合わせる。
+   * @param {number} days
+   */
   const isoDaysAgo = (days) => {
     const day = new Date(today.getFullYear(), today.getMonth(), today.getDate() - days);
     return `${day.getFullYear()}-${pad(day.getMonth() + 1)}-${pad(day.getDate())}`;
@@ -185,6 +285,7 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
     );
   }
 
+  /** @type {Map<string, MockNote>} */
   const notes = new Map([
     [
       "20260810_090000.md",
@@ -280,6 +381,7 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
     [...notes.entries()]
       .toSorted(([a], [b]) => b.localeCompare(a))
       .map(([filename, note]) => {
+        /** @type {NoteSummary} */
         const summary = {
           path: `/mock/data/${filename}`,
           filename,
@@ -299,7 +401,10 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
 
   // ---- テンプレートのつくりもの ----
 
-  /** filename -> { tags, body }。変数は本物と同じく未解決のまま持つ。 */
+  /**
+   * filename -> { tags, body }。変数は本物と同じく未解決のまま持つ。
+   * @type {Map<string, MockTemplate>}
+   */
   const templates = new Map([
     [
       "daily.md",
@@ -324,6 +429,7 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
     ],
   ]);
 
+  /** @type {Record<string, string[]>} */
   const WEEKDAYS = {
     ja: ["日", "月", "火", "水", "木", "金", "土"],
     en: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
@@ -334,6 +440,9 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
   /**
    * core の `resolve_vars` と同じ規則で解く。ハーネスだけ違う結果を返すと、
    * ブラウザで見た画面が実機の答え合わせにならない。
+   * @param {string} body
+   * @param {string | null} prev
+   * @param {string} locale
    */
   const resolveVars = (body, prev, locale) =>
     body
@@ -366,7 +475,10 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
 
   // ---- グリフのつくりもの ----
 
-  /** name -> { format, url }。 */
+  /**
+   * name -> { format, url }。
+   * @type {Map<string, MockGlyph>}
+   */
   const glyphs = new Map([
     ["236p", { format: "svg", url: svgDataUrl(glyphSvg("236P", "#d9480f")) }],
     ["623k", { format: "svg", url: svgDataUrl(glyphSvg("623K", "#1c7ed6")) }],
@@ -387,20 +499,25 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
 
   const commands = {
     list_timeline_dates: () => [...timeline.keys()].toSorted().toReversed(),
+    /** @param {{ date: string }} args */
     read_timeline_by_date: ({ date }) => timeline.get(date) ?? [],
+    /** @param {{ text: string }} args */
     save_quick_capture: ({ text }) => {
       const now = new Date();
       const iso = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
       const line = `- [${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}] ${text}`;
       timeline.set(iso, [...(timeline.get(iso) ?? []), line]);
     },
+    /** @param {{ date: string, index: number }} args */
     delete_timeline_entry: ({ date, index }) => {
       const lines = timeline.get(date) ?? [];
       lines.splice(index, 1);
     },
     // 実機のジオコーダは即答しない。名前が後から届く画面を再現する
+    /** @param {{ coordinates: [number, number][], locale: string }} args */
     resolve_places: async ({ coordinates, locale }) => {
       await delay(600);
+      /** @type {[string, string][]} */
       const answers = [];
       for (const [lat, lon] of coordinates) {
         const hit = PLACES.find((p) => placeKey(p.lat, p.lon) === placeKey(lat, lon));
@@ -410,6 +527,7 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
       }
       return answers;
     },
+    /** @param {{ query: string, tags: string[] }} args */
     search_all: ({ query, tags }) => {
       const needle = query.trim().toLowerCase();
       // 本流(core)の utils::tags と同じ規則: `#` の有無と ASCII の大小は見ない
@@ -421,11 +539,16 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
       }
       // lib/tags.ts の TAG と同じ。ここは 1 行しか読まないのでコードは切り分けない
       const TAG = /(?<![\p{L}\p{N}_-])#(?<tag>[\p{L}\p{N}_-]+)/gu;
+      /** @param {string} text */
       const parseTags = (text) => [
-        ...new Set([...text.matchAll(TAG)].map((m) => lowerTag(m.groups.tag))),
+        ...new Set([...text.matchAll(TAG)].map((m) => lowerTag(m.groups?.tag ?? ""))),
       ];
+      /** @param {string[]} own */
       const inScope = (own) => scope.every((tag) => own.includes(tag));
-      /** 本流(core)と同じ形: 一致の前後を含む抜粋と、文字数の一致位置。 */
+      /**
+       * 本流(core)と同じ形: 一致の前後を含む抜粋と、文字数の一致位置。
+       * @param {string} text
+       */
       const excerpt = (text) => {
         const flat = text.replaceAll("\n", " ");
         // タグだけで絞った一覧には光らせる場所がない
@@ -477,6 +600,7 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
       return hits.toSorted((a, b) => b.date.localeCompare(a.date)).slice(0, 100);
     },
     list_notes: () => noteList(),
+    /** @param {{ filename: string }} args */
     find_backlinks: ({ filename }) => {
       const needle = `[[${filename.replace(/\.md$/u, "")}]]`;
       const hits = [];
@@ -515,12 +639,14 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
       }
       return hits.toSorted((a, b) => b.date.localeCompare(a.date));
     },
+    /** @param {{ filename: string }} args */
     read_note: async ({ filename }) => {
       // ディスク読みの往復ぶん。ノート切替の描画順の検証に効く
       await delay(30);
       const body = notes.get(filename)?.body ?? "";
       return { body, revision: revisionOf(body) };
     },
+    /** @param {{ filename: string }} args */
     read_note_meta: async ({ filename }) => {
       await delay(30);
       const note = notes.get(filename);
@@ -537,27 +663,32 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
         ...(note.source ? { source: note.source } : {}),
       };
     },
+    /** @param {{ filename: string, time: string, tags: string[] }} args */
     update_note_meta: ({ filename, time, tags }) => {
       const note = notes.get(filename);
       if (note) {
         Object.assign(note, { time, tags });
       }
     },
+    /** @param {{ filename: string, view: string | null }} args */
     set_note_view: ({ filename, view }) => {
       const note = notes.get(filename);
       if (note) {
         note.view = view;
       }
     },
+    /** @param {{ filename: string, origin: string | null }} args */
     set_note_origin: ({ filename, origin }) => {
       const note = notes.get(filename);
       if (note) {
         note.origin = origin ?? undefined;
       }
     },
+    /** @param {{ filename: string }} args */
     delete_note: ({ filename }) => {
       notes.delete(filename);
     },
+    /** @param {{ body: string, tags?: string[], origin?: string }} args */
     create_draft: ({ body, tags, origin }) => {
       const { filename, time } = freeNoteName();
       notes.set(filename, {
@@ -572,8 +703,9 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
       });
       return `/mock/data/${filename}`;
     },
+    /** @param {{ filePath: string, body: string, revision?: string | null }} args */
     update_draft: ({ filePath, body, revision }) => {
-      const filename = filePath.split("/").at(-1);
+      const filename = filePath.split("/").at(-1) ?? filePath;
       const note = notes.get(filename);
       if (!note) {
         throw saveError("other", `note not found: ${filename}`);
@@ -592,6 +724,7 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
       [...templates.entries()]
         .map(([filename, template]) => templateSummary(filename, template))
         .toSorted((a, b) => a.name.localeCompare(b.name)),
+    /** @param {{ filename: string }} args */
     read_template: async ({ filename }) => {
       await delay(30);
       const template = templates.get(filename);
@@ -600,12 +733,15 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
       }
       return { body: template.body, tags: template.tags };
     },
+    /** @param {{ filename: string, body: string, tags?: string[] }} args */
     save_template: ({ filename, body, tags }) => {
       templates.set(filename, { body, tags: tags ?? [] });
     },
+    /** @param {{ filename: string }} args */
     delete_template: ({ filename }) => {
       templates.delete(filename);
     },
+    /** @param {{ filename: string, locale: string }} args */
     create_from_template: ({ filename, locale }) => {
       const template = templates.get(filename);
       if (!template) {
@@ -655,6 +791,7 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
       [...glyphs.entries()]
         .map(([name, glyph]) => ({ name, url: glyph.url }))
         .toSorted((a, b) => a.name.localeCompare(b.name)),
+    /** @param {{ name: string, format: string, dataBase64: string }} args */
     save_glyph: ({ name, format, dataBase64 }) => {
       // core と同じ規則。通らない名前は本物でも保存できない
       if (!/^[a-z0-9][a-z0-9_+-]{0,31}$/u.test(name)) {
@@ -666,14 +803,16 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
       const mime = format === "png" ? "image/png" : "image/svg+xml";
       glyphs.set(name, { format, url: `data:${mime};base64,${dataBase64}` });
     },
+    /** @param {{ name: string }} args */
     delete_glyph: ({ name }) => {
       glyphs.delete(name);
     },
+    /** @param {{ suggestedName: string, dataBase64: string }} args */
     save_export: ({ suggestedName, dataBase64 }) => {
       // ブラウザに保存ダイアログは無い。書き出した中身を別タブで開いて、
       // 目で確かめられるようにする
       const mime = suggestedName.endsWith(".png") ? "image/png" : "image/svg+xml";
-      const bytes = Uint8Array.from(atob(dataBase64), (c) => c.codePointAt(0));
+      const bytes = Uint8Array.from(atob(dataBase64), (c) => c.codePointAt(0) ?? 0);
       window.open(URL.createObjectURL(new Blob([bytes], { type: mime })), "_blank");
       return { saved: true };
     },
@@ -701,7 +840,11 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
 
   globalThis.__TAURI_INTERNALS__ = {
     invoke: async (cmd, args) => {
-      const handler = commands[cmd];
+      // cmd はただの文字列なので、表の側を「名前 → ハンドラ」として引く
+      const table = /** @type {Record<string, (args: Record<string, unknown>) => unknown>} */ (
+        /** @type {unknown} */ (commands)
+      );
+      const handler = table[cmd];
       if (!handler) {
         throw new Error(`mock: unknown command ${cmd}`);
       }

--- a/tauri-app/dev/tauri-internals.d.ts
+++ b/tauri-app/dev/tauri-internals.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Tauri がウェブビューに置く内部 API。公開の型は無いので、モックが名乗る
+ * ぶんだけを書く。
+ */
+interface TauriInternals {
+  invoke: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
+  transformCallback: () => number;
+  unregisterCallback: () => void;
+  convertFileSrc: (path: string) => string;
+  metadata: { currentWindow: { label: string }; currentWebview: { label: string } };
+}
+
+// globalThis に名前を生やす宣言は `var` しか書けない
+// oxlint-disable-next-line no-var, vars-on-top
+declare var __TAURI_INTERNALS__: TauriInternals | undefined;

--- a/tauri-app/justfile
+++ b/tauri-app/justfile
@@ -7,7 +7,7 @@ setup:
   pnpm install
 
 check: setup
-  oxlint src/
+  oxlint src/ dev/
   tsgo -b --noEmit
   pnpm knip
 

--- a/tauri-app/justfile
+++ b/tauri-app/justfile
@@ -9,6 +9,8 @@ setup:
 check: setup
   oxlint src/ dev/
   tsgo -b --noEmit
+  # dev/ は素の JS。tsconfig.json の include(src) の外なので別に走らせる
+  tsgo --noEmit -p tsconfig.dev.json
   pnpm knip
 
 test: setup

--- a/tauri-app/src/lib/commands.test.ts
+++ b/tauri-app/src/lib/commands.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from "vitest";
 import { mockIPC, clearMocks } from "@tauri-apps/api/mocks";
 import type { ClientContext } from "./client-context";
 import { isStaleSave, onLocalMutation, typedInvoke } from "./commands";
+// browser mode に node:fs は無い。Vite の `?raw` がソースをそのまま文字列で渡す。
+// oxlint は `?raw` を知らず、素の .ts に default export を探しに行くので黙らせる
+// oxlint-disable-next-line import/default
+import commandsSource from "./commands.ts?raw";
+import mockSource from "../../dev/ipc-mock.js?raw";
 
 // vi.mock("@tauri-apps/api/core") は使わない。browser mode のモジュールモックは
 // サーバー側の単一レジストリ越しに差し替えるため、並列実行下でモックが適用され
@@ -63,6 +68,67 @@ describe("typedInvoke local mutation notifications", () => {
     stop();
     await typedInvoke("update_draft", { filePath: "a.md", body: "x", client: CLIENT });
     expect(seen).toHaveLength(0);
+  });
+});
+
+/** Tauri の内部 API に公開の型は無い。テストが触るぶんだけ形を書く */
+interface TauriInternals {
+  __TAURI_INTERNALS__?: { invoke: (cmd: string, args?: unknown) => Promise<unknown> };
+}
+const tauri = globalThis as unknown as TauriInternals;
+
+/**
+ * `CommandMap` は型なので実行時に列挙できない。宣言そのものを読んで名前を拾う。
+ * 書き方が変わって 1 件も読めなくなったら、テストは静かに通らず落ちる。
+ */
+function declaredCommands(): string[] {
+  const from = commandsSource.indexOf("interface CommandMap {");
+  const block = commandsSource.slice(from, commandsSource.indexOf("\n}\n", from));
+  return [...block.matchAll(/^ {2}(?<name>[a-z_]+): \{/gmu)]
+    .map((match) => match.groups?.name)
+    .filter((name) => name !== undefined);
+}
+
+// CLAUDE.md の「新しい Tauri コマンドには ipc-mock のハンドラを足す」を守らせる。
+// 忘れるとブラウザ検証だけが `mock: unknown command` で死に、気付くのは
+// dev-browser を開いた人になる
+describe("dev/ipc-mock.js", () => {
+  let previous: TauriInternals["__TAURI_INTERNALS__"];
+
+  beforeAll(() => {
+    previous = tauri.__TAURI_INTERNALS__;
+    // モックは自分より先に誰かが居れば何もしない。譲る相手を先に退かす
+    delete tauri.__TAURI_INTERNALS__;
+    // `new Function` ではなく <script>。index.html に注入されるときと同じ経路で
+    // `__TAURI_INTERNALS__` が置かれることまで見る
+    const script = document.createElement("script");
+    script.textContent = mockSource;
+    document.head.append(script);
+  });
+
+  afterAll(() => {
+    tauri.__TAURI_INTERNALS__ = previous;
+  });
+
+  it("answers every command declared in CommandMap", async () => {
+    const names = declaredCommands();
+    // 0 件は「モックが完璧」ではなく「正規表現が宣言の書き方から外れた」
+    expect(names.length).toBeGreaterThan(0);
+
+    const invoke = tauri.__TAURI_INTERNALS__?.invoke;
+    const answers = await Promise.all(
+      names.map(async (name) => {
+        try {
+          // 引数は渡さない。ハンドラが中で転ぶのは構わない。見たいのは
+          // 「そのコマンドを知っているか」だけ
+          await invoke?.(name, {});
+          return `${name}: ok`;
+        } catch (error) {
+          return `${name}: ${String(error)}`;
+        }
+      }),
+    );
+    expect(answers.filter((answer) => answer.includes("unknown command"))).toStrictEqual([]);
   });
 });
 

--- a/tauri-app/tsconfig.dev.json
+++ b/tauri-app/tsconfig.dev.json
@@ -1,0 +1,10 @@
+{
+  // dev/ は素の JS のまま (インライン注入される <script> なので TS にはできない)。
+  // それでも型は見る: checkJs でここだけ別に走らせる。strict の設定は親を継ぐ。
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true
+  },
+  "include": ["dev"]
+}


### PR DESCRIPTION
## なぜやるか

- `tauri-app/dev/ipc-mock.js` は CLAUDE.md が名指しで「新しい Tauri コマンドには必ずハンドラを足す」と書いている唯一のファイルなのに、lint も型検査も CI もこのファイルを見ていなかった
- 見ていない間に oxlint 違反が 46 件たまり、ハンドラを足し忘れても気付くのは `dev-browser` を開いた人になっていた

## やったこと

- `oxlint src/` を `src/ dev/` に広げ、46 件を全部直した。モック専用の override は作らない（規則が 2 系統になると次に足す人が迷う）
- 状態を掴まないヘルパを IIFE の外に出した（`consistent-function-scoping`）。作り物の状態は IIFE の中のまま
- `tsconfig.dev.json`（`allowJs` + `checkJs`、`strict` は親を継ぐ）を足し、`just tauri_app::check` から走らせる。モックは素の JS のまま JSDoc で型を書いた
- 型を書いたことで 3 件の穴が出た: `contextFor` が無いキーを生やしていた / `save_export` が `codePointAt` の `undefined` を `Uint8Array.from` に渡していた / `update_draft` が `at(-1)` の `undefined` を `Map.get` に渡していた
- `CommandMap` に並ぶコマンドを全部モックに投げ、`mock: unknown command` が返らないことを見るテストを足した。型は実行時に列挙できないので宣言を正規表現で読み、0 件なら「正規表現が古びた」として落ちる
- CI の `frontend` パスフィルタに `tauri-app/dev/**` と `tauri-app/tsconfig.dev.json` を足した

```mermaid
flowchart LR
  M["dev/ipc-mock.js"]
  L["oxlint src/ dev/"] --> M
  T["tsgo -p tsconfig.dev.json"] --> M
  V["commands.test.ts<br/>(CommandMap 全件を invoke)"] --> M
  C["CI frontend job<br/>paths-filter"] --> L & T & V
```

## やらなかったこと

- モックの TS 化。インライン注入される素の `<script>` なので JS のまま
- ハンドラの**戻り値**が `CommandMap` の `result` と合っているかの検証。今は「そのコマンドを知っているか」までしか見ていない
- `dev/` を knip の対象に入れること。使われていない fixture が溜まっても分からないままになる

## 資料

- `just tauri_app::check` / `test` / `just verify` 全通過（rust 354 / frontend 634 / workers 33）
- Red の確認: `delete_glyph` を消す・`create_from_template` を改名 → いずれもテストが落ちることを確認
- リファクタで挙動が変わっていないことは、読み取り系 10 コマンドの JSON 出力を before/after で比較してバイト一致を確認

Closes #193
