### PR TITLE
feat(sync): report sync issues as data so the app can translate them

### DIFF
--- a/core/src/sync.rs
+++ b/core/src/sync.rs
@@ -26,7 +26,64 @@ pub struct SyncResult {
     pub deleted_remote: usize,
     pub deleted_local: usize,
     pub conflicts: usize,
-    pub errors: Vec<String>,
+    pub errors: Vec<SyncIssue>,
+}
+
+/// 同期そのものは続いたが、1 つのキーだけこけたときの記録。
+///
+/// core は文章を組まない: 呼び手はアプリ (日本語にもなる UI)・CLI・MCP・
+/// Android の JNI と分かれていて、翻訳表を置ける場所は core ではない。
+/// 素材だけを返し、文にするのは表示する側 (アプリは `lib/i18n.ts` の
+/// `sync.issue`)。`Display` は英語のままでよい CLI とログ用。
+///
+/// `kind` の文字列は TypeScript 側が分岐に使う識別子なので変えない。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SyncIssue {
+    /// `..` や先頭の `/` を含むキー。手元にもサーバーにも渡さない
+    UnsafeKey {
+        key: String,
+    },
+    /// 走査には出たのに送る段になって見つからない
+    MissingLocalFile {
+        key: String,
+    },
+    ReadFailed {
+        key: String,
+        detail: String,
+    },
+    WriteFailed {
+        key: String,
+        detail: String,
+    },
+    DecodeFailed {
+        key: String,
+        detail: String,
+    },
+    DeleteFailed {
+        key: String,
+        detail: String,
+    },
+    /// 走査から削除までのあいだに書き換わったので、消さずに残した
+    DeleteSkippedChanged {
+        key: String,
+    },
+}
+
+impl std::fmt::Display for SyncIssue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsafeKey { key } => write!(f, "unsafe key rejected: {key}"),
+            Self::MissingLocalFile { key } => write!(f, "missing local file: {key}"),
+            Self::ReadFailed { key, detail } => write!(f, "read {key}: {detail}"),
+            Self::WriteFailed { key, detail } => write!(f, "write {key}: {detail}"),
+            Self::DecodeFailed { key, detail } => write!(f, "base64 decode {key}: {detail}"),
+            Self::DeleteFailed { key, detail } => write!(f, "delete_local {key}: {detail}"),
+            Self::DeleteSkippedChanged { key } => {
+                write!(f, "delete_local {key}: changed since scan, kept")
+            }
+        }
+    }
 }
 
 /// フロントが「設定へ誘導」「再試行」などを出し分けられるよう、
