### PR TITLE
perf: trim listing and search hot spots and run them off the main thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2764,7 +2764,6 @@ dependencies = [
  "criterion",
  "jsonwebtoken",
  "keyring",
- "markdown-frontmatter",
  "reqwest",
  "serde",
  "serde_json",
@@ -2774,19 +2773,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "url",
-]
-
-[[package]]
-name = "markdown-frontmatter"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a46ec238a43080a53dc296b015d91fa033030d25bc05863f899915265afd5d"
-dependencies = [
- "serde",
- "serde_json",
- "serde_yaml",
- "thiserror 2.0.18",
- "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]

--- a/cli/src/server.rs
+++ b/cli/src/server.rs
@@ -886,7 +886,25 @@ mod tests {
             limit: None,
         }));
 
-        assert!(result.is_err());
+        assert_eq!(
+            result.err(),
+            Some("'from' (2026-02-01) is after 'to' (2026-01-01)".to_string())
+        );
+    }
+
+    /// 両端は含む。`from == to` は 1 日だけの範囲であって、逆向きではない。
+    #[test]
+    fn a_range_of_a_single_day_is_inclusive_on_both_ends() {
+        let tmp = TempDir::new().unwrap();
+        let ctx = Context::default();
+        write_day(tmp.path(), "2026-01-14", &[(9, "eve", &ctx)]);
+        write_day(tmp.path(), "2026-01-15", &[(9, "day", &ctx)]);
+        write_day(tmp.path(), "2026-01-16", &[(9, "next", &ctx)]);
+
+        let out = range(&server(tmp.path()), "2026-01-15", "2026-01-15", None);
+
+        let texts: Vec<&str> = out.entries.iter().map(|e| e.text.as_str()).collect();
+        assert_eq!(texts, vec!["day"]);
     }
 
     #[test]
@@ -1044,7 +1062,14 @@ mod tests {
             tags: None,
         }));
 
