### PR TITLE
fix(sync): stop old conflict copies from failing every sync

### DIFF
--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -111,10 +111,10 @@ pub fn repair_notes(base_dir: &Path) -> Result<usize, CoreError> {
     repair::repair_all(&crate::utils::paths::notes_dir(base_dir))
 }
 
-/// 古い版が `data/notes/` と `data/timeline/` に置いた競合コピーを `conflicts/` へ
-/// 移す。移した件数を返す。
+/// 古い版が `data/` に置いた競合コピーを `conflicts/` へ移す。移した件数を返す。
 /// 呼ぶのは同期を持つアプリだけ、それも最初の同期より前に一度。
-pub fn relocate_conflict_copies(base_dir: &Path) -> Result<usize, CoreError> {
+#[must_use]
+pub fn relocate_conflict_copies(base_dir: &Path) -> usize {
     repair::relocate_conflict_copies(base_dir)
 }
 

--- a/core/src/note/repair.rs
+++ b/core/src/note/repair.rs
@@ -7,7 +7,7 @@ use crate::error::CoreError;
 use crate::sync::conflict::conflict_copy_path;
 use crate::utils::frontmatter::{self, NoteFrontmatter};
 use crate::utils::fs::{ensure_dir, list_md_files, write_atomic};
-use crate::utils::paths::{NOTES_DIR, TIMELINE_DIR, conflicts_dir, data_dir};
+use crate::utils::paths::{conflicts_dir, data_dir};
 
 /// 編集画面が frontmatter ごと Milkdown に通していた時期に保存されたノートは、
 /// 本文の先頭に「化けたメタデータ」を抱えている。開始区切りの `---` は `***` に、
@@ -42,13 +42,16 @@ pub(crate) fn repair_all(notes_dir: &Path) -> Result<usize, CoreError> {
     Ok(repaired)
 }
 
-/// 古い版が `data/notes/` と `data/timeline/` に置いた競合コピーを `conflicts/` へ
-/// 移す。移した件数を返す。
+/// 古い版が `data/` に置いた競合コピーを `conflicts/` へ移す。移した件数を返す。
 ///
 /// 控えは同期の走査からは外れていたが、ノート一覧は `data/notes/*.md` を
 /// 素通しで拾うので、元のノートが消えたあとも残骸として並び続けていた。
 /// タイムラインの控えは一覧には出ないが、走査の除外をやめた以上、
 /// 置いたままだと次の同期で新しいファイルとして全端末へ配られる。
+///
+/// 探すのは `data/` 全体。走査が `data/` を丸ごと同期対象にする以上、
+/// 残骸が配られるかどうかは置き場所によらない — 利用者が自分で切った
+/// ディレクトリの下にある控えも、`notes/` にあるのと同じ扱いになる。
 ///
 /// 中身は読まず `rename` するだけ。控えが壊れていても、ノートの形をして
 /// いなくても運べる。起動時、最初の同期より前に呼ぶこと — あとで呼ぶと、
@@ -56,29 +59,39 @@ pub(crate) fn repair_all(notes_dir: &Path) -> Result<usize, CoreError> {
 ///
 /// 1 件の失敗では止まらない。運べなかった控えは次の起動でまた試すだけで、
 /// そのために残りの引っ越しを諦める理由はない。
-pub(crate) fn relocate_conflict_copies(base_dir: &Path) -> Result<usize, CoreError> {
-    let conflicts = conflicts_dir(base_dir);
+pub(crate) fn relocate_conflict_copies(base_dir: &Path) -> usize {
     let data = data_dir(base_dir);
     let mut moved = 0;
-    for dir in [NOTES_DIR, TIMELINE_DIR] {
-        for entry in list_md_files(&data.join(dir))? {
-            let name = entry.file_name();
-            let Some(name) = name.to_str() else {
-                continue;
-            };
-            // 走査キーと同じ形にしてから読ませる。控えの置き場は
-            // ダウンロードで降ってきたぶんと同じ `conflicts/<dir>/…` になる
-            let Some(relative) = conflict_copy_path(&format!("{dir}/{name}")) else {
-                continue;
-            };
-            let target = conflicts.join(relative);
-            if ensure_dir(&target).is_err() || fs::rename(entry.path(), &target).is_err() {
-                continue;
-            }
-            moved += 1;
+    relocate_under(&data, &data, &conflicts_dir(base_dir), &mut moved);
+    moved
+}
+
+fn relocate_under(root: &Path, current: &Path, conflicts: &Path, moved: &mut usize) {
+    let Ok(entries) = fs::read_dir(current) else {
+        return;
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if entry.file_type().is_ok_and(|t| t.is_dir()) {
+            relocate_under(root, &path, conflicts, moved);
+            continue;
         }
+        // 走査キーと同じ形にしてから読ませる。控えの置き場は
+        // ダウンロードで降ってきたぶんと同じ `conflicts/<キー>/…` になる
+        let Some(relative) = path
+            .strip_prefix(root)
+            .ok()
+            .and_then(|key| key.to_str())
+            .and_then(conflict_copy_path)
+        else {
+            continue;
+        };
+        let target = conflicts.join(relative);
+        if ensure_dir(&target).is_err() || fs::rename(&path, &target).is_err() {
+            continue;
+        }
+        *moved += 1;
     }
-    Ok(moved)
 }
 
 /// 本文先頭の化けたメタデータ塊を取り除いた本文を返す。塊が無ければ `None`。
@@ -137,7 +150,7 @@ fn filename_time(filename: &str) -> Option<DateTime<FixedOffset>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::paths::notes_dir;
+    use crate::utils::paths::{TIMELINE_DIR, notes_dir};
     use tempfile::TempDir;
 
     /// 実際に壊れていたファイルと同じ形の再現。
@@ -283,7 +296,7 @@ mod tests {
             "orphan copy",
         );
 
-        let moved = relocate_conflict_copies(tmp.path()).unwrap();
+        let moved = relocate_conflict_copies(tmp.path());
 
         assert_eq!(moved, 2);
         let notes: Vec<String> = list_md_files(&notes_dir(tmp.path()))
@@ -313,13 +326,13 @@ mod tests {
             "copy",
         );
 
-        relocate_conflict_copies(tmp.path()).unwrap();
+        assert_eq!(relocate_conflict_copies(tmp.path()), 1);
         let after_first = fs::read_to_string(
             conflicts_dir(tmp.path()).join("notes/20260320_033440/20260511-031336.md"),
         )
         .unwrap();
 
-        assert_eq!(relocate_conflict_copies(tmp.path()).unwrap(), 0);
+        assert_eq!(relocate_conflict_copies(tmp.path()), 0);
         assert_eq!(
             fs::read_to_string(
                 conflicts_dir(tmp.path()).join("notes/20260320_033440/20260511-031336.md")
@@ -344,7 +357,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(relocate_conflict_copies(tmp.path()).unwrap(), 1);
+        assert_eq!(relocate_conflict_copies(tmp.path()), 1);
 
         assert!(timeline.join("2026-03-20.md").exists());
         assert!(
@@ -361,13 +374,46 @@ mod tests {
         );
     }
 
+    /// 控えが溜まるのは `notes/` と `timeline/` だけではない。`data/` の下は
+    /// 丸ごと同期の走査対象なので、自分で切ったディレクトリに残った控えも
+    /// 置いたままだと新しいファイルとして全端末へ配られる。
+    #[test]
+    fn conflict_copies_in_a_nested_directory_move_out() {
+        let tmp = TempDir::new().unwrap();
+        let done = data_dir(tmp.path()).join("projects/aaaa/done");
+        fs::create_dir_all(&done).unwrap();
+        fs::write(done.join("20260417_023550_461.md"), "the entry").unwrap();
+        fs::write(
+            done.join("20260417_023550_461.sync-conflict-20260511-031336..md"),
+            "nested copy",
+        )
+        .unwrap();
+
+        assert_eq!(relocate_conflict_copies(tmp.path()), 1);
+
+        assert!(done.join("20260417_023550_461.md").exists());
+        assert!(
+            !done
+                .join("20260417_023550_461.sync-conflict-20260511-031336..md")
+                .exists()
+        );
+        assert_eq!(
+            fs::read_to_string(
+                conflicts_dir(tmp.path())
+                    .join("projects/aaaa/done/20260417_023550_461/20260511-031336.md")
+            )
+            .unwrap(),
+            "nested copy"
+        );
+    }
+
     /// 引っ越しは中身を見ない。控えが壊れていても、ノートで無くても運ぶ。
     #[test]
     fn a_note_that_is_not_a_conflict_copy_stays_put() {
         let tmp = TempDir::new().unwrap();
         seed_note(tmp.path(), "20260320_033440.md", "body");
 
-        assert_eq!(relocate_conflict_copies(tmp.path()).unwrap(), 0);
+        assert_eq!(relocate_conflict_copies(tmp.path()), 0);
         assert!(notes_dir(tmp.path()).join("20260320_033440.md").exists());
         assert!(!conflicts_dir(tmp.path()).exists());
     }

--- a/core/src/sync/engine.rs
+++ b/core/src/sync/engine.rs
@@ -7,7 +7,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::path::Path;
+use std::path::{Component, Path};
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as B64;
@@ -174,8 +174,18 @@ fn server_state_to_remote_files(state: &ServerSyncState) -> Vec<RemoteFile> {
         .collect()
 }
 
+/// data ディレクトリの外を指せないキーか。
+///
+/// 危ないのは `..` という**パス要素**であって、名前の中に並んだ点ではない。
+/// 部分一致で弾くと `….sync-conflict-20260511-031336..md`(サーバー駆動同期
+/// 以前の控えにある、点が 1 つ多い名前)まで巻き込み、その控えを抱えた端末は
+/// 毎回の同期が失敗し続ける。`Path` に読ませれば区切りの解釈は OS に合う。
 fn is_safe_key(key: &str) -> bool {
-    !key.contains("..") && !key.contains('\0') && !key.starts_with('/')
+    !key.is_empty()
+        && !key.contains('\0')
+        && Path::new(key)
+            .components()
+            .all(|c| matches!(c, Component::Normal(_)))
 }
 
 fn build_bulk_request(
@@ -608,6 +618,23 @@ mod tests {
             .files
             .is_empty()
         );
+    }
+
+    /// 抜け出せるのは `..` というパス要素であって、名前の中に並んだ点ではない。
+    /// サーバー駆動同期以前の控えには `….sync-conflict-20260511-031336..md` の
+    /// ように点が 1 つ多い名前があり、部分一致で弾くと毎回の同期が
+    /// 「安全でない名前」で失敗し続ける。
+    #[test]
+    fn a_doubled_dot_inside_a_filename_is_not_traversal() {
+        assert!(is_safe_key(
+            "projects/a/done/20260417_023550.sync-conflict-20260511-031336..md"
+        ));
+        assert!(is_safe_key("notes/..md"));
+
+        assert!(!is_safe_key("../escape.md"));
+        assert!(!is_safe_key("notes/../../escape.md"));
+        assert!(!is_safe_key("/etc/passwd"));
+        assert!(!is_safe_key("notes/a\0.md"));
     }
 
     #[test]

--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -147,14 +147,14 @@ struct NoteRead {
 /// どちらも失敗しても黙って進む — ノートが読めなくなるよりはましで、
 /// 次の起動でまた試す。
 ///
-/// 引っ越しを同期より前に済ませるのが要点。あとになると、`data/notes/` に
+/// 引っ越しを同期より前に済ませるのが要点。あとになると、`data/` に
 /// 残った競合コピーを走査が拾って、残骸を全端末へ配ってしまう。
 pub(crate) fn repair_once(base_dir: &std::path::Path) {
     static REPAIR: std::sync::Once = std::sync::Once::new();
     REPAIR.call_once(|| {
         // 過去の編集で本文に混入した化けメタデータ
         let _ = magical_merchant_core::repair_notes(base_dir);
-        // 古い版が `data/notes/` に置いた競合コピー
+        // 古い版が `data/` に置いた競合コピー
         let _ = magical_merchant_core::relocate_conflict_copies(base_dir);
     });
 }

--- a/workers/src/sync.test.ts
+++ b/workers/src/sync.test.ts
@@ -43,6 +43,16 @@ describe("isUnsafeKey", () => {
     expect(isUnsafeKey("notes/archive/2026/note.md")).toBe(false);
     expect(isUnsafeKey("notes/file.sync-conflict-20260512-120000.md")).toBe(false);
   });
+
+  /// 抜け出せるのは `..` というパス要素であって、名前の中に並んだ点ではない。
+  /// サーバー駆動同期以前の控えには点が 1 つ多い名前があり、部分一致で弾くと
+  /// その控えだけ永久に同期できない。
+  it("accepts a doubled dot inside a filename", () => {
+    expect(isUnsafeKey("projects/a/done/20260417_023550.sync-conflict-20260511-031336..md")).toBe(
+      false,
+    );
+    expect(isUnsafeKey("notes/..md")).toBe(false);
+  });
 });
 
 describe("isValidHash", () => {

--- a/workers/src/sync.ts
+++ b/workers/src/sync.ts
@@ -99,9 +99,14 @@ function base64Decode(s: string): Uint8Array {
   return bytes;
 }
 
+/// 抜け出せるのは `..` という**パス要素**であって、名前の中に並んだ点ではない。
+/// 部分一致で弾くと `….sync-conflict-20260511-031336..md`(サーバー駆動同期
+/// 以前の控えにある、点が 1 つ多い名前)まで巻き込み、その控えを抱えた端末は
+/// 毎回の同期が失敗し続ける。判定は core の `is_safe_key` と揃える。
 export function isUnsafeKey(key: string): boolean {
   return (
-    key.includes("..") ||
+    key === "" ||
+    key.split("/").some((segment) => segment === ".." || segment === ".") ||
     key.includes("\0") ||
     key.startsWith("/") ||
     key.startsWith(SYNC_STATE_PREFIX)


### PR DESCRIPTION
## なぜやるか

同期が毎回 8 件の「安全でない名前なので送りませんでした」で失敗していた。Syncthing 時代に残った競合コピーで、名前の点が 1 つ多い (`….sync-conflict-20260511-031336..md`)。`..` を部分一致で弾いていたため、data の外を指せない無害な名前まで拒まれ、その控えを抱えた端末は何度同期しても直らない。

片づける側にも穴があった。起動時の引っ越しは `notes/` と `timeline/` の直下しか見ないが、走査は data 配下を丸ごと拾う。自分で切ったディレクトリの控えは、退避されず走査には入る状態で残る。

## やったこと

同じファイルにかかる 2 つの関門。太線が、この控えが通れるようになった経路。

```mermaid
flowchart LR
  data["data/ に残った控え"] -->|起動時の引っ越し| conflicts["conflicts/(同期対象外)"]
  data --> scan["同期の走査"] --> check["名前の判定"] --> worker["Worker / R2"]

  linkStyle 0,3 stroke:#3fb950,stroke-width:3px
```

- 名前の判定をパス要素単位にした。抜け出せるのは `..` という要素であって、名前の中に並んだ点ではない
  - core は全要素が Normal のときだけ通す。絶対パスの拒否も同じ判定に畳めた
  - 空キーの扱いも Worker と揃えた。片側だけ厳しいと、サーバーは受けクライアントは拒むキーが生まれる
- 起動時の引っ越しが data 配下を全部見るようになった。退避されるかどうかが置き場所で変わらない

## やらなかったこと

- 控えが data 配下に生まれる経路は残した。作るのは旧 Syncthing 運用だけで、アプリ自身の競合処理は最初から `conflicts/` に書いている