@@ -65,7 +122,31 @@ impl std::error::Error for SyncError {}
 
 #[cfg(test)]
 mod tests {
-    use super::SyncError;
+    use super::{SyncError, SyncIssue};
+
+    /// TypeScript 側は `kind` で分岐して文言を選ぶ。この形が変わると、
+    /// 型は通ったまま画面の文言だけが消える
+    #[test]
+    fn an_issue_goes_over_the_wire_as_a_kind_and_its_parts() {
+        let json = serde_json::to_value(SyncIssue::DeleteSkippedChanged {
+            key: "notes/a.md".to_string(),
+        })
+        .unwrap();
+
+        assert_eq!(json["kind"], "delete_skipped_changed");
+        assert_eq!(json["key"], "notes/a.md");
+    }
+
+    /// CLI とログは英語のまま。翻訳するのはアプリだけ
+    #[test]
+    fn an_issue_still_prints_the_english_sentence() {
+        let issue = SyncIssue::ReadFailed {
+            key: "notes/a.md".to_string(),
+            detail: "permission denied".to_string(),
+        };
+
+        assert_eq!(issue.to_string(), "read notes/a.md: permission denied");
+    }
 
     #[test]
     fn busy_error_is_tagged_so_ui_can_ignore_it() {

--- a/core/src/sync/engine.rs
+++ b/core/src/sync/engine.rs
@@ -22,7 +22,7 @@ use super::diff::{self, RemoteFile, SyncAction};
 use super::lock::SyncLock;
 use super::scan::{self, LocalFile};
 use super::state::{FileSyncRecord, SyncState};
-use super::{SyncError, SyncResult};
+use super::{SyncError, SyncIssue, SyncResult};
 use crate::utils::paths;
 
 const MAX_SYNC_ATTEMPTS: usize = 3;
@@ -71,7 +71,8 @@ async fn sync_once(client: &HttpClient, base_dir: &Path) -> Result<SyncResult, S
         server_state.etag.clone(),
         &mut result,
     )
-    .map_err(SyncError::other)?;
+    // 同期そのものが止まる側。CLI もアプリの汎用エラー表示も英文で扱う
+    .map_err(|issue| SyncError::other(issue.to_string()))?;
 
     let bulk_resp = client.bulk(bulk_req).await?;
 
@@ -183,7 +184,7 @@ fn build_bulk_request(
     data_dir: &Path,
     expected_etag: Option<String>,
     result: &mut SyncResult,
-) -> Result<BulkRequest, String> {
+) -> Result<BulkRequest, SyncIssue> {
     let local_map: HashMap<&str, &LocalFile> =
         local_files.iter().map(|f| (f.key.as_str(), f)).collect();
 
@@ -195,7 +196,9 @@ fn build_bulk_request(
     for action in actions {
         let key = action_key(action);
         if !is_safe_key(key) {
-            result.errors.push(format!("unsafe key rejected: {key}"));
+            result.errors.push(SyncIssue::UnsafeKey {
+                key: key.to_string(),
+            });
             continue;
         }
 
@@ -203,9 +206,11 @@ fn build_bulk_request(
             SyncAction::UploadNew { key } | SyncAction::UploadModified { key } => {
                 let local = local_map
                     .get(key.as_str())
-                    .ok_or_else(|| format!("missing local file for upload: {key}"))?;
-                let content =
-                    fs::read(data_dir.join(key)).map_err(|e| format!("read {key}: {e}"))?;
+                    .ok_or_else(|| SyncIssue::MissingLocalFile { key: key.clone() })?;
+                let content = fs::read(data_dir.join(key)).map_err(|e| SyncIssue::ReadFailed {
+                    key: key.clone(),
+                    detail: e.to_string(),
+                })?;
                 uploads.push(WireUpload {
                     key: key.clone(),
                     content_base64: B64.encode(&content),
@@ -227,9 +232,11 @@ fn build_bulk_request(
                 // 残るので、どちらの編集も失われない
                 let local = local_map
                     .get(key.as_str())
-                    .ok_or_else(|| format!("missing local file for conflict: {key}"))?;
-                let content = fs::read(data_dir.join(key))
-                    .map_err(|e| format!("read conflict {key}: {e}"))?;
+                    .ok_or_else(|| SyncIssue::MissingLocalFile { key: key.clone() })?;
+                let content = fs::read(data_dir.join(key)).map_err(|e| SyncIssue::ReadFailed {
+                    key: key.clone(),
+                    detail: e.to_string(),
+                })?;
                 conflicts.push(WireConflictOp {
                     key: key.clone(),
                     conflict_key: conflict::conflict_filename(key, Utc::now()),
@@ -250,22 +257,33 @@ fn build_bulk_request(
     })
 }
 
-fn write_under(data_dir: &Path, key: &str, content: &[u8]) -> Result<(), String> {
+fn write_under(data_dir: &Path, key: &str, content: &[u8]) -> Result<(), SyncIssue> {
     if !is_safe_key(key) {
-        return Err(format!("unsafe key from server: {key}"));
+        return Err(SyncIssue::UnsafeKey {
+            key: key.to_string(),
+        });
     }
     let path = data_dir.join(key);
     if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|e| format!("mkdir {key}: {e}"))?;
+        fs::create_dir_all(parent).map_err(|e| SyncIssue::WriteFailed {
+            key: key.to_string(),
+            detail: format!("mkdir: {e}"),
+        })?;
     }
     // 直接上書きだと、ダウンロード書き込み中のクラッシュで手元のメモが
     // 半分だけ書けたファイルに置き換わる
-    crate::utils::fs::write_atomic(&path, content).map_err(|e| format!("write {key}: {e}"))
+    crate::utils::fs::write_atomic(&path, content).map_err(|e| SyncIssue::WriteFailed {
+        key: key.to_string(),
+        detail: e.to_string(),
+    })
 }
 
-fn decode(file: &DownloadedFile) -> Result<Vec<u8>, String> {
+fn decode(file: &DownloadedFile) -> Result<Vec<u8>, SyncIssue> {
     B64.decode(&file.content_base64)
-        .map_err(|e| format!("base64 decode {}: {e}", file.key))
+        .map_err(|e| SyncIssue::DecodeFailed {
+            key: file.key.clone(),
+            detail: e.to_string(),
+        })
 }
 
 /// サーバーの返事をローカルに反映する。書けなかったキーを返す。
@@ -347,7 +365,10 @@ fn delete_local_file(
             return;
         }
         Err(e) => {
-            result.errors.push(format!("delete_local {key}: {e}"));
+            result.errors.push(SyncIssue::DeleteFailed {
+                key: key.to_string(),
+                detail: e.to_string(),
+            });
             return;
         }
     };
@@ -357,14 +378,17 @@ fn delete_local_file(
         .find(|f| f.key == key)
         .map(|f| f.content_hash.as_str());
     if scanned != Some(scan::compute_hash(&content).as_str()) {
-        result
-            .errors
-            .push(format!("delete_local {key}: changed since scan, kept"));
+        result.errors.push(SyncIssue::DeleteSkippedChanged {
+            key: key.to_string(),
+        });
         return;
     }
 
     if let Err(e) = fs::remove_file(&path) {
-        result.errors.push(format!("delete_local {key}: {e}"));
+        result.errors.push(SyncIssue::DeleteFailed {
+            key: key.to_string(),
+            detail: e.to_string(),
+        });
     } else {
         result.deleted_local += 1;
     }
@@ -768,7 +792,14 @@ mod tests {
             "edited while the sync was in flight"
         );
         assert_eq!(result.deleted_local, 0);
-        assert_eq!(result.errors.len(), 1, "errors: {:?}", result.errors);
+        // 表示するのはアプリ (日本語) と CLI (英語) の両方なので、理由は
+        // 英文ではなくキーで返す
+        assert_eq!(
+            result.errors,
+            vec![SyncIssue::DeleteSkippedChanged {
+                key: "notes/a.md".to_string()
+            }]
+        );
     }
 
     /// サーバーの同期状態が壊れて空になったときに、それを「全部削除された」と

--- a/tauri-app/dev/ipc-mock.js
+++ b/tauri-app/dev/ipc-mock.js
@@ -484,6 +484,35 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
     ["623k", { format: "svg", url: svgDataUrl(glyphSvg("623K", "#1c7ed6")) }],
   ]);
 
+  // ---- イベント ----
+
+  /**
+   * `transformCallback` が預かった受け口。本物ではここを Rust 側が叩く。
+   * ブラウザではモック自身が叩き、同期のように「押したあとで結果が届く」
+   * 経路も動くようにする。
+   * @type {Map<number, (event: { event: string, id: number, payload: unknown }) => void>}
+   */
+  const eventHandlers = new Map();
+
+  /**
+   * イベント名 → 待っている受け口の id。
+   * @type {Map<string, number[]>}
+   */
+  const listeners = new Map();
+
+  /**
+   * @param {string} event
+   * @param {unknown} payload
+   */
+  const emit = (event, payload) => {
+    for (const id of listeners.get(event) ?? []) {
+      eventHandlers.get(id)?.({ event, id, payload });
+    }
+  };
+
+  /** 同期を押された回数。成功と失敗を交互に見せるのに使う */
+  let syncRuns = 0;
+
   // ---- コマンド実装 ----
 
   // まだ使われていない名前と、その名前が名乗る時刻。core の `Notes::create`
@@ -816,8 +845,33 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
       window.open(URL.createObjectURL(new Blob([bytes], { type: mime })), "_blank");
       return { saved: true };
     },
-    sync_start: () => {},
-    sync_status: () => ({}),
+    // 本物と同じく、押した側には何も返さない。結果は sync-complete で届く。
+    // 1 回目は成功、2 回目は失敗を 1 件混ぜて交互に流す: 失敗の文言だけは
+    // core が kind で返して画面側が訳すので、押し直せば両方の道が見られる
+    sync_start: () => {
+      syncRuns += 1;
+      const result =
+        syncRuns % 2 === 0
+          ? {
+              uploaded: 0,
+              downloaded: 1,
+              deleted_remote: 0,
+              deleted_local: 0,
+              conflicts: 0,
+              errors: [{ kind: "delete_skipped_changed", key: "notes/20260805_101500.md" }],
+            }
+          : {
+              uploaded: 2,
+              downloaded: 1,
+              deleted_remote: 0,
+              deleted_local: 0,
+              conflicts: 1,
+              errors: [],
+            };
+      // すぐ返すと「同期中」が一瞬も見えない
+      setTimeout(() => emit("sync-complete", result), 400);
+    },
+    sync_status: () => ({ is_syncing: false, last_synced_at: null, last_error: null }),
     auth_login: () => {},
     auth_status: () => true,
     auth_logout: () => {},
@@ -825,7 +879,14 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
     save_sync_config: () => {},
     is_sync_config_editable: () => true,
 
-    "plugin:event|listen": () => 1,
+    /** @param {{ event: string, handler: number }} args */
+    "plugin:event|listen": ({ event, handler }) => {
+      listeners.set(event, [...(listeners.get(event) ?? []), handler]);
+      // 本物はこの id を unlisten に渡してくる。ハンドラの id をそのまま使う
+      return handler;
+    },
+    // 受け口を外すのは `__TAURI_EVENT_PLUGIN_INTERNALS__` 側 (下)。
+    // こちらは「バックエンドも忘れた」の返事なので何もしない
     "plugin:event|unlisten": () => null,
     "plugin:deep-link|get_current": () => null,
     // ブラウザに全画面にする窓は無い。設定を入れても何も起きないのが正しい
@@ -851,12 +912,28 @@ const saveError = (kind, message) => Object.assign(new Error(message), { kind })
       // await して返す。ハンドラが同期に投げても、本物と同じく reject で届く
       return await handler(args ?? {});
     },
-    transformCallback: () => {
+    /** @param {(event: { event: string, id: number, payload: unknown }) => void} handler */
+    transformCallback: (handler) => {
       callbackId += 1;
+      eventHandlers.set(callbackId, handler);
       return callbackId;
     },
-    unregisterCallback: () => {},
+    /** @param {number} id */
+    unregisterCallback: (id) => {
+      eventHandlers.delete(id);
+    },
     convertFileSrc: (path) => path,
     metadata: { currentWindow: { label: "main" }, currentWebview: { label: "main" } },
+  };
+
+  // unlisten はここを直に呼ぶ (invoke を通らない)。置かないと購読を外す
+  // たびに TypeError で落ちる
+  globalThis.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+    unregisterListener: (event, eventId) => {
+      listeners.set(
+        event,
+        (listeners.get(event) ?? []).filter((id) => id !== eventId),
+      );
+    },
   };
 })();

--- a/tauri-app/dev/tauri-internals.d.ts
+++ b/tauri-app/dev/tauri-internals.d.ts
@@ -4,12 +4,22 @@
  */
 interface TauriInternals {
   invoke: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
-  transformCallback: () => number;
-  unregisterCallback: () => void;
+  /** イベントの受け口を預かって id を返す。本物ではその id を Rust 側が呼ぶ */
+  transformCallback: (
+    callback: (event: { event: string; id: number; payload: unknown }) => void,
+  ) => number;
+  unregisterCallback: (id: number) => void;
   convertFileSrc: (path: string) => string;
   metadata: { currentWindow: { label: string }; currentWebview: { label: string } };
+}
+
+/** イベントプラグインがウェブビュー側に置く分。unlisten だけがここを通る。 */
+interface TauriEventPluginInternals {
+  unregisterListener: (event: string, eventId: number) => void;
 }
 
 // globalThis に名前を生やす宣言は `var` しか書けない
 // oxlint-disable-next-line no-var, vars-on-top
 declare var __TAURI_INTERNALS__: TauriInternals | undefined;
+// oxlint-disable-next-line no-var, vars-on-top
+declare var __TAURI_EVENT_PLUGIN_INTERNALS__: TauriEventPluginInternals | undefined;

--- a/tauri-app/src/lib/commands.test.ts
+++ b/tauri-app/src/lib/commands.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach, vi } from "vitest";
 import { mockIPC, clearMocks } from "@tauri-apps/api/mocks";
