### PR TITLE
feat(core): keep only the newest twenty copies of each note

### DIFF
--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -364,7 +364,7 @@ pub(crate) struct CreatedNoteOutput {
 pub(crate) struct UpdatedNoteOutput {
     pub(crate) filename: String,
     /// The copy of the note taken before this write. Pass its `id` to
-    /// `restore_note` to undo.
+    /// `restore_note` to undo; only the newest 20 copies of a note are kept.
     pub(crate) snapshot: Option<SnapshotInfo>,
     /// Fingerprint of the body now on disk; the `revision` for a further
     /// `update_note`.
@@ -375,6 +375,7 @@ pub(crate) struct UpdatedNoteOutput {
 #[derive(Serialize, schemars::JsonSchema)]
 pub(crate) struct SnapshotInfo {
     /// The argument to pass to `read_note_history` / `restore_note`.
+    /// Valid until 20 newer copies of the same note exist.
     pub(crate) id: String,
     /// When the copy was taken, RFC 3339.
     pub(crate) time: String,

--- a/cli/src/server.rs
+++ b/cli/src/server.rs
@@ -43,7 +43,8 @@ note times are RFC 3339 with the offset. Bodies may contain `:name:` \
 shortcodes that the app renders as user-registered images (glyphs); \
 `list_glyphs` gives the vocabulary, and an unregistered `:name:` stays \
 literal text. When write tools are present, every overwrite first saves a \
-copy that `restore_note` can bring back.";
+copy that `restore_note` can bring back; the newest 20 copies of each note \
+are kept.";
 
 /// 書き込みは頼まれたときだけ出す。公開アプリの MCP が既定で書けると、
 /// 「読ませたつもり」の設定で日記が書き換わる。
@@ -502,7 +503,7 @@ impl McpServer {
 
     #[tool(
         name = "update_note",
-        description = "Replace a note's Markdown body, keeping its frontmatter; a copy of the previous version is saved first and can be brought back with restore_note"
+        description = "Replace a note's Markdown body, keeping its frontmatter; a copy of the previous version is saved first and can be brought back with restore_note (the newest 20 copies per note are kept)"
     )]
     fn update_note(
         &self,
@@ -555,7 +556,7 @@ impl McpServer {
 
     #[tool(
         name = "restore_note",
-        description = "Bring a note back to a saved copy; the current version is saved first so the restore itself can be undone"
+        description = "Bring a note back to a saved copy; the current version is saved first so the restore itself can be undone (the newest 20 copies per note are kept)"
     )]
     fn restore_note(
         &self,

--- a/core/src/note/history.rs
+++ b/core/src/note/history.rs
@@ -8,6 +8,9 @@
 //! 往復し、控えの控えが増える。派生物ではなく退避なので `places.json` とは
 //! 違って壊れていても作り直せないが、失って困るのは戻したいときだけで、
 //! そのときはノート本体が残っている。
+//!
+//! 残すのはノートごとに直近 [`KEEP`] 件。ノート本体が消えても控えは残す —
+//! 消したノートを控えから戻せることが、そもそも控えを取っている理由。
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -84,7 +87,7 @@ pub fn snapshot_note(
     let target = dir.join(format!("{id}.md"));
     ensure_dir(&target)?;
     write_atomic(&target, &content)?;
-    prune(&dir);
+    prune(&dir, &id);
     Ok(Some(Snapshot {
         id,
         time: now,
@@ -106,27 +109,30 @@ fn sort_key(id: &str) -> (&str, u32) {
 /// だけ — 掃除の起点を書き込みに寄せておくと、溜まったまま誰も来ない
 /// ディレクトリが残らない。
 ///
-/// ノート本体が消えても控えは残す。消したノートを控えから戻せることが、
-/// そもそも控えを取っている理由。
+/// いま書いた `written` は数に入れるが落とさない。採番は「最初の空き」なので、
+/// 掃除で空いた素の stamp を同じ秒に取り直すと `sort_key` ではその秒の
+/// 最古になる。時計が戻ったときも同じ。呼び手はその id を「戻せる控え」として
+/// 返すのだから、返した直後に無いのは許されない。
 ///
 /// 失敗は無視する。控えを取ること自体は済んでいて、落とせなかったぶんは
 /// 次の snapshot で改めて落ちる。掃除の失敗で書き換えを止める理由はない。
-fn prune(dir: &Path) {
+fn prune(dir: &Path, written: &str) {
     let Ok(entries) = list_md_files(dir) else {
         return;
     };
     // list_md_files の並びは名前順、つまり枝番が文字列のまま。落とす順は
     // 一覧と同じ `sort_key` で決め直す。
-    let mut snapshots: Vec<(String, PathBuf)> = entries
+    let mut others: Vec<(String, PathBuf)> = entries
         .into_iter()
         .filter_map(|entry| {
             let name = entry.file_name();
             let id = Path::new(&name).file_stem()?.to_str()?.to_string();
             Some((id, entry.path()))
         })
+        .filter(|(id, _)| id != written)
         .collect();
-    snapshots.sort_by(|a, b| sort_key(&b.0).cmp(&sort_key(&a.0)));
-    for (_, path) in snapshots.iter().skip(KEEP) {
+    others.sort_by(|a, b| sort_key(&b.0).cmp(&sort_key(&a.0)));
+    for (_, path) in others.iter().skip(KEEP - 1) {
         let _ = fs::remove_file(path);
     }
 }
@@ -347,6 +353,34 @@ mod tests {
         assert_eq!(listed.len(), KEEP);
         assert!(!listed.contains(&"20200101_120000-2".to_string()));
         assert!(listed.contains(&"20200101_120000-10".to_string()));
+    }
+
+    /// いま書いた控えが `sort_key` で最古になることがある — 掃除で空いた
+    /// 素の stamp を同じ秒に取り直したとき、時計が戻ったとき。それでも
+    /// 返した id のファイルが消えていてはいけない。ここでは未来の stamp を
+    /// 20 件 seed して「新しい控えが一番古く並ぶ」状況を作る。
+    #[test]
+    fn the_copy_just_written_survives_even_when_it_sorts_oldest() {
+        let tmp = TempDir::new().unwrap();
+        let (_, filename) = note(tmp.path(), "body");
+        let ids: Vec<String> = std::iter::once("20990101_120000".to_string())
+            .chain((2..=KEEP).map(|n| format!("20990101_120000-{n}")))
+            .collect();
+        seed_history(tmp.path(), &filename, &ids);
+
+        let written = snapshot_note(tmp.path(), &filename).unwrap().unwrap();
+
+        let listed: Vec<String> = list_note_history(tmp.path(), &filename)
+            .unwrap()
+            .into_iter()
+            .map(|s| s.id)
+            .collect();
+        assert_eq!(listed.len(), KEEP);
+        assert!(
+            listed.contains(&written.id),
+            "the copy just taken must outlive its own prune: {listed:?}"
+        );
+        assert!(!listed.contains(&"20990101_120000".to_string()));
     }
 
     /// 控えの置き場は同期の走査範囲の外。載せると端末間で控えが往復する。

--- a/core/src/note/history.rs
+++ b/core/src/note/history.rs
@@ -20,6 +20,13 @@ use crate::utils::fs::{ensure_dir, list_md_files, resolve_existing, write_atomic
 use crate::utils::paths::{history_dir, notes_dir};
 use crate::utils::validated::NoteFilename;
 
+/// ノート 1 つあたりに残す控えの数。同じ秒の枝番も 1 件と数える。
+///
+/// 期間で切らないのは、久しぶりに開いたノートの控えが全部消えているのを
+/// 避けるため。戻したいのは大抵、直前の数回。20 は MCP が 1 セッションで
+/// 書き換える回数を余裕で上回る。
+const KEEP: usize = 20;
+
 /// 控え 1 件。`id` がそのまま `restore` の引数。
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Snapshot {
@@ -77,6 +84,7 @@ pub fn snapshot_note(
     let target = dir.join(format!("{id}.md"));
     ensure_dir(&target)?;
     write_atomic(&target, &content)?;
+    prune(&dir);
     Ok(Some(Snapshot {
         id,
         time: now,
@@ -92,6 +100,35 @@ pub fn snapshot_note(
 fn sort_key(id: &str) -> (&str, u32) {
     let (stamp, suffix) = id.split_once('-').unwrap_or((id, "1"));
     (stamp, suffix.parse().unwrap_or(0))
+}
+
+/// `KEEP` 件を超えたぶんを古いほうから落とす。呼ぶのは控えを 1 件書いた直後
+/// だけ — 掃除の起点を書き込みに寄せておくと、溜まったまま誰も来ない
+/// ディレクトリが残らない。
+///
+/// ノート本体が消えても控えは残す。消したノートを控えから戻せることが、
+/// そもそも控えを取っている理由。
+///
+/// 失敗は無視する。控えを取ること自体は済んでいて、落とせなかったぶんは
+/// 次の snapshot で改めて落ちる。掃除の失敗で書き換えを止める理由はない。
+fn prune(dir: &Path) {
+    let Ok(entries) = list_md_files(dir) else {
+        return;
+    };
+    // list_md_files の並びは名前順、つまり枝番が文字列のまま。落とす順は
+    // 一覧と同じ `sort_key` で決め直す。
+    let mut snapshots: Vec<(String, PathBuf)> = entries
+        .into_iter()
+        .filter_map(|entry| {
+            let name = entry.file_name();
+            let id = Path::new(&name).file_stem()?.to_str()?.to_string();
+            Some((id, entry.path()))
+        })
+        .collect();
+    snapshots.sort_by(|a, b| sort_key(&b.0).cmp(&sort_key(&a.0)));
+    for (_, path) in snapshots.iter().skip(KEEP) {
+        let _ = fs::remove_file(path);
+    }
 }
 
 /// 新しいものから順に。
@@ -252,6 +289,64 @@ mod tests {
         assert_eq!(ids[0], "20260101_120000-11");
         assert_eq!(ids[1], "20260101_120000-10");
         assert_eq!(ids.last().unwrap(), "20260101_120000");
+    }
+
+    /// 控えを直に置くための下ごしらえ。`snapshot_note` を並べて呼ぶと途中で
+    /// 秒が変わって枝番が振り直され、いくつ溜まった状態を試したいのかが消える。
+    fn seed_history(base: &Path, filename: &NoteFilename, ids: &[String]) -> PathBuf {
+        let dir = note_history_dir(base, filename);
+        fs::create_dir_all(&dir).unwrap();
+        for id in ids {
+            fs::write(dir.join(format!("{id}.md")), "x").unwrap();
+        }
+        dir
+    }
+
+    /// 溜まる一方だと 1 台のディスクを AI の書き換え回数ぶん食い続ける。
+    /// 上限を超えたぶんは古いほうから落ちる。
+    #[test]
+    fn twenty_one_snapshots_keep_the_newest_twenty() {
+        let tmp = TempDir::new().unwrap();
+        let (_, filename) = note(tmp.path(), "body");
+        let ids: Vec<String> = std::iter::once("20200101_120000".to_string())
+            .chain((2..=20).map(|n| format!("20200101_120000-{n}")))
+            .collect();
+        seed_history(tmp.path(), &filename, &ids);
+
+        snapshot_note(tmp.path(), &filename).unwrap().unwrap();
+
+        let listed: Vec<String> = list_note_history(tmp.path(), &filename)
+            .unwrap()
+            .into_iter()
+            .map(|s| s.id)
+            .collect();
+        assert_eq!(listed.len(), KEEP);
+        assert!(
+            !listed.contains(&"20200101_120000".to_string()),
+            "the oldest copy is the one that goes"
+        );
+        assert_eq!(listed.last().unwrap(), "20200101_120000-2");
+    }
+
+    /// 落とす順も `sort_key` で決める。文字列順のままだと `-10` が `-2` より
+    /// 古い扱いになり、同じ秒に 10 回書き換えたノートで消える控えが逆になる。
+    #[test]
+    fn the_oldest_branch_number_is_the_one_dropped() {
+        let tmp = TempDir::new().unwrap();
+        let (_, filename) = note(tmp.path(), "body");
+        let ids: Vec<String> = (2..=21).map(|n| format!("20200101_120000-{n}")).collect();
+        seed_history(tmp.path(), &filename, &ids);
+
+        snapshot_note(tmp.path(), &filename).unwrap().unwrap();
+
+        let listed: Vec<String> = list_note_history(tmp.path(), &filename)
+            .unwrap()
+            .into_iter()
+            .map(|s| s.id)
+            .collect();
+        assert_eq!(listed.len(), KEEP);
+        assert!(!listed.contains(&"20200101_120000-2".to_string()));
+        assert!(listed.contains(&"20200101_120000-10".to_string()));
     }
 
     /// 控えの置き場は同期の走査範囲の外。載せると端末間で控えが往復する。

--- a/docs/features.md
+++ b/docs/features.md
@@ -242,7 +242,9 @@ on updates; the body is all a client sends.
 
 Every overwrite first saves a full copy of the previous version under
 `<data-dir>/history/` (outside the synced `data/`), so any change an
-assistant makes can be brought back. `read_note` also returns a `revision`
+assistant makes can be brought back. The newest 20 copies of each note are
+kept; older ones are dropped as new copies arrive, and a note's copies
+outlive the note itself. `read_note` also returns a `revision`
 of the body; pass it to `update_note` and the write is refused if the note
 changed in between (in the app, from the CLI) instead of overwriting that
 edit:

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -72,7 +72,7 @@ the typed text behind Revert, the CLI keeps it in a scratch file.
 │   │   └── 2026-08-09.md      # one file per day, entries appended
 │   └── notes/
 │       └── 20260809_143000.md # one file per note, frontmatter + body
-├── history/                   # copies taken before CLI / MCP overwrites
+├── history/                   # copies taken before CLI / MCP overwrites (newest 20 per note)
 ├── .sync-state.json           # what the server last confirmed
 └── sync-config.json           # Workers URL, auto-sync flag (shared with the CLI)
 ```


### PR DESCRIPTION
## なぜやるか

- `history/` は CLI / MCP の上書きのたびに増える一方で、消す経路が無かった。同期の外なので端末間では膨らまないが、AI に長く書かせるほど 1 台のディスクに溜まり続ける
- 期間で切ると「久しぶりに開いたノートの控えが全部消えている」が起きる。戻したいのは大抵、直前の数回

## やったこと

- ノートごとに直近 20 件だけ残す。同じ秒の枝番も 1 件と数える
- 掃除の起点は控えを 1 件書いた直後。書き込み経路に置けば、誰も呼ばない掃除係を別に用意せずに済む
- いま書いた控えは落とさない。採番は「最初の空き」なので、掃除で空いた素の stamp を同じ秒に取り直すと `sort_key` ではその秒の最古になる（時計が戻った時も同じ）。返した id が返した直後に無いのは許されない
- 落とす順は一覧と同じ `sort_key`。`list_md_files` の名前順のままだと `-10` が `-2` より古い扱いになり、消える控えが逆になる
- 削除の失敗は無視する。控えを取ること自体は済んでいて、落とせなかったぶんは次の snapshot で改めて落ちる
- 20 は MCP が 1 セッションで書き換える回数を余裕で上回る。定数 1 つなので後から変えられる

## やらなかったこと

- 「ノート本体が消えたら履歴も消す」は採らない。消したノートを控えから戻せることが、そもそも控えを取っている理由
- 保持件数の設定化。まず既定値で運用し、足りない実例が出てから
- 既存の溜まりの一括掃除。次にそのノートを書き換えた時点で 20 件に落ちるので、もう編集しないノートの控えは残り続ける

## 資料

- `just verify` 通過（rust 356+42+29 / frontend 633 / workers 33）
- テスト 3 本: 21 件目の snapshot で最古が落ちること、枝番 `-2` が `-10` より古いと判定されること、未来の stamp を 20 件 seed しても今書いた控えが残ること
- MCP のツール説明と出力 doc に「直近 20 件まで」を明記
- `docs/features.md` / `docs/introduction.md` に保持件数を追記

Closes #159

