### PR TITLE
fix(sync): file conflict copies outside the notes directory

### DIFF
--- a/.claude/skills/sync-storage/SKILL.md
+++ b/.claude/skills/sync-storage/SKILL.md
@@ -65,8 +65,10 @@ local scan → diff → one `POST /sync/bulk`.
   drives the "syncing" indicator; the file lock is the authority. Only the
   app starts a sync today — the lock is there for the CLI `sync` subcommand
   (#170), which does not exist yet
-- Conflicts keep the loser as `….sync-conflict-<ts>.md` in R2 and on disk;
-  conflict copies are excluded from scanning
+- Conflicts keep the loser as `….sync-conflict-<ts>.md` in R2, and on disk
+  as `conflicts/<key minus extension>/<ts>.md` — outside `data/`, same shape
+  as `history/`, so it neither syncs back nor lands in the notes list.
+  The name is built and read back in `core/src/sync/conflict.rs` only
 - Auto sync runs a few seconds after any successful write
 - JWT: macOS Keychain; Android falls back to app-private file (mode 600) —
   keyring's in-memory fallback silently loses tokens

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -19,8 +19,8 @@ pub use glyph::{
 pub use note::error::NoteError;
 pub use note::{
     NoteSummary, Revision, Snapshot, create_draft_note, delete_note, list_note_history, list_notes,
-    read_note, read_note_by_filename, read_note_history, read_note_meta, repair_notes,
-    restore_note, snapshot_note, update_note, update_note_meta, update_note_origin,
+    read_note, read_note_by_filename, read_note_history, read_note_meta, relocate_conflict_copies,
+    repair_notes, restore_note, snapshot_note, update_note, update_note_meta, update_note_origin,
     update_note_view,
 };
 pub use search::{HitKind, SearchHit, find_backlinks, search_all};

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -111,6 +111,12 @@ pub fn repair_notes(base_dir: &Path) -> Result<usize, CoreError> {
     repair::repair_all(&crate::utils::paths::notes_dir(base_dir))
 }
 
+/// 古い版が `data/notes/` に置いた競合コピーを `conflicts/` へ移す。移した件数を返す。
+/// 呼ぶのは同期を持つアプリだけ、それも最初の同期より前に一度。
+pub fn relocate_conflict_copies(base_dir: &Path) -> Result<usize, CoreError> {
+    repair::relocate_conflict_copies(base_dir)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -111,7 +111,8 @@ pub fn repair_notes(base_dir: &Path) -> Result<usize, CoreError> {
     repair::repair_all(&crate::utils::paths::notes_dir(base_dir))
 }
 
-/// 古い版が `data/notes/` に置いた競合コピーを `conflicts/` へ移す。移した件数を返す。
+/// 古い版が `data/notes/` と `data/timeline/` に置いた競合コピーを `conflicts/` へ
+/// 移す。移した件数を返す。
 /// 呼ぶのは同期を持つアプリだけ、それも最初の同期より前に一度。
 pub fn relocate_conflict_copies(base_dir: &Path) -> Result<usize, CoreError> {
     repair::relocate_conflict_copies(base_dir)

--- a/core/src/note/repair.rs
+++ b/core/src/note/repair.rs
@@ -4,8 +4,10 @@ use std::path::Path;
 use chrono::{DateTime, FixedOffset, Local, NaiveDateTime, TimeZone as _};
 
 use crate::error::CoreError;
+use crate::sync::conflict::conflict_copy_path;
 use crate::utils::frontmatter::{self, NoteFrontmatter};
-use crate::utils::fs::{list_md_files, write_atomic};
+use crate::utils::fs::{ensure_dir, list_md_files, write_atomic};
+use crate::utils::paths::{NOTES_DIR, conflicts_dir, notes_dir};
 
 /// 編集画面が frontmatter ごと Milkdown に通していた時期に保存されたノートは、
 /// 本文の先頭に「化けたメタデータ」を抱えている。開始区切りの `---` は `***` に、
@@ -38,6 +40,39 @@ pub(crate) fn repair_all(notes_dir: &Path) -> Result<usize, CoreError> {
         repaired += 1;
     }
     Ok(repaired)
+}
+
+/// 古い版が `data/notes/` に置いた競合コピーを `conflicts/` へ移す。移した件数を返す。
+///
+/// 控えは同期の走査からは外れていたが、ノート一覧は `data/notes/*.md` を
+/// 素通しで拾うので、元のノートが消えたあとも残骸として並び続けていた。
+///
+/// 中身は読まず `rename` するだけ。控えが壊れていても、ノートの形をして
+/// いなくても運べる。起動時、最初の同期より前に呼ぶこと — あとで呼ぶと、
+/// 除外をやめたスキャンが残骸を新しいノートとして全端末へ配ってしまう。
+///
+/// 1 件の失敗では止まらない。運べなかった控えは次の起動でまた試すだけで、
+/// そのために残りの引っ越しを諦める理由はない。
+pub(crate) fn relocate_conflict_copies(base_dir: &Path) -> Result<usize, CoreError> {
+    let conflicts = conflicts_dir(base_dir);
+    let mut moved = 0;
+    for entry in list_md_files(&notes_dir(base_dir))? {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        // 走査キーと同じ形にしてから読ませる。控えの置き場は
+        // ダウンロードで降ってきたぶんと同じ `conflicts/notes/…` になる
+        let Some(relative) = conflict_copy_path(&format!("{NOTES_DIR}/{name}")) else {
+            continue;
+        };
+        let target = conflicts.join(relative);
+        if ensure_dir(&target).is_err() || fs::rename(entry.path(), &target).is_err() {
+            continue;
+        }
+        moved += 1;
+    }
+    Ok(moved)
 }
 
 /// 本文先頭の化けたメタデータ塊を取り除いた本文を返す。塊が無ければ `None`。
@@ -213,5 +248,88 @@ mod tests {
     fn a_missing_directory_repairs_nothing() {
         let tmp = TempDir::new().unwrap();
         assert_eq!(repair_all(&tmp.path().join("nope")).unwrap(), 0);
+    }
+
+    // ──────────── 競合コピーの引っ越し ────────────
+
+    fn seed_note(base: &Path, name: &str, content: &str) {
+        let notes = notes_dir(base);
+        fs::create_dir_all(&notes).unwrap();
+        fs::write(notes.join(name), content).unwrap();
+    }
+
+    /// 古い版が置いた控えは `data/notes/` に残っている。一覧に並ぶし、
+    /// 除外をやめたスキャンに乗れば他の端末へも配られる。
+    #[test]
+    fn conflict_copies_left_in_the_notes_directory_move_out() {
+        let tmp = TempDir::new().unwrap();
+        seed_note(tmp.path(), "20260320_033440.md", "the note itself");
+        seed_note(
+            tmp.path(),
+            "20260320_033440.sync-conflict-20260511-031336.md",
+            "first copy",
+        );
+        // 元のノートが既に消えている残骸。今の手元はほとんどこれ
+        seed_note(
+            tmp.path(),
+            "20260101_000000.sync-conflict-20260511-031336..md",
+            "orphan copy",
+        );
+
+        let moved = relocate_conflict_copies(tmp.path()).unwrap();
+
+        assert_eq!(moved, 2);
+        let notes: Vec<String> = list_md_files(&notes_dir(tmp.path()))
+            .unwrap()
+            .iter()
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(notes, vec!["20260320_033440.md"]);
+        let conflicts = conflicts_dir(tmp.path());
+        assert_eq!(
+            fs::read_to_string(conflicts.join("notes/20260320_033440/20260511-031336.md")).unwrap(),
+            "first copy"
+        );
+        assert_eq!(
+            fs::read_to_string(conflicts.join("notes/20260101_000000/20260511-031336.md")).unwrap(),
+            "orphan copy"
+        );
+    }
+
+    /// 起動のたびに走る。2 回目に動くものが残っていてはいけない。
+    #[test]
+    fn relocating_twice_moves_nothing_the_second_time() {
+        let tmp = TempDir::new().unwrap();
+        seed_note(
+            tmp.path(),
+            "20260320_033440.sync-conflict-20260511-031336.md",
+            "copy",
+        );
+
+        relocate_conflict_copies(tmp.path()).unwrap();
+        let after_first = fs::read_to_string(
+            conflicts_dir(tmp.path()).join("notes/20260320_033440/20260511-031336.md"),
+        )
+        .unwrap();
+
+        assert_eq!(relocate_conflict_copies(tmp.path()).unwrap(), 0);
+        assert_eq!(
+            fs::read_to_string(
+                conflicts_dir(tmp.path()).join("notes/20260320_033440/20260511-031336.md")
+            )
+            .unwrap(),
+            after_first
+        );
+    }
+
+    /// 引っ越しは中身を見ない。控えが壊れていても、ノートで無くても運ぶ。
+    #[test]
+    fn a_note_that_is_not_a_conflict_copy_stays_put() {
+        let tmp = TempDir::new().unwrap();
+        seed_note(tmp.path(), "20260320_033440.md", "body");
+
+        assert_eq!(relocate_conflict_copies(tmp.path()).unwrap(), 0);
+        assert!(notes_dir(tmp.path()).join("20260320_033440.md").exists());
+        assert!(!conflicts_dir(tmp.path()).exists());
     }
 }

--- a/core/src/note/repair.rs
+++ b/core/src/note/repair.rs
@@ -7,7 +7,7 @@ use crate::error::CoreError;
 use crate::sync::conflict::conflict_copy_path;
 use crate::utils::frontmatter::{self, NoteFrontmatter};
 use crate::utils::fs::{ensure_dir, list_md_files, write_atomic};
-use crate::utils::paths::{NOTES_DIR, conflicts_dir, notes_dir};
+use crate::utils::paths::{NOTES_DIR, TIMELINE_DIR, conflicts_dir, data_dir};
 
 /// 編集画面が frontmatter ごと Milkdown に通していた時期に保存されたノートは、
 /// 本文の先頭に「化けたメタデータ」を抱えている。開始区切りの `---` は `***` に、
@@ -42,10 +42,13 @@ pub(crate) fn repair_all(notes_dir: &Path) -> Result<usize, CoreError> {
     Ok(repaired)
 }
 
-/// 古い版が `data/notes/` に置いた競合コピーを `conflicts/` へ移す。移した件数を返す。
+/// 古い版が `data/notes/` と `data/timeline/` に置いた競合コピーを `conflicts/` へ
+/// 移す。移した件数を返す。
 ///
 /// 控えは同期の走査からは外れていたが、ノート一覧は `data/notes/*.md` を
 /// 素通しで拾うので、元のノートが消えたあとも残骸として並び続けていた。
+/// タイムラインの控えは一覧には出ないが、走査の除外をやめた以上、
+/// 置いたままだと次の同期で新しいファイルとして全端末へ配られる。
 ///
 /// 中身は読まず `rename` するだけ。控えが壊れていても、ノートの形をして
 /// いなくても運べる。起動時、最初の同期より前に呼ぶこと — あとで呼ぶと、
@@ -55,22 +58,25 @@ pub(crate) fn repair_all(notes_dir: &Path) -> Result<usize, CoreError> {
 /// そのために残りの引っ越しを諦める理由はない。
 pub(crate) fn relocate_conflict_copies(base_dir: &Path) -> Result<usize, CoreError> {
     let conflicts = conflicts_dir(base_dir);
+    let data = data_dir(base_dir);
     let mut moved = 0;
-    for entry in list_md_files(&notes_dir(base_dir))? {
-        let name = entry.file_name();
-        let Some(name) = name.to_str() else {
-            continue;
-        };
-        // 走査キーと同じ形にしてから読ませる。控えの置き場は
-        // ダウンロードで降ってきたぶんと同じ `conflicts/notes/…` になる
-        let Some(relative) = conflict_copy_path(&format!("{NOTES_DIR}/{name}")) else {
-            continue;
-        };
-        let target = conflicts.join(relative);
-        if ensure_dir(&target).is_err() || fs::rename(entry.path(), &target).is_err() {
-            continue;
+    for dir in [NOTES_DIR, TIMELINE_DIR] {
+        for entry in list_md_files(&data.join(dir))? {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
+                continue;
+            };
+            // 走査キーと同じ形にしてから読ませる。控えの置き場は
+            // ダウンロードで降ってきたぶんと同じ `conflicts/<dir>/…` になる
+            let Some(relative) = conflict_copy_path(&format!("{dir}/{name}")) else {
+                continue;
+            };
+            let target = conflicts.join(relative);
+            if ensure_dir(&target).is_err() || fs::rename(entry.path(), &target).is_err() {
+                continue;
+            }
+            moved += 1;
         }
-        moved += 1;
     }
     Ok(moved)
 }
@@ -131,6 +137,7 @@ fn filename_time(filename: &str) -> Option<DateTime<FixedOffset>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::paths::notes_dir;
     use tempfile::TempDir;
 
     /// 実際に壊れていたファイルと同じ形の再現。
@@ -319,6 +326,38 @@ mod tests {
             )
             .unwrap(),
             after_first
+        );
+    }
+
+    /// タイムラインの控えも同じ残骸。一覧には並ばない（日付でない名前は
+    /// 捨てられる）が、走査の除外をやめた以上、置いたままだと次の同期で
+    /// 新しいファイルとして全端末へ配られる。
+    #[test]
+    fn conflict_copies_left_in_the_timeline_directory_move_out() {
+        let tmp = TempDir::new().unwrap();
+        let timeline = data_dir(tmp.path()).join(TIMELINE_DIR);
+        fs::create_dir_all(&timeline).unwrap();
+        fs::write(timeline.join("2026-03-20.md"), "the day itself").unwrap();
+        fs::write(
+            timeline.join("2026-03-20.sync-conflict-20260511-031336..md"),
+            "day copy",
+        )
+        .unwrap();
+
+        assert_eq!(relocate_conflict_copies(tmp.path()).unwrap(), 1);
+
+        assert!(timeline.join("2026-03-20.md").exists());
+        assert!(
+            !timeline
+                .join("2026-03-20.sync-conflict-20260511-031336..md")
+                .exists()
+        );
+        assert_eq!(
+            fs::read_to_string(
+                conflicts_dir(tmp.path()).join("timeline/2026-03-20/20260511-031336.md")
+            )
+            .unwrap(),
+            "day copy"
         );
     }
 

--- a/core/src/sync/conflict.rs
+++ b/core/src/sync/conflict.rs
@@ -2,6 +2,10 @@ use std::path::Path;
 
 use chrono::{DateTime, Utc};
 
+/// 競合コピーだと分かる印。名前を組むのも読み戻すのもこのファイルだけなので、
+/// 綴りが 2 か所に割れることはない。
+const CONFLICT_MARKER: &str = ".sync-conflict-";
+
 #[must_use]
 pub fn conflict_filename(key: &str, timestamp: DateTime<Utc>) -> String {
     let path = Path::new(key);
@@ -11,10 +15,41 @@ pub fn conflict_filename(key: &str, timestamp: DateTime<Utc>) -> String {
     let ts = timestamp.format("%Y%m%d-%H%M%S");
 
     if parent.is_empty() {
-        format!("{stem}.sync-conflict-{ts}.{ext}")
+        format!("{stem}{CONFLICT_MARKER}{ts}.{ext}")
     } else {
-        format!("{parent}/{stem}.sync-conflict-{ts}.{ext}")
+        format!("{parent}/{stem}{CONFLICT_MARKER}{ts}.{ext}")
     }
+}
+
+/// `conflict_filename` の逆。控えのキーから、元のキーと控えを取った時刻を返す。
+/// 競合コピーの名前でなければ `None`。
+///
+/// 拡張子は `Path` に読ませる。サーバー駆動同期以前の控えには
+/// `….sync-conflict-20260511-031336..md` のように点が 1 つ多い名前があり、
+/// 素朴に最初の `.` で切ると時刻に点が残る。
+fn conflict_copy_origin(key: &str) -> Option<(String, String)> {
+    let (stem_path, rest) = key.split_once(CONFLICT_MARKER)?;
+    let rest = Path::new(rest);
+    let ext = rest.extension().and_then(|e| e.to_str()).unwrap_or("md");
+    let timestamp = rest
+        .file_stem()
+        .and_then(|s| s.to_str())?
+        .trim_end_matches('.');
+    Some((format!("{stem_path}.{ext}"), timestamp.to_string()))
+}
+
+/// 控えを置く、控え置き場からの相対パス。競合コピーの名前でなければ `None`。
+///
+/// 元のキーから拡張子を落としてディレクトリにし、その下に時刻で置く
+/// (`notes/20260320_033440/20260511-031336.md`)。`history/<stem>/<日時>.md`
+/// と同じ形なので、1 本のノートの控えが何度増えても 1 か所に集まる。
+#[must_use]
+pub fn conflict_copy_path(key: &str) -> Option<String> {
+    let (original, timestamp) = conflict_copy_origin(key)?;
+    let path = Path::new(&original);
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("md");
+    let dir = original.strip_suffix(&format!(".{ext}"))?;
+    Some(format!("{dir}/{timestamp}.{ext}"))
 }
 
 #[cfg(test)]
@@ -46,6 +81,54 @@ mod tests {
         assert_eq!(
             conflict_filename("notes/archive/2026/note.md", ts),
             "notes/archive/2026/note.sync-conflict-20260422-120000.md"
+        );
+    }
+
+    /// 控えの置き場を決めるには、名前から元のキーが読み戻せないといけない。
+    /// 親付きのキーでも親ごと戻る。
+    #[test]
+    fn a_generated_name_reads_back_to_the_key_it_came_from() {
+        let ts = Utc.with_ymd_and_hms(2026, 5, 11, 3, 13, 36).unwrap();
+        for key in [
+            "notes/20260320_033440.md",
+            "note.md",
+            "notes/archive/2026/note.md",
+            "glyphs/236p.png",
+        ] {
+            assert_eq!(
+                conflict_copy_origin(&conflict_filename(key, ts)),
+                Some((key.to_string(), "20260511-031336".to_string())),
+                "{key}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_name_without_the_marker_is_not_a_conflict_copy() {
+        assert_eq!(conflict_copy_origin("notes/20260320_033440.md"), None);
+        assert_eq!(conflict_copy_path("notes/20260320_033440.md"), None);
+    }
+
+    /// 控えは元のノートごとに 1 ディレクトリ。history と同じ形。
+    #[test]
+    fn a_copy_is_filed_under_the_note_it_came_from() {
+        assert_eq!(
+            conflict_copy_path("notes/20260320_033440.sync-conflict-20260511-031336.md"),
+            Some("notes/20260320_033440/20260511-031336.md".to_string())
+        );
+        assert_eq!(
+            conflict_copy_path("notes/archive/2026/note.sync-conflict-20260422-120000.md"),
+            Some("notes/archive/2026/note/20260422-120000.md".to_string())
+        );
+    }
+
+    /// 手元に残っている古い控えは点が 1 つ多い。時刻にその点を混ぜたまま
+    /// ディレクトリ名にすると、同じノートの控えが 2 か所に分かれる。
+    #[test]
+    fn an_old_double_dotted_name_still_reads_back() {
+        assert_eq!(
+            conflict_copy_path("notes/20260320_033440.sync-conflict-20260511-031336..md"),
+            Some("notes/20260320_033440/20260511-031336.md".to_string())
         );
     }
 }

--- a/core/src/sync/engine.rs
+++ b/core/src/sync/engine.rs
@@ -293,12 +293,15 @@ fn apply_response(
         }
     }
 
-    // 競合で負けたリモート側。`.sync-conflict-` はスキャン対象外なので、
-    // ローカルに置いても同期ループにはならない。
+    // 競合で負けたリモート側。`data/` の外に置くので同期にも載らず、
+    // ノート一覧にも並ばない。
     // 失敗しても `unwritten` には入れない: 控えのキーは state に載らないので、
     // 入れたところで何も除けない（サーバー側の控えは残るので中身も失われない）
+    let conflicts_dir = paths::conflicts_dir(base_dir);
     for d in &bulk_resp.conflict_downloads {
-        if let Err(e) = decode(d).and_then(|content| write_under(&data_dir, &d.key, &content)) {
+        // 名前が読めなければキーのまま置く。形が古くても控えは控え
+        let key = conflict::conflict_copy_path(&d.key).unwrap_or_else(|| d.key.clone());
+        if let Err(e) = decode(d).and_then(|content| write_under(&conflicts_dir, &key, &content)) {
             result.errors.push(e);
         }
     }
@@ -606,8 +609,16 @@ mod tests {
             fs::read_to_string(data.join("notes/a.md")).unwrap(),
             "remote"
         );
+        // 控えは書き続けるノートではない。`data/notes/` に置くと同期からは
+        // 外れていてもノート一覧に並び、元のノートが消えたあとも残骸として残る
+        assert!(
+            !data
+                .join("notes/a.sync-conflict-20260805-000000.md")
+                .exists()
+        );
         assert_eq!(
-            fs::read_to_string(data.join("notes/a.sync-conflict-20260805-000000.md")).unwrap(),
+            fs::read_to_string(paths::conflicts_dir(dir.path()).join("notes/a/20260805-000000.md"))
+                .unwrap(),
             "other device"
         );
         assert_eq!(result.downloaded, 1);

--- a/core/src/sync/engine.rs
+++ b/core/src/sync/engine.rs
@@ -23,6 +23,7 @@ use super::lock::SyncLock;
 use super::scan::{self, LocalFile};
 use super::state::{FileSyncRecord, SyncState};
 use super::{SyncError, SyncResult};
+use crate::utils::paths;
 
 const MAX_SYNC_ATTEMPTS: usize = 3;
 
@@ -61,7 +62,7 @@ async fn sync_once(client: &HttpClient, base_dir: &Path) -> Result<SyncResult, S
 
     refuse_wholesale_local_deletion(&actions, &local_files)?;
 
-    let data_dir = crate::utils::paths::data_dir(base_dir);
+    let data_dir = paths::data_dir(base_dir);
     let mut result = SyncResult::default();
     let bulk_req = build_bulk_request(
         &actions,
@@ -74,7 +75,7 @@ async fn sync_once(client: &HttpClient, base_dir: &Path) -> Result<SyncResult, S
 
     let bulk_resp = client.bulk(bulk_req).await?;
 
-    let unwritten = apply_response(&bulk_resp, &actions, &local_files, &data_dir, &mut result);
+    let unwritten = apply_response(&bulk_resp, &actions, &local_files, base_dir, &mut result);
 
     // サーバーが確定させた状態をそのままローカルにも記録する。
     // ここでローカルを再スキャンして組み直すと、ダウンロード直後の mtime が
@@ -276,13 +277,14 @@ fn apply_response(
     bulk_resp: &BulkResponse,
     actions: &[SyncAction],
     local_files: &[LocalFile],
-    data_dir: &Path,
+    base_dir: &Path,
     result: &mut SyncResult,
 ) -> HashSet<String> {
+    let data_dir = paths::data_dir(base_dir);
     let mut unwritten = HashSet::new();
 
     for d in &bulk_resp.downloads {
-        match decode(d).and_then(|content| write_under(data_dir, &d.key, &content)) {
+        match decode(d).and_then(|content| write_under(&data_dir, &d.key, &content)) {
             Ok(()) => result.downloaded += 1,
             Err(e) => {
                 result.errors.push(e);
@@ -296,7 +298,7 @@ fn apply_response(
     // 失敗しても `unwritten` には入れない: 控えのキーは state に載らないので、
     // 入れたところで何も除けない（サーバー側の控えは残るので中身も失われない）
     for d in &bulk_resp.conflict_downloads {
-        if let Err(e) = decode(d).and_then(|content| write_under(data_dir, &d.key, &content)) {
+        if let Err(e) = decode(d).and_then(|content| write_under(&data_dir, &d.key, &content)) {
             result.errors.push(e);
         }
     }
@@ -313,7 +315,7 @@ fn apply_response(
                 result.conflicts += 1;
             }
             SyncAction::DeleteLocal { key } => {
-                delete_local_file(key, local_files, data_dir, result);
+                delete_local_file(key, local_files, &data_dir, result);
             }
             SyncAction::DownloadNew { .. } | SyncAction::DownloadModified { .. } => {}
         }
@@ -466,8 +468,10 @@ mod tests {
         }
     }
 
-    fn seed(data_dir: &Path, key: &str, content: &str) {
-        let path = data_dir.join(key);
+    /// テストはどれもアプリと同じ `base_dir` を渡す。同期が触るのはその下の
+    /// `data/` だけなので、置くのもそこ。
+    fn seed(base_dir: &Path, key: &str, content: &str) {
+        let path = paths::data_dir(base_dir).join(key);
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(path, content).unwrap();
     }
@@ -483,7 +487,14 @@ mod tests {
         }];
 
         let mut result = SyncResult::default();
-        let req = build_bulk_request(&actions, &locals, dir.path(), None, &mut result).unwrap();
+        let req = build_bulk_request(
+            &actions,
+            &locals,
+            &paths::data_dir(dir.path()),
+            None,
+            &mut result,
+        )
+        .unwrap();
 
         assert_eq!(req.uploads.len(), 1);
         assert_eq!(req.uploads[0].hash, "deadbeef");
@@ -500,7 +511,14 @@ mod tests {
         }];
 
         let mut result = SyncResult::default();
-        let req = build_bulk_request(&actions, &locals, dir.path(), None, &mut result).unwrap();
+        let req = build_bulk_request(
+            &actions,
+            &locals,
+            &paths::data_dir(dir.path()),
+            None,
+            &mut result,
+        )
+        .unwrap();
 
         assert_eq!(req.conflicts.len(), 1);
         assert_eq!(req.conflicts[0].hash, "hash-local");
@@ -514,7 +532,12 @@ mod tests {
         seed(dir.path(), "notes/a.md", "content");
         let state = server_state(&[("notes/a.md", "hash-a", "2026-08-05T00:00:00Z")]);
 
-        let local = to_local_state(&state, dir.path(), &HashSet::new(), &SyncState::default());
+        let local = to_local_state(
+            &state,
+            &paths::data_dir(dir.path()),
+            &HashSet::new(),
+            &SyncState::default(),
+        );
 
         let record = &local.files["notes/a.md"];
         assert_eq!(record.content_hash, "hash-a");
@@ -532,9 +555,14 @@ mod tests {
         let state = server_state(&[("notes/missing.md", "hash-a", "2026-08-05T00:00:00Z")]);
 
         assert!(
-            to_local_state(&state, dir.path(), &HashSet::new(), &SyncState::default())
-                .files
-                .is_empty()
+            to_local_state(
+                &state,
+                &paths::data_dir(dir.path()),
+                &HashSet::new(),
+                &SyncState::default()
+            )
+            .files
+            .is_empty()
         );
     }
 
@@ -544,9 +572,14 @@ mod tests {
         let state = server_state(&[("../escape.md", "hash-a", "2026-08-05T00:00:00Z")]);
 
         assert!(
-            to_local_state(&state, dir.path(), &HashSet::new(), &SyncState::default())
-                .files
-                .is_empty()
+            to_local_state(
+                &state,
+                &paths::data_dir(dir.path()),
+                &HashSet::new(),
+                &SyncState::default()
+            )
+            .files
+            .is_empty()
         );
     }
 
@@ -568,13 +601,13 @@ mod tests {
         let mut result = SyncResult::default();
         apply_response(&resp, &[], &[], dir.path(), &mut result);
 
+        let data = paths::data_dir(dir.path());
         assert_eq!(
-            fs::read_to_string(dir.path().join("notes/a.md")).unwrap(),
+            fs::read_to_string(data.join("notes/a.md")).unwrap(),
             "remote"
         );
         assert_eq!(
-            fs::read_to_string(dir.path().join("notes/a.sync-conflict-20260805-000000.md"))
-                .unwrap(),
+            fs::read_to_string(data.join("notes/a.sync-conflict-20260805-000000.md")).unwrap(),
             "other device"
         );
         assert_eq!(result.downloaded, 1);
@@ -621,12 +654,13 @@ mod tests {
         let mut result = SyncResult::default();
         let unwritten = apply_response(&resp, &[], &[], dir.path(), &mut result);
 
+        let data = paths::data_dir(dir.path());
         assert_eq!(
-            fs::read_to_string(dir.path().join("notes/good.md")).unwrap(),
+            fs::read_to_string(data.join("notes/good.md")).unwrap(),
             "remote"
         );
         assert_eq!(
-            fs::read_to_string(dir.path().join("notes/bad.md")).unwrap(),
+            fs::read_to_string(data.join("notes/bad.md")).unwrap(),
             "stale local copy"
         );
         assert_eq!(result.downloaded, 1);
@@ -634,7 +668,7 @@ mod tests {
 
         // 取れなかったキーを「同期済み」と記録すると、手元の古い版が
         // 新しいハッシュで確定してしまう。かわりに前回の記録をそのまま残す
-        let state = to_local_state(&resp.new_state, dir.path(), &unwritten, &previous);
+        let state = to_local_state(&resp.new_state, &data, &unwritten, &previous);
         assert_eq!(state.files["notes/good.md"].content_hash, "hash-good");
         let kept = &state.files["notes/bad.md"];
         assert_eq!(kept.content_hash, "hash-stale");
@@ -692,7 +726,7 @@ mod tests {
             &mut result,
         );
 
-        assert!(!dir.path().join("notes/a.md").exists());
+        assert!(!paths::data_dir(dir.path()).join("notes/a.md").exists());
         assert_eq!(result.deleted_local, 1);
         assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
     }
@@ -719,7 +753,7 @@ mod tests {
         );
 
         assert_eq!(
-            fs::read_to_string(dir.path().join("notes/a.md")).unwrap(),
+            fs::read_to_string(paths::data_dir(dir.path()).join("notes/a.md")).unwrap(),
             "edited while the sync was in flight"
         );
         assert_eq!(result.deleted_local, 0);
@@ -826,7 +860,7 @@ mod tests {
         let mut result = SyncResult::default();
         let unwritten = apply_response(&resp, &[], &[], dir.path(), &mut result);
 
-        assert!(!dir.path().parent().unwrap().join("escaped.md").exists());
+        assert!(!dir.path().join("escaped.md").exists());
         assert_eq!(result.downloaded, 0);
         assert_eq!(result.errors.len(), 1, "errors: {:?}", result.errors);
         assert!(unwritten.contains("../escaped.md"));

--- a/core/src/sync/scan.rs
+++ b/core/src/sync/scan.rs
@@ -176,10 +176,11 @@ fn walk_dir(root: &Path, current: &Path, walk: &mut Walk) -> Result<(), CoreErro
     Ok(())
 }
 
+/// 同期の道具立てそのものは同期しない。競合コピーはここに出てこない —
+/// `data/` の外 (`conflicts/`) に置くので、そもそも走査が届かない。
 fn is_excluded(file_name: &str) -> bool {
-    file_name.contains(".sync-conflict-")
-        || file_name == ".sync-state.json"
-        // サーバー駆動同期以前のクライアントがクラッシュ時に残した一時ファイル
+    file_name == ".sync-state.json"
+        // `write_atomic` が rename の直前に置く一時ファイル。クラッシュで残る
         || file_name.starts_with(".sync-tmp-")
 }
 
@@ -220,24 +221,6 @@ mod tests {
         let notes = data.join("notes");
         fs::create_dir_all(&notes).unwrap();
         fs::write(notes.join("test.md"), "hello").unwrap();
-
-        let files = scan_local_files(dir.path()).unwrap();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].key, "notes/test.md");
-    }
-
-    #[test]
-    fn scan_excludes_conflict_files() {
-        let dir = tempfile::tempdir().unwrap();
-        let data = dir.path().join("data");
-        let notes = data.join("notes");
-        fs::create_dir_all(&notes).unwrap();
-        fs::write(notes.join("test.md"), "hello").unwrap();
-        fs::write(
-            notes.join("test.sync-conflict-20260422-120000.md"),
-            "conflict",
-        )
-        .unwrap();
 
         let files = scan_local_files(dir.path()).unwrap();
         assert_eq!(files.len(), 1);

--- a/core/src/utils/paths.rs
+++ b/core/src/utils/paths.rs
@@ -56,6 +56,16 @@ pub fn history_dir(base_dir: &Path) -> PathBuf {
     base_dir.join("history")
 }
 
+/// 競合で負けた側の控えの置き場。
+///
+/// `data/` の外に置く。同期の走査から外れるのはもちろん、ノート一覧が拾う
+/// `data/notes/*.md` からも外れる。控えは戻すためのもので、書き続ける
+/// ノートとして並ぶものではない。
+#[must_use]
+pub fn conflicts_dir(base_dir: &Path) -> PathBuf {
+    base_dir.join("conflicts")
+}
+
 /// 地名キャッシュの置き場。
 ///
 /// `data/` の外に置く。中身は座標から引き直せる派生物でしかなく、同期に
@@ -106,6 +116,16 @@ mod tests {
         assert_eq!(
             glyphs_dir(Path::new("/app")),
             PathBuf::from("/app/data/glyphs")
+        );
+    }
+
+    /// 控えは history と同じく `data/` の外。中に置くと同期で往復するうえ、
+    /// ノート一覧にも並ぶ。
+    #[test]
+    fn conflict_copies_sit_outside_the_synced_tree() {
+        assert_eq!(
+            conflicts_dir(Path::new("/app")),
+            PathBuf::from("/app/conflicts")
         );
     }
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -150,9 +150,9 @@ native fullscreen (its own Space, like the green button) from the next launch.
 ## Sync (optional)
 
 A Cloudflare Worker + R2 backend syncs the Markdown files across devices.
-Conflicts keep the local copy and preserve the loser as a
-`.sync-conflict-<timestamp>.md` next to the note. See [sync.md](sync.md) for
-deployment and the change-detection protocol.
+Conflicts keep the local copy and preserve the loser under `conflicts/`,
+outside the synced tree. See [sync.md](sync.md) for deployment and the
+change-detection protocol.
 
 ## Android widgets
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -60,8 +60,8 @@ the typed text behind Revert, the CLI keeps it in a scratch file.
   command layer and the same logic serves the MCP server.
 - **Server-authoritative sync state.** The client never constructs the sync
   state it sends back; it stores what the server confirmed. Conflicts are
-  resolved local-wins, with the losing side kept as a `.sync-conflict-*`
-  copy so no edit is ever silently dropped.
+  resolved local-wins, with the losing side kept under `conflicts/` so no
+  edit is ever silently dropped.
 
 ## On-disk layout
 
@@ -73,6 +73,10 @@ the typed text behind Revert, the CLI keeps it in a scratch file.
 │   └── notes/
 │       └── 20260809_143000.md # one file per note, frontmatter + body
 ├── history/                   # copies taken before CLI / MCP overwrites
+├── conflicts/                 # the losing side of a sync conflict
+│   └── notes/
+│       └── 20260809_143000/
+│           └── 20260511-031336.md
 ├── .sync-state.json           # what the server last confirmed
 └── sync-config.json           # Workers URL, auto-sync flag (shared with the CLI)
 ```

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -52,9 +52,9 @@ in-memory store, which loses the token immediately — so on Android the token
 is written to the app-private data directory (mode `600`) instead.
 
 On a conflict the local copy wins the key, and the overwritten remote copy is
-kept both in R2 under `….sync-conflict-<timestamp>.md` and on disk next to
-the note. Conflict copies are excluded from scanning, so they never sync
-back.
+kept both in R2 under `….sync-conflict-<timestamp>.md` and on disk under
+`conflicts/<key without its extension>/<timestamp>.md`. That directory sits
+outside `data/`, so a copy neither syncs back nor appears in the notes list.
 
 ## Deployment
 

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -124,18 +124,29 @@ struct NoteRead {
     revision: String,
 }
 
+/// 起動してから一度だけの後始末。最初の一覧より前に、そして最初の同期より前に。
+///
+/// setup でやらないのは、Android の `app_data_dir` がメインスレッドから
+/// 呼べないのと、修復前の一覧が一瞬でも画面に出るのを避けるため。
+/// どちらも失敗しても黙って進む — ノートが読めなくなるよりはましで、
+/// 次の起動でまた試す。
+///
+/// 引っ越しを同期より前に済ませるのが要点。あとになると、`data/notes/` に
+/// 残った競合コピーを走査が拾って、残骸を全端末へ配ってしまう。
+pub(crate) fn repair_once(base_dir: &std::path::Path) {
+    static REPAIR: std::sync::Once = std::sync::Once::new();
+    REPAIR.call_once(|| {
+        // 過去の編集で本文に混入した化けメタデータ
+        let _ = magical_merchant_core::repair_notes(base_dir);
+        // 古い版が `data/notes/` に置いた競合コピー
+        let _ = magical_merchant_core::relocate_conflict_copies(base_dir);
+    });
+}
+
 #[tauri::command]
 fn list_notes(handle: AppHandle) -> Result<Vec<NoteSummary>, String> {
-    // 過去の編集で本文に混入した化けメタデータを、最初の一覧より前に一度だけ直す。
-    // setup でやらないのは、Android の `app_data_dir` がメインスレッドから
-    // 呼べないのと、修復前の一覧が一瞬でも画面に出るのを避けるため。
-    // 修復に失敗してもノートが読めなくなるよりは、そのまま出すほうがいい。
-    static REPAIR: std::sync::Once = std::sync::Once::new();
-
     let base_dir = app_base_dir(&handle)?;
-    REPAIR.call_once(|| {
-        let _ = magical_merchant_core::repair_notes(&base_dir);
-    });
+    repair_once(&base_dir);
 
     magical_merchant_core::list_notes(&base_dir).map_err(|e| e.to_string())
 }

--- a/tauri-app/src-tauri/src/sync.rs
+++ b/tauri-app/src-tauri/src/sync.rs
@@ -138,6 +138,11 @@ async fn do_sync(handle: &AppHandle) -> Result<SyncResult, SyncError> {
         .path()
         .app_data_dir()
         .map_err(|e| SyncError::other(e.to_string()))?;
+    // タイムラインだけ見て同期を押すと、ノート一覧より先にここへ来る。
+    // 走査より前に競合コピーを `data/` の外へ出しておかないと、残骸が
+    // 新しいノートとして全端末へ配られる
+    crate::repair_once(&base_dir);
+
     let config = SyncConfig::load(&base_dir)?.unwrap_or_default();
     if !config.is_configured() {
         return Err(SyncError::new(


### PR DESCRIPTION
このPRは #196 の上に積んである（base: `fix/sync-retry-failed-download`）。

## なぜやるか

- 競合で負けた控えは `data/notes/<stem>.sync-conflict-<ts>.md` に落ちていた。同期の走査からは外れていたが、`list_notes` は素の `.md` を全部拾うのでノート一覧に並ぶ
- 手元の Mac には 17 件あり、全部が元ノートの消えた残骸。一覧のノイズにしかなっていない
- 控えは「戻すためのもの」で、書き続けるノートではない。`history/` と同じく `data/` の外が正しい置き場

## やったこと

- `conflicts/<元のキーから拡張子を落としたもの>/<ts>.<ext>` に置くようにした（例 `conflicts/notes/20260320_033440/20260511-031336.md`）。`history/<stem>/<日時>.md` と同じ形なので、同じノートの控えが何度増えても 1 か所に集まる
- 名前の生成と読み戻しを `core/src/sync/conflict.rs` に閉じた。`.sync-conflict-` の綴りを知っているのはこのファイルだけ
- 既に `data/notes/` と `data/timeline/` にある控えは、起動時（最初のノート一覧、または最初の同期のどちらか早いほう）に `rename` で引っ越す。中身を読まないので、壊れた控えでも運べる
- 引っ越しは必ず走査より前。あとになると、除外をやめた走査が残骸を新しいノートとして全端末へ配ってしまう
- `scan.rs` の `.sync-conflict-` 除外を落とした。`data/` の中にその名前はもう生まれない（`.sync-state.json` と `.sync-tmp-*` の除外は残す — 後者は `write_atomic` が `data/` の中に置く一時ファイル）

```mermaid
flowchart LR
    W["Worker<br/>負けた側を R2 に put"]
    A["apply_response<br/>(クライアント)"]
    R["起動時 relocate_conflict_copies"]
    OLD["data/notes/*.sync-conflict-*.md<br/>古い版が残した 17 件"]
    C["conflicts/notes/&lt;stem&gt;/&lt;ts&gt;.md<br/>data/ の外"]

    W -- conflict_downloads --> A
    A --> C
    OLD -- rename --> R
    R --> C
    C -.- N["同期の走査にもノート一覧にも出ない"]
```

## やらなかったこと

- **控えを見る・戻す MCP ツール**（`list_note_history` / `restore_note` の conflicts 版）。置き場が history と同じ形なので `history.rs` の `dir` を差し替えるだけで足りる見込み。今回は「一覧に出ない」で #172 の実害が消えるので分ける
- **Worker が控えを R2 に put するのをやめる**。`deriveState` が state に載せないので誰にも読まれない dead weight だが、古いクライアントが `conflict_downloads` を期待するため、Worker の変更はクライアントと同時には出せない

## 手元での移行確認（マージ前に実機で）

```sh
BASE=~/Library/Application\ Support/com.magical-merchant.app
ls "$BASE"/data/notes/*.sync-conflict-* | wc -l      # 17 のはず
ls "$BASE"/data/timeline/*.sync-conflict-* | wc -l   # 5 のはず
# アプリを起動して Notes を開く（または同期ボタンを押す）
ls "$BASE"/data/notes/*.sync-conflict-* 2>/dev/null | wc -l   # 0
find "$BASE/conflicts" -name '*.md' | wc -l                    # 22
```

## 資料

- `just verify` 通過（rust 361+42+29 / frontend 633 / workers 33）、`just rust::check-rustls` も通過
- 古い控えの `….sync-conflict-20260511-031336..md`（点が 1 つ多い）も `Path::extension` で読むので、同じノートの控えが 2 か所に分かれないことをテストで固定

Closes #172