+import { listen } from "@tauri-apps/api/event";
 import type { ClientContext } from "./client-context";
 import { isStaleSave, onLocalMutation, typedInvoke } from "./commands";
+import { describeSyncResult } from "./sync-status";
+import type { SyncResultPayload } from "./sync-status";
 // browser mode に node:fs は無い。Vite の `?raw` がソースをそのまま文字列で渡す。
 // oxlint は `?raw` を知らず、素の .ts に default export を探しに行くので黙らせる
 // oxlint-disable-next-line import/default
@@ -129,6 +132,26 @@ describe("dev/ipc-mock.js", () => {
       }),
     );
     expect(answers.filter((answer) => answer.includes("unknown command"))).toStrictEqual([]);
+  });
+
+  // 同期の結果はコマンドの戻りではなくイベントで届く。モックが流す形が
+  // core の `SyncIssue` からずれると、ブラウザ検証では出ているように見えて
+  // 実機では文言が空になる
+  it("delivers sync results the app can put into words", async () => {
+    const results: SyncResultPayload[] = [];
+    const unlisten = await listen<SyncResultPayload>("sync-complete", (event) =>
+      results.push(event.payload),
+    );
+    const invoke = tauri.__TAURI_INTERNALS__?.invoke;
+    // 成功と失敗を交互に流すので、2 回押せば両方が来る
+    await invoke?.("sync_start", {});
+    await invoke?.("sync_start", {});
+    await vi.waitFor(() => expect(results).toHaveLength(2));
+    unlisten();
+
+    const messages = results.map((result) => describeSyncResult(result).message);
+    expect(messages.every((message) => message.length > 0)).toBe(true);
+    expect(messages.some((message) => message.includes("notes/20260805_101500.md"))).toBe(true);
   });
 });
 