-        assert!(result.is_err());
+        assert_eq!(result.err(), Some("body is empty".to_string()));
+        // 断ったなら何も書かない。空のファイルが残ると一覧に「(空のメモ)」が並ぶ
+        assert!(
+            magical_merchant_core::list_notes(tmp.path())
+                .unwrap()
+                .is_empty()
+        );
+        assert!(!tmp.path().join("data/notes").exists());
     }
 
     #[test]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,7 +26,6 @@ sync-client = [
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
-markdown-frontmatter = { version = "0.5", features = ["yaml"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/core/src/glyph.rs
+++ b/core/src/glyph.rs
@@ -295,6 +295,19 @@ mod tests {
         assert!(!tmp.path().join("data/glyphs/big.png").exists());
     }
 
+    /// 上限ちょうどは通す。`>=` で弾くと、上限を狙って縮めた画像が入らない。
+    #[test]
+    fn an_image_of_exactly_the_limit_is_accepted() {
+        let tmp = TempDir::new().unwrap();
+        let mut big = PNG.to_vec();
+        big.resize(GLYPH_MAX_BYTES, 0);
+
+        save_glyph(tmp.path(), &name("big"), GlyphFormat::Png, &big).unwrap();
+
+        let saved = read_glyph(tmp.path(), &name("big")).unwrap();
+        assert_eq!(saved.bytes.len(), GLYPH_MAX_BYTES);
+    }
+
     /// 拡張子と中身が食い違うファイルは描けないので、入り口で弾く。
     #[test]
     fn content_that_is_not_the_named_format_is_refused() {

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -268,11 +268,15 @@ mod tests {
         let filename = filename_of(&path);
         assert_eq!(read_note_meta(tmp.path(), &filename).unwrap().updated, None);
 
+        // 作成時刻は秒に丸まっているので、書き直した瞬間はそれより後になる。
+        // `>= time` では作成時刻を写しただけでも通ってしまう
+        let before = chrono::Local::now();
         update_note(&path, "updated", &mock_context(), None).unwrap();
 
         let meta = read_note_meta(tmp.path(), &filename).unwrap();
-        assert!(meta.updated.is_some());
-        assert!(meta.updated.unwrap() >= meta.time);
+        let updated = meta.updated.expect("updated is stamped");
+        assert!(updated >= before, "updated {updated} < before {before}");
+        assert!(updated <= chrono::Local::now());
     }
 
     /// 読んでから書くまでに別の書き手が本文を変えていたら、その上に書かない。

--- a/core/src/note/summary.rs
+++ b/core/src/note/summary.rs
@@ -84,9 +84,38 @@ mod tests {
             "note.md".to_string(),
             &content,
         );
-        assert!(summary.time.is_some());
+        assert_eq!(
+            summary.time,
+            Some(
+                FixedOffset::east_opt(9 * 3600)
+                    .unwrap()
+                    .with_ymd_and_hms(2026, 3, 20, 14, 30, 0)
+                    .unwrap()
+            )
+        );
         assert_eq!(summary.tags, vec!["a", "b"]);
-        assert!(summary.preview.contains("# Title"));
+        assert_eq!(summary.preview, "# Title\nBody");
+    }
+
+    /// 一覧に載せるのは先頭 100 文字。バイトではなく文字で切らないと、
+    /// 日本語の本文は 3 分の 1 しか見えない。
+    #[test]
+    fn the_preview_is_the_first_hundred_chars_of_the_body() {
+        let preview_of = |len: usize| {
+            let body = "あ".repeat(len);
+            let content = frontmatter::render(&at(2026, 3, 20, 14, 30), &body).unwrap();
+            Summary::from_file(
+                PathBuf::from("/test/note.md"),
+                "note.md".to_string(),
+                &content,
+            )
+            .preview
+        };
+
+        assert_eq!(preview_of(99).chars().count(), 99);
+        assert_eq!(preview_of(100).chars().count(), 100);
+        assert_eq!(preview_of(101).chars().count(), 100);
+        assert_eq!(preview_of(101), "あ".repeat(100));
     }
 
     /// origin はタイムラインのチップ表示が使う。一覧に乗らないと、昇格した

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -7,6 +7,7 @@ use crate::timeline::Timeline;
 use crate::timeline::day::DayLog;
 use crate::utils::markdown::strip_timeline_prefix;
 use crate::utils::tags;
+use crate::utils::text::lowercase;
 use crate::{list_notes, list_timeline_dates};
 
 /// 検索結果がどちらの保管場所から来たか。
@@ -67,7 +68,7 @@ fn timeline_hits(
         };
         // エントリ本文はその日のファイルの部分文字列なので、ファイル全体に無いなら
         // どのエントリにも無い。分割もコンテキスト JSON の判定も丸ごと省ける。
-        if day_filter_applies && !content.to_lowercase().contains(needle) {
+        if day_filter_applies && !lowercase(&content).contains(needle) {
             continue;
         }
 
@@ -80,7 +81,7 @@ fn timeline_hits(
             .enumerate()
         {
             let text = strip_timeline_prefix(&entry);
-            let lowered = text.to_lowercase();
+            let lowered = lowercase(text);
             if !lowered.contains(needle) {
                 continue;
             }
@@ -117,7 +118,7 @@ pub fn search_all(
     query: &str,
     tags: &[String],
 ) -> Result<Vec<SearchHit>, CoreError> {
-    let needle = query.trim().to_lowercase();
+    let needle = lowercase(query.trim());
     let scope: Vec<String> = tags
         .iter()
         .map(|t| tags::normalize(t))
@@ -141,10 +142,10 @@ pub fn search_all(
             haystack.push(' ');
             haystack.push_str(tag);
         }
-        if !haystack.to_lowercase().contains(&needle) {
+        if !lowercase(&haystack).contains(&needle) {
             continue;
         }
-        let lowered = note.preview.to_lowercase();
+        let lowered = lowercase(&note.preview);
         let excerpt = snippet(&note.preview, &lowered, &needle);
         hits.push(SearchHit {
             kind: HitKind::Note,
@@ -194,7 +195,7 @@ pub fn find_backlinks(
         if !body.contains(&needle) {
             continue;
         }
-        let lowered = body.to_lowercase();
+        let lowered = lowercase(&body);
         let excerpt = snippet(&body, &lowered, &needle);
         hits.push(SearchHit {
             kind: HitKind::Note,

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -434,13 +434,48 @@ mod tests {
     #[test]
     fn finds_a_note_by_body_and_reports_its_filename() {
         let tmp = TempDir::new().unwrap();
-        draft(&tmp, "R2 のリトライ設計", &[]).unwrap();
+        let path = draft(&tmp, "R2 のリトライ設計", &[]).unwrap();
 
         let hits = search_all(tmp.path(), "リトライ", &[]).unwrap();
 
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].kind, HitKind::Note);
-        assert!(hits[0].filename.is_some());
+        // 開くときに使う名前なので、作られたファイルの名前そのものでなければならない
+        assert_eq!(
+            hits[0].filename.as_deref(),
+            path.file_name().and_then(|n| n.to_str())
+        );
+        assert_eq!(hits[0].index, None);
+    }
+
+    /// 日付を固定して 1 行書く。`save_timeline_entry` は今日にしか書けない。
+    fn write_day(tmp: &TempDir, date: chrono::NaiveDate, text: &str) {
+        let dir = tmp.path().join("data/timeline");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join(format!("{}.md", date.format("%Y-%m-%d"))),
+            format!("- [09:00:00] {text}\n"),
+        )
+        .unwrap();
+    }
+
+    /// 返すのは新しい方から 100 件まで。古い方を落とすのは、探しているのは
+    /// たいてい最近書いたものだから。
+    #[test]
+    fn hits_are_capped_at_the_newest_hundred() {
+        let tmp = TempDir::new().unwrap();
+        let oldest = chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap();
+        for offset in 0..=100 {
+            let date = oldest + chrono::Duration::days(offset);
+            write_day(&tmp, date, &format!("needle {offset}"));
+        }
+
+        let hits = search_all(tmp.path(), "needle", &[]).unwrap();
+
+        assert_eq!(hits.len(), MAX_HITS);
+        assert_eq!(hits[0].date, "2025-04-11");
+        assert_eq!(hits[MAX_HITS - 1].date, "2025-01-02");
+        assert!(hits.iter().all(|h| h.date != "2025-01-01"));
     }
 
     #[test]
@@ -506,6 +541,28 @@ mod tests {
         let hits = search_all(tmp.path(), "needle", &[]).unwrap();
 
         assert_eq!(hits[0].snippet, "needle のあと 改行");
+    }
+
+    /// 前後 40 文字ちょうどなら丸ごと収まり、41 文字目から省略する。
+    /// 文字数で数える — バイトで数えると日本語では 13 文字で切れる。
+    #[test]
+    fn a_snippet_elides_only_beyond_forty_chars_of_context() {
+        let tmp = TempDir::new().unwrap();
+        let exact = format!("{}リトライ{}", "前".repeat(40), "後".repeat(40));
+        let over = format!("{}リトライ{}", "前".repeat(41), "後".repeat(41));
+        draft(&tmp, &exact, &[]).unwrap();
+        draft(&tmp, &over, &[]).unwrap();
+
+        let hits = search_all(tmp.path(), "リトライ", &[]).unwrap();
+
+        let exact_hit = hits.iter().find(|h| h.snippet == exact).unwrap();
+        assert_eq!(exact_hit.match_start, Some(40));
+        let over_hit = hits.iter().find(|h| h.snippet != exact).unwrap();
+        assert_eq!(
+            over_hit.snippet,
+            format!("…{}リトライ{}…", "前".repeat(40), "後".repeat(40))
+        );
+        assert_eq!(over_hit.match_start, Some(41));
     }
 
     #[test]

--- a/core/src/sync/engine.rs
+++ b/core/src/sync/engine.rs
@@ -842,6 +842,19 @@ mod tests {
         assert!(refuse_wholesale_local_deletion(&actions, &locals).is_ok());
     }
 
+    /// しきい値(3)の 1 つ下。2 件の全消しはまだ「取り返しがつく」側。
+    #[test]
+    fn allows_clearing_a_workspace_just_below_the_threshold() {
+        let locals = vec![
+            local_file("notes/a.md", "h1"),
+            local_file("notes/b.md", "h2"),
+        ];
+        let actions = vec![delete_local("notes/a.md"), delete_local("notes/b.md")];
+
+        assert_eq!(locals.len(), WHOLESALE_DELETION_THRESHOLD - 1);
+        assert!(refuse_wholesale_local_deletion(&actions, &locals).is_ok());
+    }
+
     /// ロックは入口で取る。取れないまま走査や HTTP に進むと、
     /// もう一方のプロセスが書いている最中の状態を読んでしまう。
     /// 到達できない宛先を渡してあるので、通信まで進んでいれば kind は `network` になる。

--- a/core/src/sync/scan.rs
+++ b/core/src/sync/scan.rs
@@ -214,6 +214,34 @@ mod tests {
         assert!(files.is_empty());
     }
 
+    /// `data/` はあるが中身が無い。無い場合の早期 return とは別の経路で、
+    /// 走査そのものが空を返さなければならない。
+    #[test]
+    fn scan_an_existing_but_empty_data_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("data")).unwrap();
+
+        let files = scan_local_files(dir.path()).unwrap();
+
+        assert!(files.is_empty());
+    }
+
+    /// 同期の道具立て(状態ファイルと書きかけの一時ファイル)は、data の中に
+    /// あっても同期しない。載ると端末同士が互いの状態を上書きし合う。
+    #[test]
+    fn sync_state_and_temp_files_inside_data_are_not_scanned() {
+        let dir = tempfile::tempdir().unwrap();
+        let data = dir.path().join("data");
+        seed_note(dir.path(), "a.md", "hello");
+        fs::write(data.join(".sync-state.json"), "{}").unwrap();
+        fs::write(data.join(".sync-tmp-1-0"), "half written").unwrap();
+
+        let files = scan_local_files(dir.path()).unwrap();
+
+        let keys: Vec<&str> = files.iter().map(|f| f.key.as_str()).collect();
+        assert_eq!(keys, vec!["notes/a.md"]);
+    }
+
     #[test]
     fn scan_finds_md_files() {
         let dir = tempfile::tempdir().unwrap();

--- a/core/src/sync/state.rs
+++ b/core/src/sync/state.rs
@@ -53,17 +53,21 @@ mod tests {
         assert!(state.last_sync.is_none());
     }
 
+    /// 書いた値がそのまま戻る。時刻は秒より細かい桁まで — ここが丸まると
+    /// 次の同期で「ローカルが新しい」と誤判定して転送し直す。
     #[test]
     fn save_and_load_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
+        let last_sync = Utc::now();
+        let last_synced_modified = Utc::now() - chrono::Duration::seconds(30);
         let mut state = SyncState {
-            last_sync: Some(Utc::now()),
+            last_sync: Some(last_sync),
             ..SyncState::default()
         };
         state.files.insert(
             "notes/test.md".to_string(),
             FileSyncRecord {
-                last_synced_modified: Utc::now(),
+                last_synced_modified,
                 content_hash: "abc123".to_string(),
             },
         );
@@ -72,7 +76,9 @@ mod tests {
         let loaded = SyncState::load(dir.path()).unwrap();
 
         assert_eq!(loaded.files.len(), 1);
-        assert!(loaded.files.contains_key("notes/test.md"));
-        assert!(loaded.last_sync.is_some());
+        let record = &loaded.files["notes/test.md"];
+        assert_eq!(record.last_synced_modified, last_synced_modified);
+        assert_eq!(record.content_hash, "abc123");
+        assert_eq!(loaded.last_sync, Some(last_sync));
     }
 }

--- a/core/src/sync/token.rs
+++ b/core/src/sync/token.rs
@@ -141,6 +141,14 @@ mod tests {
         assert!(!is_token_valid(&make_jwt(soon)));
     }
 
+    /// 猶予ちょうど(`exp == now + 300`)は「まだ使える」に入れない。判定は
+    /// `>` なので、テスト側の now より判定時の now が進んでいても結論は同じ。
+    #[test]
+    fn a_token_expiring_exactly_at_the_buffer_is_not_valid() {
+        let at_buffer = chrono::Utc::now().timestamp() + 300;
+        assert!(!is_token_valid(&make_jwt(at_buffer)));
+    }
+
     #[test]
     fn invalid_token_format() {
         assert!(!is_token_valid("not-a-jwt"));

--- a/core/src/timeline/day.rs
+++ b/core/src/timeline/day.rs
@@ -337,6 +337,37 @@ mod tests {
         assert_eq!(day.devices.len(), 1);
     }
 
+    /// 空行だけの日は記録が無い日。空のエントリを 1 件作ってはいけない。
+    #[test]
+    fn an_empty_body_has_no_entries() {
+        assert!(split_entries("").is_empty());
+        assert!(split_entries("\n\n\n").is_empty());
+    }
+
+    /// 先頭が `- [` でない行から始まる本文。時刻の無い旧い記録を捨てずに
+    /// 最初のエントリとして拾い、続く行はその続きにする。
+    #[test]
+    fn a_body_that_does_not_start_with_a_bullet_keeps_its_first_line() {
+        let entries = split_entries("plain first\nstill first\n- [10:00:00] second\n");
+
+        assert_eq!(
+            entries,
+            vec!["plain first\nstill first", "- [10:00:00] second"]
+        );
+    }
+
+    /// 端末一覧に無い番号を指す行は、壊れた行として触らずに返す。
+    /// 別の端末の情報を付けて返すよりは、そのままのほうがまし。
+    #[test]
+    fn an_entry_pointing_past_the_device_list_is_returned_unchanged() {
+        let mut day = DayLog::default();
+        day.push("known", at(9), &mac(), None);
+        let stray = "- [10:00:00] stray {\"battery\":1,\"d\":5}";
+
+        assert_eq!(day.devices.len(), 1);
+        assert_eq!(day.expand(stray), stray);
+    }
+
     #[test]
     fn a_battery_reading_is_kept_per_entry() {
         let mut day = DayLog::default();

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -5,4 +5,5 @@ pub mod markdown;
 pub mod paths;
 pub mod place;
 pub mod tags;
+pub mod text;
 pub mod validated;

--- a/core/src/utils/frontmatter.rs
+++ b/core/src/utils/frontmatter.rs
@@ -81,44 +81,82 @@ pub fn render<T: Serialize>(fm: &T, body: &str) -> Result<String, CoreError> {
 
 /// 本文は `content` を借りて返す。呼び出し側の多くは先頭だけしか使わないので、
 /// ここで所有権を持たせると読み捨てるぶんまで丸ごと複製することになる。
+///
+/// frontmatter が無ければ空の対応表として読む — 全キーが省略可能な型は
+/// 既定値で通り、`time` のような必須キーを持つ型はここで失敗する。
+/// 区切りだけあって中身が無い(`---\n---`)ものも同じ扱い。
+///
+/// YAML は `T` に直接読む。いったん `serde_yaml::Value` を組み立ててから
+/// 変換すると、ノート 1 本ごとに木を 1 つ余分に作って捨てることになり、
+/// 一覧(`list_notes`)で最も広い frame だった。
 pub fn parse<T: DeserializeOwned>(content: &str) -> Result<(T, &str), CoreError> {
-    markdown_frontmatter::parse::<T>(content).map_err(|e| CoreError::Parse(format!("{e:?}")))
+    let (matter, body) = match split(content) {
+        Split::Some { matter, body } => (matter, body),
+        Split::None { body } => ("", body),
+        Split::Unclosed => {
+            return Err(CoreError::Parse(
+                "frontmatter is missing its closing delimiter".to_string(),
+            ));
+        }
+    };
+    let matter = if matter.trim().is_empty() {
+        "{}"
+    } else {
+        matter
+    };
+    let fm = serde_yaml::from_str::<T>(matter).map_err(|e| CoreError::Parse(e.to_string()))?;
+    Ok((fm, body))
 }
 
 /// frontmatter を捨てて本文だけを返す。`parse` と違い YAML の中身は見ないので、
 /// メタデータが壊れているファイルでも本文が画面に漏れ出さない。
 /// 区切りが閉じていなければ frontmatter とはみなさず全文を返す。
-///
-/// 区切りの探し方は `parse` が使う `markdown-frontmatter` の分割と同じ規則に
-/// 揃えてある(先頭の空白は落とす、行末は LF / CRLF / CR のどれでもよい、
-/// 開始直後の `---` も閉じ区切り)。crate は分割位置を公開していないので実装は
-/// 2 つあり、規則が食い違うと一覧(`parse`)は正しいのに編集経路(`strip`)
-/// だけ frontmatter を本文として抱える — `strip_matches_parse_body` がその
-/// 食い違いを見張っている。
 #[must_use]
 pub fn strip(content: &str) -> &str {
-    // `parse` は本文を trim 後の文字列から切り出すので、ここも揃える。
+    match split(content) {
+        Split::Some { body, .. } | Split::None { body } => body,
+        Split::Unclosed => content.trim_start(),
+    }
+}
+
+enum Split<'a> {
+    /// 区切りの内側と、閉じ区切りの次の行からの本文。
+    Some { matter: &'a str, body: &'a str },
+    /// 先頭が `---` ではない。本文は先頭の空白を落とした全文。
+    None { body: &'a str },
+    /// 開き区切りはあるが閉じていない。
+    Unclosed,
+}
+
+/// 区切りの規則はここ 1 か所: 先頭の空白は落とす、行末は LF / CRLF / CR の
+/// どれでもよい、開始直後の `---` も閉じ区切り。`parse` と `strip` が同じ
+/// 分割を使うので、一覧と編集経路で本文の始まりがずれることはない。
+fn split(content: &str) -> Split<'_> {
     let content = content.trim_start();
     let Some(first) = next_line(content, 0) else {
-        return content;
+        return Split::None { body: content };
     };
     if first.text != "---" {
-        return content;
+        return Split::None { body: content };
     }
     let mut pos = first.next_start;
     while let Some(line) = next_line(content, pos) {
         if line.text == "---" {
-            return &content[line.next_start..];
+            return Split::Some {
+                matter: &content[first.next_start..line.start],
+                body: &content[line.next_start..],
+            };
         }
         pos = line.next_start;
     }
-    // 閉じ区切りが無いなら frontmatter ではない
-    content
+    Split::Unclosed
 }
 
 struct Line<'a> {
     /// 行末の改行を含まない行の中身。
     text: &'a str,
+    /// この行の開始位置。
+    start: usize,
     /// 次の行の開始位置。行末が無い(末尾の行)なら文字列の長さ。
     next_start: usize,
 }
@@ -142,6 +180,7 @@ fn next_line(s: &str, pos: usize) -> Option<Line<'_>> {
     }
     Some(Line {
         text: &s[pos..end],
+        start: pos,
         next_start,
     })
 }
@@ -358,14 +397,76 @@ mod tests {
             "---\ntime: x\n---\nbody line\n",
             // CRLF
             "---\r\ntime: x\r\n---\r\nbody line\r\n",
+            // CR だけ
+            "---\rtime: x\r---\rbody line\r",
             // 空 frontmatter
             "---\n---\nbody line\n",
             // 本文中に閉じ区切りと同じ行がある
             "---\ntime: x\n---\nbefore\n---\nafter\n",
+            // 先頭の空白
+            "\n\n  ---\ntime: x\n---\nbody line\n",
+            // frontmatter 無し
+            "body line\n",
         ] {
             let (_fm, body): (serde_yaml::Value, &str) = parse(content).unwrap();
             assert_eq!(strip(content), body, "content: {content:?}");
         }
+    }
+
+    // ──────────── 境界 ────────────
+
+    /// 全キーが省略可能な型は、frontmatter が無くても・空でも既定値で読める。
+    /// 日ファイルの端末一覧がこれ。区切りだけの `---\n---` を壊れた
+    /// メタデータ扱いにすると、`---` の行が本文(エントリ)として残る。
+    #[test]
+    fn an_absent_or_empty_frontmatter_reads_as_defaults() {
+        #[derive(Debug, Default, PartialEq, serde::Deserialize)]
+        struct Optional {
+            #[serde(default)]
+            items: Vec<String>,
+        }
+
+        for content in ["body", "---\n---\nbody", "---\n\n---\nbody"] {
+            let (fm, body): (Optional, &str) = parse(content).unwrap();
+            assert_eq!(fm, Optional::default(), "content: {content:?}");
+            assert_eq!(body, "body", "content: {content:?}");
+        }
+    }
+
+    /// `time` を必須とするノートは、frontmatter が無ければ読めない。
+    /// 一覧はそこで `strip` に倒れ、本文をプレビューに出す。
+    #[test]
+    fn a_note_without_frontmatter_is_a_parse_error() {
+        let result = parse::<NoteFrontmatter>("just body");
+        assert!(matches!(result, Err(CoreError::Parse(_))));
+    }
+
+    /// 開き区切りだけの本文。`parse` は失敗し、`strip` は全文を返す —
+    /// 閉じていないものを frontmatter とみなすと本文が丸ごと消える。
+    #[test]
+    fn an_unclosed_delimiter_is_not_a_frontmatter() {
+        let content = "---\ntime: x\nbody line";
+        assert!(matches!(
+            parse::<serde_yaml::Value>(content),
+            Err(CoreError::Parse(_))
+        ));
+        assert_eq!(strip(content), content);
+    }
+
+    /// 閉じ区切りの直後で終わるファイル。本文は空で、範囲外に触れない。
+    #[test]
+    fn a_closing_delimiter_at_the_very_end_leaves_an_empty_body() {
+        let (_fm, body): (serde_yaml::Value, &str) = parse("---\ntime: x\n---").unwrap();
+        assert_eq!(body, "");
+    }
+
+    /// `---` に前後の空白や余分な記号が付いた行は区切りではない。
+    #[test]
+    fn a_delimiter_must_be_exactly_three_dashes() {
+        for content in ["--- \ntime: x\n---\nbody", "----\ntime: x\n---\nbody"] {
+            assert_eq!(strip(content), content, "content: {content:?}");
+        }
+        assert_eq!(strip("---\ntime: x\n--- \n---\nbody"), "body");
     }
 
     #[test]

--- a/core/src/utils/markdown.rs
+++ b/core/src/utils/markdown.rs
@@ -179,6 +179,19 @@ mod tests {
         assert_eq!(timeline_entry_time("- plain bullet"), None);
     }
 
+    /// 括弧の中は `HH:MM:SS` の 8 文字だけを時刻と見る。本文が `- [` で
+    /// 始まる普通の箇条書き(`- [x] done` など)を時刻と取り違えない。
+    #[test]
+    fn a_time_prefix_is_exactly_eight_digits_and_colons() {
+        assert_eq!(
+            split_time_prefix("- [09:00:00] x"),
+            Some(("- [09:00:00] ", "x"))
+        );
+        assert_eq!(split_time_prefix("- [9:00:00] x"), None);
+        assert_eq!(split_time_prefix("- [09:00:000] x"), None);
+        assert_eq!(split_time_prefix("- [aa:bb:cc] x"), None);
+    }
+
     #[test]
     fn test_format_note_markdown() {
         let tags = vec!["rust".to_string(), "memo".to_string()];

--- a/core/src/utils/tags.rs
+++ b/core/src/utils/tags.rs
@@ -108,31 +108,37 @@ fn collect_line(line: &str, tags: &mut Vec<String>) {
 ///
 /// 大文字小文字の違いは書き手にとって同じタグ。ASCII だけ小文字に寄せる
 /// (日本語に大文字小文字は無く、ロケール依存の変換も持ち込まない)。
+///
+/// 文字を 1 つずつ見ないで `#` まで飛ぶ。`is_alphanumeric` は日本語の
+/// 1 文字ごとに Unicode の表を引くので、本文を全文なぞると一覧の
+/// 読み込みで最も高くつく処理になっていた。タグの有無を決めるのは
+/// `#` の直前の 1 文字と直後のタグ文字だけで、それ以外は見なくてよい。
 fn collect_span(span: &str, tags: &mut Vec<String>) {
-    let mut at_boundary = true;
+    let mut pos = 0;
+    while let Some(offset) = span[pos..].find('#') {
+        let hash = pos + offset;
+        let start = hash + '#'.len_utf8();
+        pos = start;
 
-    let mut chars = span.char_indices().peekable();
-    while let Some((index, c)) = chars.next() {
-        if c != '#' || !at_boundary {
-            at_boundary = !is_tag_char(c);
+        // 直前がタグ文字なら語中の `#`。`#a#b` の 2 つ目もここに入る
+        if span[..hash].chars().next_back().is_some_and(is_tag_char) {
             continue;
         }
 
-        let start = index + '#'.len_utf8();
-        let mut end = start;
-        while chars.peek().is_some_and(|&(_, next)| is_tag_char(next)) {
-            let (offset, next) = chars.next().unwrap_or((end, ' '));
-            end = offset + next.len_utf8();
+        let rest = &span[start..];
+        let len = rest
+            .char_indices()
+            .find(|&(_, c)| !is_tag_char(c))
+            .map_or(rest.len(), |(index, _)| index);
+        if len == 0 {
+            continue;
         }
 
-        if end > start {
-            let tag = span[start..end].to_ascii_lowercase();
-            if !tags.contains(&tag) {
-                tags.push(tag);
-            }
+        let tag = rest[..len].to_ascii_lowercase();
+        if !tags.contains(&tag) {
+            tags.push(tag);
         }
-        // タグを 1 つ読んだ直後の `#` は、直前がタグ文字なので境界ではない。
-        at_boundary = end == start;
+        pos = start + len;
     }
 }
 
@@ -257,5 +263,54 @@ mod tests {
     fn ignores_a_bare_hash() {
         assert_eq!(parse("# "), Vec::<String>::new());
         assert_eq!(parse("#"), Vec::<String>::new());
+    }
+
+    // ──────────── 境界 ────────────
+
+    #[test]
+    fn finds_nothing_in_empty_text() {
+        assert_eq!(parse(""), Vec::<String>::new());
+    }
+
+    /// 本文の末尾の `#` は、その先に 1 文字も無い。
+    #[test]
+    fn ignores_a_hash_at_the_very_end() {
+        assert_eq!(parse("終わり#"), Vec::<String>::new());
+        assert_eq!(parse("end #"), Vec::<String>::new());
+    }
+
+    /// タグの直後の `#` は語中。`#a#b` は `a#b` という 1 語に `#` を付けたもの。
+    #[test]
+    fn a_hash_right_after_a_tag_is_inside_the_word() {
+        assert_eq!(parse("#a#b"), vec!["a"]);
+    }
+
+    /// `##a` の 1 つ目は空タグ、2 つ目の直前は `#` なので境界。
+    #[test]
+    fn a_doubled_hash_still_yields_the_tag() {
+        assert_eq!(parse("##a"), vec!["a"]);
+    }
+
+    /// 漢字・数字・`_`・`-` はどれもタグ文字。直前にあれば語中の `#`。
+    #[test]
+    fn ignores_a_hash_glued_to_the_previous_word() {
+        assert_eq!(parse("設計#tag"), Vec::<String>::new());
+        assert_eq!(parse("v2#tag"), Vec::<String>::new());
+        assert_eq!(parse("a_#tag"), Vec::<String>::new());
+        assert_eq!(parse("a-#tag"), Vec::<String>::new());
+    }
+
+    /// 全角記号は境界。直後の全角文字はタグの中。
+    #[test]
+    fn stops_at_fullwidth_punctuation_and_keeps_multibyte_tags() {
+        assert_eq!(parse("「#タグ」"), vec!["タグ"]);
+        assert_eq!(parse("#タグ!"), vec!["タグ"]);
+        assert_eq!(parse("#2026 年"), vec!["2026"]);
+    }
+
+    /// 1 行に複数のコードスパンがあっても、その間の本文は読む。
+    #[test]
+    fn reads_the_text_between_two_code_spans() {
+        assert_eq!(parse("`a` #one `b` #two `c`"), vec!["one", "two"]);
     }
 }

--- a/core/src/utils/text.rs
+++ b/core/src/utils/text.rs
@@ -1,0 +1,86 @@
+//! 検索の突き合わせに使う小文字化。
+
+/// `str::to_lowercase` と同じ結果を返す。日本語が主の本文で速い。
+///
+/// 標準の `to_lowercase` は ASCII でない文字を 1 つずつ Unicode の変換表で
+/// 引く。仮名・漢字・句読点には大文字も小文字も無いのに、その表引きが
+/// 検索(全日・全ノートの本文を小文字にする)の 15% を占めていた。
+///
+/// 大小の区別が無いと分かっている範囲の文字はそのまま写し、ASCII は
+/// ビット演算で倒す。それ以外の文字(ラテン拡張・ギリシャ文字など)が
+/// 1 つでも混じる本文は、標準の `to_lowercase` にそっくり渡す —
+/// 語末のシグマのような文脈依存の規則を、ここで真似はしない。
+///
+/// 「範囲に大小の区別が無い」ことはテストが全文字について確かめている。
+#[must_use]
+pub(crate) fn lowercase(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        if c.is_ascii() {
+            out.push(c.to_ascii_lowercase());
+        } else if is_caseless(c) {
+            out.push(c);
+        } else {
+            return text.to_lowercase();
+        }
+    }
+    out
+}
+
+/// 大文字・小文字の対応を 1 つも持たない、日本語の本文でよく出る範囲。
+///
+/// 全角英字(U+FF21–FF5A)はここに入れない — `Ａ` には `ａ` がある。
+const CASELESS: &[std::ops::RangeInclusive<char>] = &[
+    // 一般句読点(— … など)
+    '\u{2000}'..='\u{206F}',
+    // CJK の記号と句読点、ひらがな、カタカナ
+    '\u{3000}'..='\u{30FF}',
+    // CJK 統合漢字(拡張 A と本体)
+    '\u{3400}'..='\u{4DBF}',
+    '\u{4E00}'..='\u{9FFF}',
+    // 半角カタカナ
+    '\u{FF61}'..='\u{FF9F}',
+];
+
+fn is_caseless(c: char) -> bool {
+    CASELESS.iter().any(|range| range.contains(&c))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 速い経路の前提。範囲の中に 1 文字でも小文字の対応を持つものが
+    /// 混じると、標準との結果がずれて検索の取りこぼしになる。
+    #[test]
+    fn every_char_in_the_caseless_ranges_lowercases_to_itself() {
+        for range in CASELESS {
+            for c in range.clone() {
+                let mut lowered = c.to_lowercase();
+                assert_eq!(lowered.next(), Some(c), "U+{:04X}", u32::from(c));
+                assert_eq!(lowered.next(), None, "U+{:04X}", u32::from(c));
+            }
+        }
+    }
+
+    #[test]
+    fn matches_the_standard_library_on_mixed_text() {
+        for text in [
+            "",
+            "ASCII Only",
+            "同期処理のリトライ戦略を詰める — Rust で",
+            "半角ｶﾀｶﾅ と 全角Ａ",
+            "ΣΊΣΥΦΟΣ",
+            "İstanbul straße",
+            "- [09:00:00] メモ {\"battery\":72}",
+        ] {
+            assert_eq!(lowercase(text), text.to_lowercase(), "{text}");
+        }
+    }
+
+    /// 全角英字は範囲の外なので標準に倒される。
+    #[test]
+    fn fullwidth_latin_still_gets_lowercased() {
+        assert_eq!(lowercase("ＡＢＣ"), "ａｂｃ");
+    }
+}

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -36,6 +36,22 @@ use magical_merchant_core::{
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_deep_link::DeepLinkExt as _;
 
+/// 全ファイルを舐める読み取りをメインスレッドから外す。
+///
+/// 同期コマンドはメインスレッドで実行される。一覧・検索・バックリンクは
+/// ノート数と日数に比例して伸び(1 年分で 10〜30ms、実機ではその数倍)、
+/// その間ウィンドウの操作もイベントも止まる。`resolve_places` と同じく
+/// blocking プールで走らせ、メインスレッドには結果だけ返す。
+async fn off_main_thread<T, F>(work: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(work)
+        .await
+        .map_err(|e| e.to_string())?
+}
+
 fn app_base_dir(handle: &AppHandle) -> Result<std::path::PathBuf, String> {
     handle.path().app_data_dir().map_err(|e| e.to_string())
 }
@@ -144,11 +160,14 @@ pub(crate) fn repair_once(base_dir: &std::path::Path) {
 }
 
 #[tauri::command]
-fn list_notes(handle: AppHandle) -> Result<Vec<NoteSummary>, String> {
+async fn list_notes(handle: AppHandle) -> Result<Vec<NoteSummary>, String> {
     let base_dir = app_base_dir(&handle)?;
-    repair_once(&base_dir);
+    off_main_thread(move || {
+        repair_once(&base_dir);
 
-    magical_merchant_core::list_notes(&base_dir).map_err(|e| e.to_string())
+        magical_merchant_core::list_notes(&base_dir).map_err(|e| e.to_string())
+    })
+    .await
 }
 
 #[tauri::command]
@@ -162,10 +181,13 @@ fn read_note(handle: AppHandle, filename: String) -> Result<NoteRead, String> {
 }
 
 #[tauri::command]
-fn find_backlinks(handle: AppHandle, filename: String) -> Result<Vec<SearchHit>, String> {
+async fn find_backlinks(handle: AppHandle, filename: String) -> Result<Vec<SearchHit>, String> {
     let base_dir = app_base_dir(&handle)?;
     let filename = parse_filename(&filename)?;
-    magical_merchant_core::find_backlinks(&base_dir, &filename).map_err(|e| e.to_string())
+    off_main_thread(move || {
+        magical_merchant_core::find_backlinks(&base_dir, &filename).map_err(|e| e.to_string())
+    })
+    .await
 }
 
 #[tauri::command]
@@ -387,13 +409,16 @@ async fn resolve_places(
 }
 
 #[tauri::command]
-fn search_all(
+async fn search_all(
     handle: AppHandle,
     query: String,
     tags: Vec<String>,
 ) -> Result<Vec<SearchHit>, String> {
     let base_dir = app_base_dir(&handle)?;
-    magical_merchant_core::search_all(&base_dir, &query, &tags).map_err(|e| e.to_string())
+    off_main_thread(move || {
+        magical_merchant_core::search_all(&base_dir, &query, &tags).map_err(|e| e.to_string())
+    })
+    .await
 }
 
 #[tauri::command]

--- a/tauri-app/src-tauri/src/widget_summary.rs
+++ b/tauri-app/src-tauri/src/widget_summary.rs
@@ -210,13 +210,44 @@ mod tests {
         assert_eq!(last.text, "- plain");
     }
 
+    /// 先に出たタグが少ないほうでも、数の多いほうが前に来る。出現順で
+    /// 並べても通る並びでは、数えているかどうかが分からない。
     #[test]
     fn tags_come_back_most_used_first() {
         let entries = vec![
-            "- [09:00:00] #work started".to_string(),
-            "- [10:00:00] #rust and #work".to_string(),
+            "- [09:00:00] #rust started".to_string(),
+            "- [10:00:00] #work and #rust".to_string(),
+            "- [11:00:00] #work again".to_string(),
+            "- [12:00:00] #work still".to_string(),
         ];
         assert_eq!(top_tags(&entries), vec!["#work", "#rust"]);
+    }
+
+    /// 同数なら先に出たほう。並びが実行ごとに変わると、同じ画面を開いた
+    /// だけでチップが入れ替わって見える。
+    #[test]
+    fn tags_used_equally_keep_their_first_seen_order() {
+        let entries = vec![
+            "- [09:00:00] #b then #a".to_string(),
+            "- [10:00:00] #a and #b".to_string(),
+        ];
+        assert_eq!(top_tags(&entries), vec!["#b", "#a"]);
+    }
+
+    /// 4 つ目からはチップが 1 行に収まらないので落とす。落ちるのは
+    /// いちばん使われていないタグ。
+    #[test]
+    fn only_the_most_used_tags_fit_on_the_sheet() {
+        let entries = vec![
+            "- [09:00:00] #d once".to_string(),
+            "- [10:00:00] #a #b #c".to_string(),
+            "- [11:00:00] #a #b #c".to_string(),
+            "- [12:00:00] #a #b".to_string(),
+            "- [13:00:00] #a".to_string(),
+        ];
+        let tags = top_tags(&entries);
+        assert_eq!(tags.len(), TAG_LIMIT);
+        assert_eq!(tags, vec!["#a", "#b", "#c"]);
     }
 
     #[test]

--- a/tauri-app/src/lib/smoke.test.ts
+++ b/tauri-app/src/lib/smoke.test.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from "vitest";
-
-describe("test setup", () => {
-  it("works", () => {
-    expect(1 + 1).toBe(2);
-  });
-});


### PR DESCRIPTION
## なぜやるか

ノート一覧と検索は全ファイルを開いて読む経路で、1 年分のデータだと Mac で 10〜30ms、実機ではその数倍かかる。しかも同期コマンドとしてメインスレッドで走るので、その間はウィンドウの操作もイベントも止まる。
flame graph を取ると、CPU 側の時間は 3 か所に集中していた: タグ抽出が本文の全文字を Unicode 判定していること、小文字化が仮名・漢字まで変換表を引いていること、frontmatter を `serde_yaml::Value` 経由で二重にパースしていること。

## やったこと

一覧・検索・バックリンクの 3 コマンドが blocking プールを経由するようになった(緑が新しい経路)。

```mermaid
flowchart LR
  ui["画面 (⌘K / 一覧 / エントリのチップ)"] --> main["Tauri メインスレッド"]
  main --> pool["blocking プール"]
  pool --> core["core: list_notes / search_all / find_backlinks"]
  main -.->|"従来はここで待っていた"| core

  classDef added stroke:#3fb950,stroke-width:3px
  class pool added
```

- core のホットスポット 3 つを潰した(数値は同一マシンで main と交互に計測)

  | 経路 | main | このブランチ | 差 |
  | --- | --- | --- | --- |
  | search_all(該当なし) | 18.9 ms | 15.7 ms | −17% |
  | search_all(高頻度語) | 27.9 ms | 22.3 ms | −20% |
  | list_notes(500 件) | 10.4 ms | 8.7 ms | −16% |

  - タグ抽出は `#` まで飛んでから前後だけ見る。結果は同じで、境界(`#a#b`・末尾の `#`・語に貼り付いた `#`)をテストで固定
  - 小文字化は大小の無い範囲(仮名・漢字・CJK 記号)を素通しし、それ以外が混じる文は標準に丸投げ。範囲の全文字が自分自身に小文字化されることをテストが確かめる
  - frontmatter は自前で区切ってから `serde_yaml` に直接読ませる。`markdown-frontmatter` crate は不要になり、`parse` と `strip` の分割規則も 1 つになった
- 一覧・検索・バックリンクは `resolve_places` と同じ形で blocking プールに移した。引数と戻り値は変えていないので画面側と IPC モックはそのまま
- テストの監査。通らないことがない assertion(`is_some()`、`is_err()` だけ、頻度順と出現順が同じ fixture)を実値の比較に直し、上限(MAX_HITS・SNIPPET_CONTEXT・preview 100 文字・GLYPH_MAX_BYTES・トークンの猶予・全消し閾値)を境界値でピン留めした

<details>
<summary>flame graph の幅の変化(前 → 後、各経路の全体に対する割合)</summary>

| 関数 | list_notes | search_all(高頻度語) |
| --- | --- | --- |
| `tags::parse` | 14.6% → 4.2% | 12.1% → 3.2% |
| 小文字化 | – | 15.3% → 7.7% |
| frontmatter のパース | 16.0% → 14.0% | 6.2% → 6.2% |
| `open(2)` | 54% → 63% | 37% → 45% |

計測: `cargo bench -p magical-merchant-core`(365 日 × 20 件 + 500 ノート、criterion)。flame graph は macOS の `sample` + FlameGraph。
</details>

## やらなかったこと

- 残りの 6 割は `open(2)`(macOS で 1 件 12µs × 865 ファイル)。「インデックスを持たない」設計の天井で、削るなら scan-cache と同じ mtime+size の summary キャッシュが要る。設計判断なので別 issue に
- 日付に依存するテスト(`Local::now()` で今日のファイル名を再計算する timeline / template のテスト群)。日付境界で落ちうるが、直すには時計の注入が要るので今回は触っていない
- `split_entries` が空白だけの行を空エントリとして残す件。監査で見つかったが挙動の変更なので別に
