### PR TITLE
feat(android): route the log crate into logcat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1341,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
 ]
 
 [[package]]
@@ -2677,12 +2704,14 @@ dependencies = [
 name = "magical-merchant-app"
 version = "0.4.0"
 dependencies = [
+ "android_logger",
  "base64 0.23.1",
  "battery",
  "block2",
  "chrono",
  "hostname",
  "jni 0.22.4",
+ "log",
  "magical-merchant-core",
  "ndk-context",
  "objc2",

--- a/tauri-app/src-tauri/Cargo.toml
+++ b/tauri-app/src-tauri/Cargo.toml
@@ -60,6 +60,11 @@ rustls-platform-verifier = "0.7"
 # rustls は reqwest が既定 feature 付きで持っているものと同じ版に解決させる
 rustls = "0.23"
 webpki-roots = "1"
+# 上の検証器は失敗の理由を `log` にしか書かない。Android の `log` は既定で
+# どこにも出ないので、logcat に橋を架けるここだけが唯一の読み口になる。
+# 自前のログは足さない: 依存クレートの出力を読むためだけの依存
+log = "0.4"
+android_logger = "0.15"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -452,6 +452,22 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .manage(sync::AppSyncState::default())
         .setup(|app| {
+            // Android には `log` の受け手が居らず、依存クレートの警告は捨てられる。
+            // 下の android_tls が使う rustls-platform-verifier は証明書を拒んだ
+            // 理由をここにしか書かないので、初期化はその前に済ませる。
+            // リリースで Warn 止まりなのは、Debug まで出すと依存クレートの
+            // 通常時のログが logcat を埋めて肝心の 1 行が流れるため。
+            #[cfg(target_os = "android")]
+            android_logger::init_once(
+                android_logger::Config::default()
+                    .with_max_level(if cfg!(debug_assertions) {
+                        log::LevelFilter::Debug
+                    } else {
+                        log::LevelFilter::Warn
+                    })
+                    .with_tag("magical-merchant"),
+            );
+
             // ブラウザで認証している間に OS がアプリを回収すると、トークンは
             // 起動 URL として届く。`new-url` イベントはアプリが生きていた場合に
             // しか飛ばないので、両方を見ないとログインが黙って失敗する。


### PR DESCRIPTION
## なぜやるか

- 端末での同期失敗が読めない。rustls-platform-verifier は拒否理由（`certificate was revoked: …`）を `log::warn!` にしか書かず、呼び出し元には汎用エラーしか返さない
- Android には `log` の受け手が居らず、その記録は logcat に届く前に捨てられる
- #175 で失効判定を推測で迂回するしかなかったのは、この理由が読めなかったため

## やったこと

- Android ターゲットにだけ `log` と `android_logger` を追加した（他 OS は stderr が使えるので不要）
- `setup` の冒頭、`android_tls::init` より前で `android_logger::init_once` を呼ぶようにした。最初のハンドシェイクを取りこぼさないため
- デバッグビルドは Debug、リリースは Warn 止まり。Info まで出すと依存クレートの平常時のログで肝心の 1 行が流れる
- 自前の `log::` 呼び出しは足していない。他クレートの記録を `adb logcat -s magical-merchant` で読めるようにするだけの変更

### 実機での確認手順

1. `just tauri_app::android-dev` で実機に入れる
2. `adb logcat -s magical-merchant rustls_platform_verifier`
3. 同期を 1 回走らせ、TLS 検証のログ（または何も出ないこと）を見る
4. #175 の迂回（`webpki-roots` への切り替え）を一時的に外したビルドで `certificate was revoked: …` が出れば、本 PR の目的は達成

## やらなかったこと

- ロガー初期化のテストは書いていない。プロセス全体の状態を触る副作用だけの初期化で、固定しても回帰を守らない
- アプリ自身のログ出力は入れていない。今回の目的は依存クレートの出力を読めるようにすることだけ
- Android ターゲットの clippy 3 件（`android_tls.rs` / `place.rs`、いずれも本 PR 対象外）は直していない。CI もホストターゲットしか見ていない
- 実機での確認は未実施。上の手順のとおり

## 資料

- `just rust::check` / `test`（425 tests）/ `check-rustls` すべて通過
- `nix develop .#android` で `cargo check -p magical-merchant-app --target aarch64-linux-android` が通ることを確認
- `cargo tree --target aarch64-linux-android` で `log v0.4.29` が 1 版に解決
- Cargo.lock の増分は `android_logger` / `android_log-sys` / `env_filter` の 3 クレートのみ

Closes #176