--- a/tauri-app/src/lib/i18n.ts
+++ b/tauri-app/src/lib/i18n.ts
@@ -12,6 +12,7 @@
  */
 
 import { createSignal } from "solid-js";
+import type { SyncIssue } from "./sync-status";
 
 export type Locale = "ja" | "en";
 /** 設定に残す値。`system` は端末の言語に従う。 */
@@ -180,6 +181,39 @@ const ja = {
     minutesAgo: (minutes: number) => `${minutes}分前`,
     hoursAgo: (hours: number) => `${hours}時間前`,
     daysAgo: (days: number) => `${days}日前`,
+    // 1 回の同期が終わったあとの知らせ。core は kind と材料だけを返すので、
+    // 文にするのはここ (`sync-status.ts` の describeSyncResult)
+    result: {
+      upToDate: "すべて同期済み",
+      synced: (parts: string) => `同期しました ${parts}`,
+      conflictsSaved: (count: number) => `競合${count}件を控えに保存しました`,
+      failed: (count: number, first: string) => `${count} 件が失敗 — ${first}`,
+      issue: (issue: SyncIssue) => {
+        switch (issue.kind) {
+          case "unsafe_key": {
+            return `${issue.key}: 安全でない名前なので送りませんでした`;
+          }
+          case "missing_local_file": {
+            return `${issue.key}: 送る直前に見つかりませんでした`;
+          }
+          case "read_failed": {
+            return `${issue.key}: 読めませんでした (${issue.detail})`;
+          }
+          case "write_failed": {
+            return `${issue.key}: 書けませんでした (${issue.detail})`;
+          }
+          case "decode_failed": {
+            return `${issue.key}: 受け取った中身を戻せませんでした (${issue.detail})`;
+          }
+          case "delete_failed": {
+            return `${issue.key}: 消せませんでした (${issue.detail})`;
+          }
+          case "delete_skipped_changed": {
+            return `${issue.key}: 同期中に書き換わったので消さずに残しました`;
+          }
+        }
+      },
+    },
   },
   settings: {
     title: "設定",
@@ -462,6 +496,37 @@ const en: Messages = {
     minutesAgo: (minutes: number) => `${minutes} min ago`,
     hoursAgo: (hours: number) => `${hours} h ago`,
     daysAgo: (days: number) => `${days} d ago`,
+    result: {
+      upToDate: "Already up to date",
+      synced: (parts: string) => `Synced ${parts}`,
+      conflictsSaved: (count: number) => `${count} conflict(s) saved as copies`,
+      failed: (count: number, first: string) => `${count} item(s) failed — ${first}`,
+      issue: (issue: SyncIssue) => {
+        switch (issue.kind) {
+          case "unsafe_key": {
+            return `${issue.key}: unsafe name, not synced`;
+          }
+          case "missing_local_file": {
+            return `${issue.key}: gone by the time it was sent`;
+          }
+          case "read_failed": {
+            return `${issue.key}: could not be read (${issue.detail})`;
+          }
+          case "write_failed": {
+            return `${issue.key}: could not be written (${issue.detail})`;
+          }
+          case "decode_failed": {
+            return `${issue.key}: what arrived could not be decoded (${issue.detail})`;
+          }
+          case "delete_failed": {
+            return `${issue.key}: could not be deleted (${issue.detail})`;
+          }
+          case "delete_skipped_changed": {
+            return `${issue.key}: changed during the sync, so it was kept`;
+          }
+        }
+      },
+    },
   },
   settings: {
     title: "Settings",

--- a/tauri-app/src/lib/sync-status.test.ts
+++ b/tauri-app/src/lib/sync-status.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+import { setLocale, t } from "./i18n";
 import { describeSyncResult, describeSyncError } from "./sync-status";
+import type { SyncIssue } from "./sync-status";
 
 const emptyResult = {
   uploaded: 0,
@@ -7,14 +9,17 @@ const emptyResult = {
   deleted_remote: 0,
   deleted_local: 0,
   conflicts: 0,
-  errors: [] as string[],
+  errors: [] as SyncIssue[],
 };
 
 describe("describeSyncResult", () => {
+  // 既定は test-setup の ja。英語を見たいところだけ切り替える
+  afterEach(() => setLocale("ja"));
+
   it("reports up to date when nothing changed", () => {
     const ui = describeSyncResult(emptyResult);
     expect(ui.status).toBe("success");
-    expect(ui.message).toBe("Already up to date");
+    expect(ui.message).toBe(t().sync.result.upToDate);
   });
 
   it("reports upload and download counts", () => {
@@ -27,24 +32,49 @@ describe("describeSyncResult", () => {
   it("counts deletions as changes", () => {
     const ui = describeSyncResult({ ...emptyResult, deleted_remote: 1, deleted_local: 2 });
     expect(ui.status).toBe("success");
-    expect(ui.message).not.toBe("Already up to date");
+    expect(ui.message).not.toBe(t().sync.result.upToDate);
   });
 
   it("mentions conflicts", () => {
     const ui = describeSyncResult({ ...emptyResult, downloaded: 1, conflicts: 2 });
     expect(ui.status).toBe("success");
-    expect(ui.message).toContain("2 conflict(s)");
+    expect(ui.message).toContain("2");
+    expect(ui.message).toContain(t().sync.result.conflictsSaved(2));
   });
 
-  it("reports errors with the first error message", () => {
+  // core は英文ではなく kind とキーを返す。文にするのはここなので、
+  // 選ばれている言語で出る
+  it("reports failures in japanese", () => {
     const ui = describeSyncResult({
       ...emptyResult,
       uploaded: 1,
-      errors: ["upload notes/a.md: Network error: timeout", "upload notes/b.md: HTTP 500"],
+      errors: [
+        { kind: "delete_skipped_changed", key: "notes/a.md" },
+        { kind: "write_failed", key: "notes/b.md", detail: "disk full" },
+      ],
     });
     expect(ui.status).toBe("error");
-    expect(ui.message).toContain("2");
-    expect(ui.message).toContain("upload notes/a.md");
+    expect(ui.message).toContain("2 件が失敗");
+    expect(ui.message).toContain("notes/a.md");
+  });
+
+  it("reports the same failure in english", () => {
+    setLocale("en");
+    const ui = describeSyncResult({
+      ...emptyResult,
+      errors: [{ kind: "delete_skipped_changed", key: "notes/a.md" }],
+    });
+    expect(ui.message).toContain("1 item(s) failed");
+    expect(ui.message).toContain("notes/a.md");
+  });
+
+  // 詳細を落とすと、書き込み失敗の原因 (容量・権限) が画面から消える
+  it("keeps the detail core attached to a failure", () => {
+    const ui = describeSyncResult({
+      ...emptyResult,
+      errors: [{ kind: "write_failed", key: "notes/b.md", detail: "disk full" }],
+    });
+    expect(ui.message).toContain("disk full");
   });
 });
 

--- a/tauri-app/src/lib/sync-status.ts
+++ b/tauri-app/src/lib/sync-status.ts
@@ -1,10 +1,27 @@
+import { t } from "./i18n";
+
+/**
+ * 同期の途中で 1 件だけこけたときの記録 (core の `SyncIssue`)。
+ *
+ * core は文を組まない — CLI や MCP からも呼ばれ、翻訳表を置く場所が無いので、
+ * `kind` と材料だけが届く。日本語にするのは `i18n.ts` の `sync.result.issue`。
+ */
+export type SyncIssue =
+  | { kind: "unsafe_key"; key: string }
+  | { kind: "missing_local_file"; key: string }
+  | { kind: "read_failed"; key: string; detail: string }
+  | { kind: "write_failed"; key: string; detail: string }
+  | { kind: "decode_failed"; key: string; detail: string }
+  | { kind: "delete_failed"; key: string; detail: string }
+  | { kind: "delete_skipped_changed"; key: string };
+
 export interface SyncResultPayload {
   uploaded: number;
   downloaded: number;
   deleted_remote: number;
   deleted_local: number;
   conflicts: number;
-  errors: string[];
+  errors: SyncIssue[];
 }
 
 interface SyncErrorInfo {
@@ -18,19 +35,23 @@ export interface SyncUiState {
 }
 
 export function describeSyncResult(result: SyncResultPayload): SyncUiState {
-  if (result.errors?.length) {
+  const strings = t().sync.result;
+
+  const [first] = result.errors ?? [];
+  if (first) {
     return {
       status: "error",
-      message: `${result.errors.length} item(s) failed — ${result.errors[0]}`,
+      message: strings.failed(result.errors.length, strings.issue(first)),
     };
   }
 
   const changed =
     result.uploaded + result.downloaded + result.deleted_remote + result.deleted_local;
   if (changed === 0 && result.conflicts === 0) {
-    return { status: "success", message: "Already up to date" };
+    return { status: "success", message: strings.upToDate };
   }
 
+  // 矢印と数字は言語を持たない。訳すのは前後の言葉だけ
   const parts: string[] = [];
   if (result.uploaded) {
     parts.push(`↑${result.uploaded}`);
@@ -41,9 +62,9 @@ export function describeSyncResult(result: SyncResultPayload): SyncUiState {
   if (result.deleted_remote + result.deleted_local) {
     parts.push(`−${result.deleted_remote + result.deleted_local}`);
   }
-  let message = `Synced ${parts.join(" ")}`.trim();
+  let message = strings.synced(parts.join(" ")).trim();
   if (result.conflicts) {
-    message += ` · ${result.conflicts} conflict(s) saved as copies`;
+    message += ` · ${strings.conflictsSaved(result.conflicts)}`;
   }
   return { status: "success", message };
 }


### PR DESCRIPTION
このPRは #193 と #172 の上に積んである（base: `fix/conflict-copies-out-of-notes`）。

## なぜやるか

- 同期後のトーストだけが英語のままだった。とくに `N item(s) failed — <英文>` は、ユーザーが読んで手を打つ必要がある唯一の文言
- core は CLI・MCP・Android JNI からも呼ばれるので、翻訳表を置ける場所ではない。文字列を core で組んでいる限りアプリは英語のまま

## やったこと

- core は `SyncResult.errors` に英文ではなく `SyncIssue`（`kind` + キー + 詳細）を積む。文にするのは呼び手
- `Display` は今までの英文をそのまま持つ。CLI と、同期そのものが止まる `SyncError` 側はこれを使う
- アプリは `lib/i18n.ts` の `sync.result.*`（ja / en）から文言を選ぶだけになった。矢印と数字は言語を持たないのでそのまま
- ブラウザ検証用の IPC モックがイベントを配れるようになり、同期結果のトーストを ja / en 両方で見られる（ついでに、購読解除のたびに `unregisterListener` で落ちていたのも直った）

```mermaid
flowchart LR
  core["core sync engine<br/>SyncIssue { kind, key, detail }"]
  core -->|serde| app["アプリ<br/>i18n.ts sync.result.issue"]
  core -->|Display| cli["CLI / ログ<br/>英文のまま"]
  core -->|Display → SyncError::other| stop["同期が止まった時の表示"]
  app --> ui["「1 件が失敗 — …消さずに残しました」"]
```

## やらなかったこと

- `SyncError`（`notConfigured` / `conflict` など、同期そのものが止まる側）の文言。`kind` で既に振り分けており、`message` は設定画面への導線に使われているので別途
- 英文が 2 種あった 2 箇所は 1 バリアントに畳んだ（`unsafe key rejected` / `unsafe key from server`、`missing local file for upload` / `for conflict`）。区別は英語ログからは消える
- 成功時の文言（`同期しました ↑2` / `すべて同期済み`）を出す導線。`SyncPopover` は失敗時しか `message()` を描かないので、訳しても今は画面に出ない

## 資料

- `just verify` 通過（rust 363+42+29 / frontend 637 / workers 33）
- `just tauri_app::dev-browser` で実画面を確認
  - ja: `1 件が失敗 — notes/20260805_101500.md: 同期中に書き換わったので消さずに残しました`
  - en: `1 item(s) failed — notes/20260805_101500.md: changed during the sync, so it was kept`
- i18n のキーは `sync.result.*` に入れ子。`sync.synced` / `sync.failed` は SyncPopover の見出しで使用中なので上書きしていない

Closes #192
